### PR TITLE
fix(agent): surface OpenRouter 200-wrapped failures + harness accounting hardening

### DIFF
--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -537,11 +537,18 @@ export async function runAgent(
   }
 
   let phaseResults: PhaseResult[] | undefined;
+  // Declared outside the try so the catch block below can prefer whatever
+  // executeSingleQuery/executePhasedQuery already populated here over
+  // rebuilding usage from scratch. A postcondition check can throw a plain
+  // Error AFTER these locals hold real, billed usage (see the catch block's
+  // "run-end postcondition" comment) — without hoisting, that usage was
+  // invisible to the catch and contract-failed runs persisted tokens_used=0
+  // despite full billed turns (observed on ea34158d, 0f22a8c3).
+  let tokensUsed: number | undefined;
+  let costUsd: number | null | undefined;
+  let costData: CostResolution | undefined;
+  let usage: RuntimeUsage | undefined;
   try {
-    let tokensUsed: number;
-    let costUsd: number | null;
-    let costData: CostResolution;
-    let usage: RuntimeUsage;
     let runSessionRef = checkpointState.harnessState?.ref ?? checkpointState.sessionRef;
 
     const persistHarnessState = async (
@@ -742,21 +749,39 @@ export async function runAgent(
       error: errorMessage,
     });
 
+    // Captured before the inner try block shadows `usage`/`costData` with
+    // its own failure-record locals — see the priority-order comment below.
+    const preThrowUsage = usage;
+    const preThrowCostData = costData;
+
     try {
-      // Non-phased failures carry their usage on HarnessExecutionError
-      // telemetry — without it a failed single-query records zero
-      // tokens/cost even though the requests were billed.
+      // Usage/cost for the failure record, in priority order:
+      //  1. phaseResults — always authoritative when present (a phased run
+      //     that got at least one phase in).
+      //  2. `preThrowUsage`/`preThrowCostData` — already populated by
+      //     executeSingleQuery (or executePhasedQuery) BEFORE a run-end
+      //     postcondition check throws a plain Error. Postcondition failures
+      //     are not HarnessExecutionError, so without this branch their real,
+      //     billed usage was invisible here and the failure recorded
+      //     tokens_used=0 (observed on ea34158d, 0f22a8c3).
+      //  3. HarnessExecutionError.telemetry — the harness crashed before
+      //     executeSingleQuery returned, so its own partial-usage rescue is
+      //     the only source.
+      //  4. empty usage — nothing was ever populated (crashed before any
+      //     turn).
       const failureTelemetry = err instanceof HarnessExecutionError ? err.telemetry : undefined;
       const usage = phaseResults
         ? aggregateUsage(phaseResults.map((phase) => phase.usage))
-        : failureTelemetry?.usage ?? aggregateUsage([]);
+        : preThrowUsage ?? failureTelemetry?.usage ?? aggregateUsage([]);
       logTokenBudgetPressure(config.taskName, usage, effectiveProvider, options?.logger);
-      const costData = phaseResults ? summarizePhaseCosts(phaseResults) : await resolveCost({
-        harness: harnessId,
-        provider: effectiveProvider,
-        model: effectiveModel,
-        usage,
-      });
+      const costData = phaseResults
+        ? summarizePhaseCosts(phaseResults)
+        : preThrowCostData ?? await resolveCost({
+          harness: harnessId,
+          provider: effectiveProvider,
+          model: effectiveModel,
+          usage,
+        });
 
       // Detect the "expired SDK session" zombie-run pattern: we were
       // resuming a run whose checkpoint carried a sessionRef, the harness

--- a/packages/myco/src/agent/harness/classify-error.ts
+++ b/packages/myco/src/agent/harness/classify-error.ts
@@ -5,6 +5,15 @@
 // "Was there a typo in the url or port?" / "Unable to connect" on a refused
 // socket; Node-style errors surface ECONNREFUSED/ETIMEDOUT/ECONNRESET. These
 // must NOT consume a per-item retry budget — they are infrastructure, not content.
+//
+// `openrouter upstream provider failure` / `provider_unavailable` is the
+// wording openai.ts's harnessFetch synthesizes when OpenRouter's
+// /api/v1/responses returns HTTP 200 with status:"failed" (or
+// "incomplete" + no non-reasoning output) — the upstream provider (e.g. an
+// Azure OpenAI deployment behind an openai/* route) rejected the request,
+// but OpenRouter's own transport succeeded. That is content-adjacent
+// plumbing failure, not a caller mistake — it belongs in the same
+// retryable bucket as a dropped socket.
 const CONNECTION_PATTERNS = [
   /typo in the url or port/i,
   /unable to connect/i,
@@ -18,6 +27,8 @@ const CONNECTION_PATTERNS = [
   /network/i,
   /\btimeout\b/i,
   /AbortError/,
+  /provider_unavailable/i,
+  /upstream provider failure/i,
 ];
 
 export function isConnectionError(message: string): boolean {

--- a/packages/myco/src/agent/harness/openai.ts
+++ b/packages/myco/src/agent/harness/openai.ts
@@ -23,7 +23,7 @@ import {
 } from './types.js';
 import { isConnectionError, isCapHitMessage } from './classify-error.js';
 import { createLocalVaultMcpServer } from './openai-local-mcp.js';
-import type { ProviderConfig, RuntimeUsage } from '@myco/agent/types.js';
+import type { ProviderConfig, RunLogger, RuntimeUsage } from '@myco/agent/types.js';
 import { HARNESS_OPENAI_AGENTS } from '@myco/agent/types.js';
 import { DEFAULT_LOCAL_AGENT_CONTEXT_WINDOW_TOKENS } from '@myco/agent/context-windows.js';
 import { ensureOllamaContextVariant } from '@myco/agent/ollama-context.js';
@@ -38,7 +38,8 @@ import {
 import { DEFAULT_OPENAI_URL, DEFAULT_OPENROUTER_URL } from '@myco/agent/provider.js';
 import { resolveModelSettings } from '@myco/agent/reasoning-levels.js';
 import { errorMessage } from '@myco/utils/error-message.js';
-import { createInstrumentedFetch } from '@myco/utils/instrumented-fetch.js';
+import { createInstrumentedFetch, type FetchLike, type InstrumentedFetchLogger } from '@myco/utils/instrumented-fetch.js';
+import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 
 export function classifyHarnessErrorKind(message: string, errName: string | undefined): HarnessErrorKind {
   if (isConnectionError(message)) return 'connection';
@@ -264,38 +265,209 @@ async function prepareLocalProviderExecution(
 }
 
 /**
- * Outbound LLM fetch instrumentation for the OpenAI Agents harness.
+ * A Responses-API response body shaped closely enough to check the fields
+ * the SDK ignores. OpenRouter's `/api/v1/responses` uses this exact shape
+ * for both success and upstream-provider-failure bodies — the only thing
+ * that changes is `status`/`error`/`output`. Left loose (all fields
+ * optional, `unknown` output items) because we only ever read three fields
+ * and must never throw while inspecting an otherwise-valid body from a
+ * spec-compliant provider.
+ */
+interface ResponsesBodyShape {
+  status?: string;
+  error?: { message?: string; code?: string; [key: string]: unknown } | null;
+  output?: Array<{ type?: string; [key: string]: unknown }> | null;
+  id?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * True when a parsed Responses-API body represents an upstream provider
+ * failure OpenAI's own SDK would never surface as an error on its own:
+ *   - `status: "failed"` with an `error` payload — the terminal failure
+ *     shape spore discovery-5c27c512 verified live against OpenRouter.
+ *   - `status: "incomplete"` where every output item is a `reasoning` item
+ *     (or there are none at all) — the model was cut off before producing
+ *     any real content, which agents-core's turn loop treats identically
+ *     to a fully empty turn ("if there is no output we just run again").
+ * `status: "completed"` (or any other status) with a non-empty non-
+ * reasoning output always passes through untouched.
+ */
+export function isUnsurfacedResponsesFailure(body: ResponsesBodyShape): boolean {
+  if (body.status === 'failed') {
+    return true;
+  }
+  if (body.status === 'incomplete') {
+    const output = Array.isArray(body.output) ? body.output : [];
+    const hasSubstantiveOutput = output.some((item) => item?.type !== 'reasoning');
+    return !hasSubstantiveOutput;
+  }
+  return false;
+}
+
+function describeResponsesFailure(body: ResponsesBodyShape): string {
+  const detail = body.error?.message ?? (body.status === 'incomplete'
+    ? 'incomplete response with no non-reasoning output'
+    : 'no error detail provided');
+  const generationId = body.id ? ` (response id: ${body.id})` : '';
+  return `OpenRouter upstream provider failure: ${detail}${generationId}`;
+}
+
+/**
+ * Wrap an already-instrumented fetch with Responses-API body validation —
+ * the fix for spore discovery-5c27c512: OpenRouter's `/api/v1/responses`
+ * returns HTTP 200 for an upstream provider failure (`status: "failed"`,
+ * `error: {...}`, `output: []`, `usage: null`; also `status: "incomplete"`
+ * with reasoning-only output). `@openai/agents` v0.12.0's
+ * `OpenAIResponsesModel.getResponse` reads only `response.output` and
+ * `response.usage` — it never checks `status`/`error` — so a 200-wrapped
+ * failure becomes a zero-item model turn, and agents-core's turn loop
+ * silently re-runs ("if there is no output we just run again") until
+ * `MaxTurnsExceededError`, burning the whole turn budget in seconds with
+ * zero tool events and zero recorded usage.
  *
- * Owns the cross-provider protection that's missing from the SDK out of
- * the box: bounded response-headers timeout, no-progress watchdog (any
- * stream that drops below the idle threshold gets aborted with a stable
- * `fetch.stall` log entry), and `setImmediate` yields between body chunks
- * so a high-rate streamed response never starves libuv timers or the
- * daemon's HTTP listener. See `utils/instrumented-fetch.ts` for the full
- * contract.
+ * Interception point: `@openai/agents`'s `Runner.run()` (called by
+ * `runOpenAIAgent` below) never passes `stream: true` — `getResponse`
+ * (non-streaming) is the only path this harness exercises, and it calls
+ * `this._client.responses.create(requestData, requestOptions)` with
+ * `requestData.stream` unset/false, which the OpenAI SDK turns into
+ * `POST /responses` with `stream: false` (openai/resources/responses/
+ * responses.js). That single non-streaming POST response is exactly what
+ * this wrapper inspects. Streaming responses (SSE body, incremental
+ * `response.output_text.delta` events) are NOT inspected here — this
+ * harness's own call path never produces one, so there is no streaming
+ * residual to cover. If a future caller starts passing `stream: true`,
+ * this wrapper passes those responses through untouched (the streaming
+ * check below only matches non-streaming POST requests) and the original
+ * silent-loop failure mode would return uncovered for that path.
+ *
+ * Applies to any POST whose URL path ends in `/responses` — not just
+ * OpenRouter — since the same SDK gap exists for any Responses-API-shaped
+ * provider that returns this 200-wrapped-failure shape.
+ *
+ * On a clean body (anything that doesn't match
+ * `isUnsurfacedResponsesFailure`), the original `Response` is returned
+ * byte-identical: same status/headers/body stream, no re-serialization.
+ */
+export function wrapResponsesFailureDetection(baseFetch: FetchLike, logger?: InstrumentedFetchLogger): FetchLike {
+  return async function harnessValidatingFetch(input, init) {
+    const response = await baseFetch(input, init);
+
+    const method = (init?.method
+      ?? (typeof input === 'object' && input !== null && 'method' in (input as Request) ? (input as Request).method : 'GET')
+      ?? 'GET').toUpperCase();
+    if (method !== 'POST' || !response.ok || !response.body) {
+      return response;
+    }
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : (input as Request).url;
+    let pathname: string;
+    try {
+      pathname = new URL(url, 'http://localhost').pathname;
+    } catch {
+      return response;
+    }
+    if (!pathname.endsWith('/responses')) {
+      return response;
+    }
+    // A streamed request (`stream: true` in the POST body) yields an SSE
+    // body, not a single JSON object — `.json()` would hang waiting for the
+    // stream to close or throw on the first `data: {...}` chunk. This
+    // harness never sends `stream: true` (see the doc comment above), so
+    // this branch protects against a future caller silently losing
+    // coverage rather than crashing on a shape this wrapper can't parse.
+    const contentType = response.headers.get('content-type') ?? '';
+    if (contentType.includes('text/event-stream')) {
+      return response;
+    }
+
+    const cloned = response.clone();
+    let body: ResponsesBodyShape;
+    try {
+      body = await cloned.json();
+    } catch {
+      // Not JSON (or malformed) — not our shape to police. Let the OpenAI
+      // SDK's own body handling see the original, still-unread response.
+      return response;
+    }
+
+    if (!isUnsurfacedResponsesFailure(body)) {
+      return response;
+    }
+
+    const message = describeResponsesFailure(body);
+    logger?.warn?.(LOG_KINDS.FETCH_PROVIDER_FAILURE, `agent.openai-harness: ${message}`, {
+      component: 'agent.openai-harness',
+      url: redactQuery(url),
+      status: body.status,
+      responseId: body.id,
+      errorCode: body.error?.code,
+    });
+
+    // Synthesize a 5xx so the OpenAI SDK's own response handling
+    // (client.js) parses the body as an API error and throws `APIError`/
+    // `InternalServerError` — the same code path a genuine HTTP 5xx takes,
+    // including the SDK's own retry-on-5xx behavior. This keeps the error
+    // surfacing through the SDK's normal machinery instead of throwing
+    // out-of-band from inside a `fetch` implementation, which callers of
+    // `fetch` don't expect and the SDK isn't set up to catch cleanly.
+    return new Response(JSON.stringify({ error: { message, code: body.error?.code ?? 'provider_unavailable' } }), {
+      status: 502,
+      statusText: 'Bad Gateway',
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+}
+
+/** Strip query params before logging — provider URLs can carry tokens. */
+function redactQuery(url: string): string {
+  try {
+    const u = new URL(url);
+    u.search = '';
+    return u.href;
+  } catch {
+    return url.split('?')[0] ?? url;
+  }
+}
+
+/**
+ * Build the outbound LLM fetch for the OpenAI Agents harness: instrumented
+ * (bounded response-headers timeout, no-progress watchdog, per-chunk
+ * event-loop yields — see `utils/instrumented-fetch.ts`) and wrapped with
+ * Responses-API failure detection (`wrapResponsesFailureDetection` above).
+ *
+ * Called once per `createProvider` invocation (i.e. once per harness
+ * execute/openScope call) so the run's own logger flows into both layers —
+ * `agent.openai-harness` debug/warn log lines are otherwise permanently
+ * silent, since the run logger is the only logger threaded through
+ * `HarnessExecuteInput`/`HarnessScopeSetup` (there is no ambient daemon
+ * logger reachable from this module).
  *
  * Defaults are chosen for local-provider tolerance — LMStudio / Ollama
  * on cold first-byte and big context loads can take a while — but still
  * tight enough that a wedged stream dies in tens of seconds, not the
  * SDK's default 600s.
  */
-const harnessFetch = createInstrumentedFetch({
-  component: 'agent.openai-harness',
-  // 90s of silence allowed before headers — covers cold model warm-up on
-  // a local backend at high context.
-  responseHeadersTimeoutMs: 90_000,
-  // 45s between body chunks before we treat the stream as wedged. A
-  // healthy local model emits chunks well under a second apart even when
-  // it's reasoning; 45s is several orders of magnitude above that.
-  idleTimeoutMs: 45_000,
-});
+function createHarnessFetch(logger?: RunLogger): FetchLike {
+  const instrumented = createInstrumentedFetch({
+    component: 'agent.openai-harness',
+    logger,
+    // 90s of silence allowed before headers — covers cold model warm-up on
+    // a local backend at high context.
+    responseHeadersTimeoutMs: 90_000,
+    // 45s between body chunks before we treat the stream as wedged. A
+    // healthy local model emits chunks well under a second apart even when
+    // it's reasoning; 45s is several orders of magnitude above that.
+    idleTimeoutMs: 45_000,
+  });
+  return wrapResponsesFailureDetection(instrumented, logger);
+}
 
-function createProvider(provider: ProviderConfig | undefined): OpenAIProvider {
+function createProvider(provider: ProviderConfig | undefined, logger?: RunLogger): OpenAIProvider {
   const { apiKey, baseURL } = resolveOpenAIClientConfig(provider);
   const client = new OpenAI({
     apiKey,
     ...(baseURL ? { baseURL } : {}),
-    fetch: harnessFetch,
+    fetch: createHarnessFetch(logger),
   });
 
   return new OpenAIProvider({
@@ -536,6 +708,18 @@ export function toStrictJsonObjectSchema(schema: Record<string, unknown>): Recor
 }
 
 /**
+ * Strip an OpenRouter-style vendor prefix ("openai/gpt-5.4-mini" ->
+ * "gpt-5.4-mini") for model-family classification only. OpenRouter slugs
+ * are `<vendor>/<model>`; everything through the first '/' is the vendor.
+ * A slug with no '/' (a bare OpenAI model name, or a non-vendor-prefixed
+ * route) is returned unchanged.
+ */
+function stripVendorPrefix(model: string): string {
+  const slashIndex = model.indexOf('/');
+  return slashIndex === -1 ? model : model.slice(slashIndex + 1);
+}
+
+/**
  * Build the per-setup SDK machinery: connect the MCP server, construct
  * the Agent + Runner pair. Both `execute` (single-shot, runs once and
  * closes) and `openScope` (long-lived, scope.run() called N times) share
@@ -563,7 +747,13 @@ async function prepareOpenAIRun(
   // an arbitrary openrouter route would bypass that guard and send fields
   // the model's API rejects with a 400. Omitting the key entirely for a
   // non-reasoning-capable model preserves the SDK's own pre-branch default.
-  const modelSettings = gpt5ReasoningSettingsRequired(preparedExecution.model)
+  //
+  // `gpt5ReasoningSettingsRequired` does a plain `startsWith('gpt-5')` check,
+  // which fails on OpenRouter's vendor-prefixed slugs (e.g.
+  // "openai/gpt-5.4-mini") — the check must see the unprefixed model name.
+  // Strip the vendor prefix ONLY for this classification; the actual request
+  // still sends `preparedExecution.model` (the full slug) unchanged.
+  const modelSettings = gpt5ReasoningSettingsRequired(stripVendorPrefix(preparedExecution.model))
     ? resolveModelSettings(setup.reasoningLevel, setup.provider)
     : undefined;
   const agent = new Agent({
@@ -582,7 +772,7 @@ async function prepareOpenAIRun(
     } : {}),
   });
   const runner = new Runner({
-    modelProvider: testOverrides.modelProvider ?? createProvider(preparedExecution.provider),
+    modelProvider: testOverrides.modelProvider ?? createProvider(preparedExecution.provider, setup.logger),
   });
   return { agent, runner, mcpServer };
 }
@@ -592,12 +782,21 @@ async function prepareOpenAIRun(
  * thrown SDK error so the caller still gets usage telemetry on failure.
  * The shape varies across SDK versions and error types — we check the
  * common ones and return undefined if none match.
+ *
+ * `AgentsError` (the base class of e.g. `MaxTurnsExceededError`) carries a
+ * bare `RunState` on `.state`, not a `RunResult` — `RunResult.rawResponses`
+ * is a getter that reads `this.state._modelResponses` (agents-core
+ * result.js), but `RunState` itself exposes only `_modelResponses` directly,
+ * with no `rawResponses` getter of its own. Without this candidate, every
+ * MaxTurnsExceededError rescue silently returned {} usage even though the
+ * SDK had already accumulated real, billed turns on `state._modelResponses`.
  */
 function extractPartialRawResponses(err: unknown): Array<Parameters<typeof toOpenAIUsage>[0][number]> | undefined {
   if (!err || typeof err !== 'object') return undefined;
   const candidates: unknown[] = [
     (err as { rawResponses?: unknown }).rawResponses,
     (err as { state?: { rawResponses?: unknown } }).state?.rawResponses,
+    (err as { state?: { _modelResponses?: unknown } }).state?._modelResponses,
     (err as { result?: { rawResponses?: unknown } }).result?.rawResponses,
   ];
   for (const c of candidates) {

--- a/packages/myco/src/constants/log-kinds.ts
+++ b/packages/myco/src/constants/log-kinds.ts
@@ -92,6 +92,14 @@ export const LOG_KINDS = {
   FETCH_TIMEOUT: 'fetch.timeout',
   FETCH_STALL: 'fetch.stall',
   FETCH_ABORT: 'fetch.abort',
+  // OpenRouter (and any Responses-API-shaped provider) can return HTTP 200
+  // for an upstream provider failure — status:"failed"/"incomplete" with an
+  // error body and empty/reasoning-only output. The OpenAI Agents SDK reads
+  // only output/usage and never checks status/error, so left unguarded this
+  // becomes a silent zero-item turn that loops to MaxTurnsExceededError.
+  // Emitted by openai.ts's harnessFetch wrapper when it converts one of
+  // these 200-wrapped failures into a synthesized error response.
+  FETCH_PROVIDER_FAILURE: 'fetch.provider-failure',
 
   // Server (HTTP)
   SERVER_REQUEST: 'server.request',

--- a/tests/agent/executor.test.ts
+++ b/tests/agent/executor.test.ts
@@ -1353,6 +1353,16 @@ describe('runAgent', () => {
     const run = getRun(result.runId, ALL_PROJECTS_SCOPE);
     expect(run?.status).toBe('failed');
     expect(run?.error).toContain('title-summary');
+    // Regression guard: executeSingleQuery's mocked harness call succeeds
+    // (1500 input + 350 output = 1850 tokens, same usage shape as the
+    // 'records tokens_used from num_turns' success-path test) BEFORE the
+    // run-end postcondition throws a plain Error. Postcondition failures
+    // are not HarnessExecutionError, so before hoisting `tokensUsed`/`usage`
+    // out of the try block (executor.ts), the catch block's failure-usage
+    // rebuild had no way to see this already-populated usage and always
+    // persisted tokens_used=0 despite the run being fully billed (observed
+    // on ea34158d, 0f22a8c3).
+    expect(run?.tokens_used).toBe(1850);
   });
 
   it('allows title-summary to complete when it reports a skip', async () => {

--- a/tests/agent/harness/classify-error.test.ts
+++ b/tests/agent/harness/classify-error.test.ts
@@ -11,6 +11,12 @@ describe('isConnectionError', () => {
     'Unable to connect. Is the computer able to access the url?',
     'socket hang up',
     'ECONNRESET',
+    // The synthesized 502 message openai.ts's harnessFetch produces when
+    // OpenRouter's /api/v1/responses returns HTTP 200 for an upstream
+    // provider failure (spore discovery-5c27c512) — must classify as
+    // retryable connection-class, not a caller-content mistake.
+    '502 OpenRouter upstream provider failure: Azure upstream rejected the request (response id: gen-abc123)',
+    'provider_unavailable',
   ])('classifies "%s" as a connection error', (msg) => {
     expect(isConnectionError(msg)).toBe(true);
   });

--- a/tests/agent/harness/openai-model-settings.test.ts
+++ b/tests/agent/harness/openai-model-settings.test.ts
@@ -187,17 +187,39 @@ describe('OpenAIAgentsHarness.execute — modelSettings wiring', () => {
   });
 
   // OpenRouter catalogs GPT-5-family models under vendor-prefixed slugs
-  // ('openai/gpt-5.4-mini'), which the SDK's gpt5ReasoningSettingsRequired
-  // classifies as non-reasoning (startsWith('gpt-5') fails on the prefix).
-  // The gate therefore sends no modelSettings for them — identical to the
-  // SDK's own pre-gate constructor behavior for these names. Attaching
-  // settings for prefixed slugs would require model-name normalization plus
-  // a live openrouter smoke; until then this test pins the parity behavior.
-  it('openrouter vendor-prefixed GPT-5 slugs currently get no modelSettings (SDK gpt5ReasoningSettingsRequired parity — known gap)', async () => {
+  // ('openai/gpt-5.4-mini'). The SDK's own gpt5ReasoningSettingsRequired does
+  // a plain startsWith('gpt-5') check, which fails on the vendor prefix — so
+  // prepareOpenAIRun strips everything through the first '/' before running
+  // the classification (stripVendorPrefix in openai.ts). The ACTUAL request
+  // still sends the full "openai/gpt-5.4-mini" slug; only the classification
+  // input is normalized.
+  it('openrouter vendor-prefixed GPT-5 slugs get modelSettings attached (vendor-prefix normalized before the gpt5 check)', async () => {
     const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider() });
     const capturedAgent = await captureConstructedAgent(() => harness.execute({
       prompt: 'do something',
       model: 'openai/gpt-5.4-mini',
+      provider: {
+        type: 'openrouter',
+        effortMap: { high: { effort: 'xhigh', verbosity: 'high' } },
+      },
+      reasoningLevel: 'high',
+      toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+    }));
+
+    expect(capturedAgent?.modelSettings).toEqual({
+      reasoning: { effort: 'xhigh' },
+      text: { verbosity: 'high' },
+    });
+    // The full vendor-prefixed slug is still what's sent as the model —
+    // normalization applies ONLY to the gpt5ReasoningSettingsRequired check.
+    expect(capturedAgent?.model).toBe('openai/gpt-5.4-mini');
+  });
+
+  it('vendor-prefixed NON-GPT-5 openrouter slugs still get no modelSettings after stripping the prefix', async () => {
+    const harness = new OpenAIAgentsHarness({ modelProvider: stubModelProvider() });
+    const capturedAgent = await captureConstructedAgent(() => harness.execute({
+      prompt: 'do something',
+      model: 'openai/gpt-4o-mini',
       provider: {
         type: 'openrouter',
         effortMap: { high: { effort: 'xhigh', verbosity: 'high' } },

--- a/tests/agent/harness/openai-responses-failure-detection.test.ts
+++ b/tests/agent/harness/openai-responses-failure-detection.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Tests for the OpenAI Agents harness fetch-seam guard against spore
+ * discovery-5c27c512: OpenRouter's `/api/v1/responses` returns HTTP 200 for
+ * an upstream provider failure (`status: "failed"`, `error: {...}`,
+ * `output: []`, `usage: null`; also `status: "incomplete"` with only
+ * reasoning-shaped output). `@openai/agents` v0.12.0's
+ * `OpenAIResponsesModel.getResponse` reads only `response.output`/
+ * `response.usage` and never checks `status`/`error`, so an unguarded
+ * 200-wrapped failure becomes a zero-item model turn that agents-core's
+ * turn loop silently re-runs until `MaxTurnsExceededError` — 8 turns in ~7s
+ * with zero tool events and zero recorded usage (run 3e23e9bf).
+ *
+ * `isUnsurfacedResponsesFailure` and `wrapResponsesFailureDetection` are
+ * exported directly from openai.ts for unit testing — driving this through
+ * a full `harness.execute()` call would require a real `OpenAIProvider` +
+ * stubbed global fetch, which every other harness test avoids by injecting
+ * a `modelProvider` test override that bypasses `createProvider`/
+ * `harnessFetch` (and therefore this guard) entirely.
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test';
+import { vi } from '../../helpers/vi-shim.js';
+import {
+  isUnsurfacedResponsesFailure,
+  wrapResponsesFailureDetection,
+  OpenAIAgentsHarness,
+} from '@myco/agent/harness/openai.js';
+import { HarnessExecutionError } from '@myco/agent/harness/types.js';
+import type { FetchLike } from '@myco/utils/instrumented-fetch.js';
+
+function jsonResponse(body: unknown, init: { status?: number; ok?: boolean } = {}): Response {
+  const status = init.status ?? 200;
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function stubFetch(response: Response): FetchLike {
+  return async () => response;
+}
+
+const RESPONSES_URL = 'https://openrouter.ai/api/v1/responses';
+
+// The exact shape spore discovery-5c27c512 verified live against OpenRouter.
+const FAILED_BODY = {
+  id: 'gen-abc123',
+  status: 'failed',
+  error: { code: 'provider_unavailable', message: 'Azure upstream rejected the request' },
+  output: [],
+  usage: null,
+};
+
+const INCOMPLETE_REASONING_ONLY_BODY = {
+  id: 'gen-def456',
+  status: 'incomplete',
+  output: [{ type: 'reasoning', content: [] }],
+  usage: { requests: 1, input_tokens: 10, output_tokens: 0, total_tokens: 10 },
+};
+
+const CLEAN_BODY = {
+  id: 'gen-ghi789',
+  status: 'completed',
+  output: [{ type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'hi' }] }],
+  usage: { requests: 1, input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+};
+
+describe('isUnsurfacedResponsesFailure', () => {
+  it('flags status: "failed"', () => {
+    expect(isUnsurfacedResponsesFailure(FAILED_BODY)).toBe(true);
+  });
+
+  it('flags status: "incomplete" with only reasoning-shaped output', () => {
+    expect(isUnsurfacedResponsesFailure(INCOMPLETE_REASONING_ONLY_BODY)).toBe(true);
+  });
+
+  it('flags status: "incomplete" with empty output', () => {
+    expect(isUnsurfacedResponsesFailure({ status: 'incomplete', output: [] })).toBe(true);
+  });
+
+  it('flags status: "incomplete" with no output key at all', () => {
+    expect(isUnsurfacedResponsesFailure({ status: 'incomplete' })).toBe(true);
+  });
+
+  it('passes status: "incomplete" that has at least one non-reasoning item', () => {
+    expect(isUnsurfacedResponsesFailure({
+      status: 'incomplete',
+      output: [
+        { type: 'reasoning', content: [] },
+        { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'partial' }] },
+      ],
+    })).toBe(false);
+  });
+
+  it('passes a clean status: "completed" body', () => {
+    expect(isUnsurfacedResponsesFailure(CLEAN_BODY)).toBe(false);
+  });
+
+  it('passes an unrecognized status untouched (not our shape to police)', () => {
+    expect(isUnsurfacedResponsesFailure({ status: 'queued', output: [] })).toBe(false);
+  });
+});
+
+describe('wrapResponsesFailureDetection', () => {
+  it('converts a 200 status:"failed" body into a synthesized 5xx the OpenAI SDK will raise as APIError', async () => {
+    const wrapped = wrapResponsesFailureDetection(stubFetch(jsonResponse(FAILED_BODY)));
+    const result = await wrapped(RESPONSES_URL, { method: 'POST', body: '{}' });
+
+    expect(result.status).toBeGreaterThanOrEqual(500);
+    expect(result.ok).toBe(false);
+    const parsed = await result.json();
+    expect(parsed.error.message).toContain('Azure upstream rejected the request');
+    expect(parsed.error.code).toBe('provider_unavailable');
+  });
+
+  it('converts a 200 status:"incomplete" reasoning-only body the same way', async () => {
+    const wrapped = wrapResponsesFailureDetection(stubFetch(jsonResponse(INCOMPLETE_REASONING_ONLY_BODY)));
+    const result = await wrapped(RESPONSES_URL, { method: 'POST', body: '{}' });
+
+    expect(result.status).toBeGreaterThanOrEqual(500);
+    const parsed = await result.json();
+    expect(parsed.error.message).toContain('incomplete response with no non-reasoning output');
+  });
+
+  it('passes a clean 200 response through byte-identical', async () => {
+    const clean = jsonResponse(CLEAN_BODY);
+    const wrapped = wrapResponsesFailureDetection(stubFetch(clean));
+    const result = await wrapped(RESPONSES_URL, { method: 'POST', body: '{}' });
+
+    expect(result.status).toBe(200);
+    expect(result.ok).toBe(true);
+    const parsed = await result.json();
+    expect(parsed).toEqual(CLEAN_BODY);
+  });
+
+  it('ignores GET requests to a /responses path (e.g. retrieve-by-id)', async () => {
+    const wrapped = wrapResponsesFailureDetection(stubFetch(jsonResponse(FAILED_BODY)));
+    const result = await wrapped(`${RESPONSES_URL}/gen-abc123`, { method: 'GET' });
+
+    expect(result.status).toBe(200);
+  });
+
+  it('ignores POST requests whose path does not end in /responses', async () => {
+    const wrapped = wrapResponsesFailureDetection(stubFetch(jsonResponse(FAILED_BODY)));
+    const result = await wrapped('https://openrouter.ai/api/v1/chat/completions', { method: 'POST', body: '{}' });
+
+    expect(result.status).toBe(200);
+  });
+
+  it('leaves an already-erroring (non-2xx) response untouched', async () => {
+    const errorResponse = jsonResponse({ error: { message: 'invalid api key' } }, { status: 401 });
+    const wrapped = wrapResponsesFailureDetection(stubFetch(errorResponse));
+    const result = await wrapped(RESPONSES_URL, { method: 'POST', body: '{}' });
+
+    expect(result.status).toBe(401);
+    const parsed = await result.json();
+    expect(parsed.error.message).toBe('invalid api key');
+  });
+
+  it('passes through a streamed (SSE content-type) response untouched', async () => {
+    const sseResponse = new Response('data: {"type":"response.created"}\n\n', {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    });
+    const wrapped = wrapResponsesFailureDetection(stubFetch(sseResponse));
+    const result = await wrapped(RESPONSES_URL, { method: 'POST', body: '{"stream":true}' });
+
+    expect(result.status).toBe(200);
+    expect(result.headers.get('content-type')).toBe('text/event-stream');
+  });
+
+  it('passes through a non-JSON body without throwing', async () => {
+    const textResponse = new Response('not json', { status: 200, headers: { 'content-type': 'text/plain' } });
+    const wrapped = wrapResponsesFailureDetection(stubFetch(textResponse));
+    const result = await wrapped(RESPONSES_URL, { method: 'POST', body: '{}' });
+
+    expect(result.status).toBe(200);
+    expect(await result.text()).toBe('not json');
+  });
+
+  it('logs a warn-level fetch.provider-failure entry with the provider error message', async () => {
+    const logs: Array<{ kind: string; message: string; data?: Record<string, unknown> }> = [];
+    const logger = {
+      warn: (kind: string, message: string, data?: Record<string, unknown>) => {
+        logs.push({ kind, message, data });
+      },
+    };
+    const wrapped = wrapResponsesFailureDetection(stubFetch(jsonResponse(FAILED_BODY)), logger);
+    await wrapped(RESPONSES_URL, { method: 'POST', body: '{}' });
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0]!.kind).toBe('fetch.provider-failure');
+    expect(logs[0]!.message).toContain('Azure upstream rejected the request');
+    expect(logs[0]!.data?.status).toBe('failed');
+    expect(logs[0]!.data?.responseId).toBe('gen-abc123');
+  });
+
+  it('does not log when no logger is provided (silent instrumentation stays silent, not throwing)', async () => {
+    const wrapped = wrapResponsesFailureDetection(stubFetch(jsonResponse(FAILED_BODY)));
+    const result = await wrapped(RESPONSES_URL, { method: 'POST', body: '{}' });
+    expect(result.status).toBeGreaterThanOrEqual(500);
+  });
+});
+
+/**
+ * End-to-end proof that the fetch-seam guard is actually wired into the
+ * live harness path: no `modelProvider` test override here (that would
+ * bypass `createProvider`/`createHarnessFetch` — and this guard — entirely,
+ * same as every other harness test file). `global.fetch` is stubbed so
+ * `OpenAIProvider`'s real `OpenAI` client, constructed by `createProvider`
+ * with `fetch: createHarnessFetch(logger)`, actually round-trips through
+ * `wrapResponsesFailureDetection`. This is the run 3e23e9bf reproduction:
+ * before Fix 1, this exact stub would silently loop to
+ * MaxTurnsExceededError in a handful of empty turns; after the fix it
+ * throws on the FIRST turn.
+ */
+describe('OpenAIAgentsHarness.execute — end-to-end fetch-seam guard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('throws immediately on turn 1 instead of looping to MaxTurnsExceededError', async () => {
+    let fetchCallCount = 0;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      fetchCallCount += 1;
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : (input as Request).url;
+      if (new URL(url).pathname.endsWith('/responses')) {
+        return jsonResponse(FAILED_BODY);
+      }
+      throw new Error(`unexpected fetch in test: ${url}`);
+    }));
+
+    const priorKey = process.env.MYCO_OPENROUTER_API_KEY;
+    process.env.MYCO_OPENROUTER_API_KEY = 'test-key';
+    try {
+      const harness = new OpenAIAgentsHarness();
+      let caught: unknown;
+      try {
+        await harness.execute({
+          prompt: 'do something',
+          model: 'openai/gpt-5.4-mini',
+          provider: { type: 'openrouter' },
+          maxTurns: 8,
+          toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+        });
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(HarnessExecutionError);
+      const harnessErr = caught as InstanceType<typeof HarnessExecutionError>;
+      expect(harnessErr.telemetry.kind).toBe('connection');
+      expect(harnessErr.message).toContain('Azure upstream rejected the request');
+      // The whole point: the SDK's own retry-on-5xx may issue a couple of
+      // attempts, but this must NOT consume the full maxTurns budget (8) —
+      // that was the 3e23e9bf failure mode (8 turns in ~7s, zero events).
+      expect(fetchCallCount).toBeLessThan(8);
+    } finally {
+      if (priorKey === undefined) delete process.env.MYCO_OPENROUTER_API_KEY;
+      else process.env.MYCO_OPENROUTER_API_KEY = priorKey;
+    }
+  });
+
+  it('threads the run logger into harnessFetch so the provider-failure warning is actually logged', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(FAILED_BODY)));
+
+    const priorKey = process.env.MYCO_OPENROUTER_API_KEY;
+    process.env.MYCO_OPENROUTER_API_KEY = 'test-key';
+    const warnCalls: Array<{ kind: string; message: string }> = [];
+    const logger = {
+      debug: () => {},
+      info: () => {},
+      warn: (kind: string, message: string) => { warnCalls.push({ kind, message }); },
+      error: () => {},
+    };
+    try {
+      const harness = new OpenAIAgentsHarness();
+      await harness.execute({
+        prompt: 'do something',
+        model: 'openai/gpt-5.4-mini',
+        provider: { type: 'openrouter' },
+        maxTurns: 8,
+        logger,
+        toolSurface: { agentId: 'a', runId: 'r', toolNames: [] },
+      }).catch(() => {});
+
+      expect(warnCalls.some((c) => c.kind === 'fetch.provider-failure')).toBe(true);
+    } finally {
+      if (priorKey === undefined) delete process.env.MYCO_OPENROUTER_API_KEY;
+      else process.env.MYCO_OPENROUTER_API_KEY = priorKey;
+    }
+  });
+});

--- a/tests/agent/harness/openai-usage-rescue.test.ts
+++ b/tests/agent/harness/openai-usage-rescue.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for extractPartialRawResponses's MaxTurnsExceededError rescue path
+ * (gotcha-82ccd461): `AgentsError.state` (thrown by e.g.
+ * MaxTurnsExceededError, agents-core turnPreparation.js) is a bare
+ * `RunState`, not a `RunResult`. `RunResult.rawResponses` is a getter that
+ * reads `this.state._modelResponses` (agents-core result.js), but
+ * `RunState` itself only exposes `_modelResponses` directly — it has no
+ * `rawResponses` getter of its own. Before this fix, extractPartialRawResponses
+ * probed `err.state?.rawResponses` (always undefined on a RunState) and
+ * every MaxTurnsExceededError rescue silently returned {} usage, so a
+ * failed run that had already burned real, billed turns recorded
+ * tokens_used=0.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { OpenAIAgentsHarness } from '@myco/agent/harness/openai.js';
+import { HarnessExecutionError } from '@myco/agent/harness/types.js';
+
+// A model stub whose getResponse() always returns a non-empty, billed turn
+// but never produces a final text output — the Runner keeps calling it
+// every turn until state._maxTurns binds and turnPreparation.js throws
+// MaxTurnsExceededError(message, state). Each turn's usage lands on
+// state._modelResponses via state._lastTurnResponse (run.js ~455/479),
+// mirroring how a real provider call accumulates usage before a max-turns
+// failure — not the OpenRouter 200-wrapped-failure shape (that's covered by
+// openai-responses-failure-detection.test.ts and Fix 1's fetch-seam guard;
+// this test is specifically about the SDK's own max-turns error carrying
+// real usage that the harness must not lose on rescue).
+function loopingToolCallModelProvider(perTurnTokens: number) {
+  return {
+    async getModel() {
+      return {
+        async getResponse() {
+          return {
+            output: [
+              {
+                type: 'function_call',
+                callId: 'call_1',
+                name: 'noop_tool',
+                arguments: '{}',
+                status: 'completed',
+              },
+            ],
+            usage: {
+              requests: 1,
+              inputTokens: perTurnTokens,
+              outputTokens: perTurnTokens,
+              totalTokens: perTurnTokens * 2,
+            },
+          };
+        },
+      };
+    },
+  } as any;
+}
+
+describe('OpenAIAgentsHarness.execute — MaxTurnsExceededError usage rescue', () => {
+  it('records non-zero usage when the run hits maxTurns via a tool-call loop', async () => {
+    const harness = new OpenAIAgentsHarness({ modelProvider: loopingToolCallModelProvider(100) });
+
+    let caught: unknown;
+    try {
+      await harness.execute({
+        prompt: 'do something',
+        model: 'gpt-5.4-mini',
+        provider: { type: 'openai' },
+        maxTurns: 3,
+        toolSurface: {
+          agentId: 'a',
+          runId: 'r',
+          tools: [{
+            name: 'noop_tool',
+            description: 'does nothing',
+            parameters: { type: 'object', properties: {}, additionalProperties: false },
+            handler: async () => 'ok',
+          }] as any,
+        },
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(HarnessExecutionError);
+    const harnessErr = caught as InstanceType<typeof HarnessExecutionError>;
+    expect(harnessErr.telemetry.kind).toBe('max-turns');
+    // The bug: before the fix this was 0 (extractPartialRawResponses found
+    // nothing on state.rawResponses, which doesn't exist on a RunState).
+    expect(harnessErr.telemetry.usage.totalTokens ?? 0).toBeGreaterThan(0);
+    expect(harnessErr.telemetry.usage.requests ?? 0).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
Root-caused from the 2026-07-02 dev-daemon failures (runs 3e23e9bf/0f22a8c3): OpenRouter's `/api/v1/responses` wraps upstream provider failures (including silent Azure routing) in HTTP 200 bodies; `@openai/agents` never checks `status`/`error`; agents-core silently re-loops empty turns — so a transient provider incident burned 8 turns in ~7s with zero trace. Five pattern-level fixes in Myco's harness layer (no SDK forks):

1. **Responses-body validation at the `harnessFetch` seam** — 200 bodies with `status:"failed"`/`error != null` (or `incomplete` with no substantive output) now surface immediately as retryable `HarnessExecutionError` kind `connection`, carrying the provider error. Clone-based inspection; clean bodies pass through byte-identical; SSE passed through untouched.
2. **Usage rescue reads `err.state?._modelResponses`** — `MaxTurnsExceededError` paths now record real usage instead of zeros.
3. **Contract failures keep real usage** — postcondition-failed runs persist actual `tokens_used` instead of 0 (fixes the recurring failure-path usage blindness: ea34158d, 0f22a8c3).
4. **`harnessFetch` gets the run logger** — harness wire failures now reach daemon logs.
5. **Vendor-prefix slug normalization** — `reasoningLevel` no longer silently no-ops for `openai/gpt-5.x` via OpenRouter (check-only strip; full slug still sent).

## Verification
- 2 new test files (20 tests) + 3 extended; every new assertion verified to fail pre-fix via manual revert.
- Full `npm test` green; `tsc --noEmit` clean; `make build` green; rebased on main post-#625 with the overlapping agent/harness suites re-run (760/760).
- Independent review: all 5 fixes pass spec, explicitly cleared for healthy-run safety (clean bodies byte-identical, bounded retries, no cross-run usage bleed).

Investigation record: spores `discovery-5c27c512`, `gotcha-82ccd461`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)