### PR TITLE
fix(grove): make the default and last grove undeletable

### DIFF
--- a/packages/myco/src/daemon/api/groves.ts
+++ b/packages/myco/src/daemon/api/groves.ts
@@ -5,10 +5,12 @@ import type { CapabilityId } from '@myco/config/scope.js';
 import { resolveProjectVaultDir } from '@myco/grove/paths.js';
 import {
   createGrove,
+  DefaultGroveUndeletableError,
   deleteGrove,
   findRegisteredProject,
   getDefaultGroveId,
   getRegisteredProjectInGrove,
+  LastGroveUndeletableError,
   listGroves,
   listRegisteredProjects,
   loadGroveRecord,
@@ -360,6 +362,12 @@ export function createDeleteGroveHandler(_daemonStateDir: string): RouteHandler 
       deleteGrove(groveId, { force: false });
       return { status: 204, body: undefined };
     } catch (err) {
+      if (err instanceof DefaultGroveUndeletableError) {
+        return { status: 409, body: errorBody('default_grove_undeletable', err.message) };
+      }
+      if (err instanceof LastGroveUndeletableError) {
+        return { status: 409, body: errorBody('last_grove_undeletable', err.message) };
+      }
       return { status: 500, body: errorBody('delete_failed', (err as Error).message) };
     }
   };

--- a/packages/myco/src/grove/registry.ts
+++ b/packages/myco/src/grove/registry.ts
@@ -244,6 +244,36 @@ export class UnknownGroveError extends Error {
 }
 
 /**
+ * A caller tried to delete the Grove currently pointed to by
+ * `default_grove_id`. Thrown by {@link deleteGrove} — every `MYCO_HOME`
+ * must keep a default Grove to operate against, so the default must be
+ * reassigned (`setDefaultGrove`) to another Grove before this one can be
+ * removed. Not bypassed by `force` (that flag only waives the
+ * bound-projects guard). The daemon transport maps this to a 409
+ * `default_grove_undeletable`.
+ */
+export class DefaultGroveUndeletableError extends Error {
+  constructor(public readonly groveId: string) {
+    super(`Grove ${groveId} is the default Grove; reassign the default Grove first`);
+    this.name = 'DefaultGroveUndeletableError';
+  }
+}
+
+/**
+ * A caller tried to delete the only Grove left in the registry. Thrown by
+ * {@link deleteGrove} as a belt for a stale or unset default pointer — the
+ * at-least-one-Grove invariant holds regardless of what
+ * `getDefaultGroveId` currently reports. Not bypassed by `force`. The
+ * daemon transport maps this to a 409 `last_grove_undeletable`.
+ */
+export class LastGroveUndeletableError extends Error {
+  constructor(public readonly groveId: string) {
+    super(`Grove ${groveId} is the only Grove; at least one Grove must remain`);
+    this.name = 'LastGroveUndeletableError';
+  }
+}
+
+/**
  * Existence + ownership gate for caller-named Grove ids that arrive
  * OUTSIDE the request-context funnel (body `ActionScope.grove_id`, URL
  * `:id` params). Throws {@link UnknownGroveError} when no record exists —
@@ -979,13 +1009,27 @@ export function renameGrove(
  * `force: true` is passed — moves are the supported path for project
  * relocation, not a "smart" delete.
  *
+ * Two additional refusals run BEFORE the bound-projects guard and are
+ * never bypassed by `force` — a Myco home must always have a default
+ * Grove to operate against:
+ *   1. Deleting the current default Grove throws
+ *      {@link DefaultGroveUndeletableError} — reassign the default
+ *      (`setDefaultGrove`) to another Grove first.
+ *   2. Deleting the last remaining Grove throws
+ *      {@link LastGroveUndeletableError} — belt for a stale/unset
+ *      default pointer; the at-least-one-Grove invariant holds
+ *      regardless of what the pointer says.
+ *
  * On success: removes `~/.myco/groves/<groveId>/` (metadata, registry,
  * SQLite, vectors). Clears the cross-Grove default pointer if the
- * deleted Grove was the default.
+ * deleted Grove was the default (unreachable in practice now that (1)
+ * refuses that case, kept as defense in depth).
  *
  * Note: `force: true` discards any per-project pause state on bound
  * projects along with the rest of the Grove dir — pauses live in the
- * Grove's `projects.toml`, which is removed with the directory.
+ * Grove's `projects.toml`, which is removed with the directory. `force`
+ * bypasses ONLY the bound-projects guard below; it never bypasses the
+ * default-Grove or last-Grove refusals.
  */
 export function deleteGrove(
   groveId: string,
@@ -994,6 +1038,14 @@ export function deleteGrove(
 ): void {
   const existing = loadGroveRecord(groveId, mycoHome);
   if (!existing) throw new Error(`Unknown Grove: ${groveId}`);
+
+  if (getDefaultGroveId(mycoHome) === groveId) {
+    throw new DefaultGroveUndeletableError(groveId);
+  }
+
+  if (listGroves(mycoHome).length === 1) {
+    throw new LastGroveUndeletableError(groveId);
+  }
 
   const projects = listRegisteredProjects(groveId, mycoHome);
   if (projects.length > 0 && !opts.force) {

--- a/packages/myco/ui/src/components/groves/GroveActionMenu.tsx
+++ b/packages/myco/ui/src/components/groves/GroveActionMenu.tsx
@@ -31,8 +31,12 @@ export function GroveActionMenu({
       key: 'delete',
       label: 'Delete Grove',
       destructive: true,
-      disabled: hasProjects,
-      disabledReason: hasProjects ? 'Move or remove projects first' : undefined,
+      disabled: isDefault || hasProjects,
+      disabledReason: isDefault
+        ? "The default Grove can't be deleted — set another Grove as default first"
+        : hasProjects
+          ? 'Move or remove projects first'
+          : undefined,
       onSelect: onDelete,
     },
   ];

--- a/tests/cli/grove.test.ts
+++ b/tests/cli/grove.test.ts
@@ -112,6 +112,9 @@ describe('myco grove CLI', () => {
   });
 
   it('deletes an empty Grove', async () => {
+    // Anchor Grove keeps `grove` non-default and non-last, isolating
+    // this test from the default/last-Grove refusals.
+    createGrove('Anchor', home);
     const grove = createGrove('To Delete', home);
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -125,6 +128,7 @@ describe('myco grove CLI', () => {
   });
 
   it('refuses to delete a non-empty Grove without --force', async () => {
+    createGrove('Anchor', home);
     const grove = createGrove('Busy', home);
     const projectRoot = path.join(home, 'project-busy');
     fs.mkdirSync(projectRoot, { recursive: true });
@@ -151,6 +155,7 @@ describe('myco grove CLI', () => {
   });
 
   it('deletes a non-empty Grove with --force', async () => {
+    createGrove('Anchor', home);
     const grove = createGrove('Force Me', home);
     const projectRoot = path.join(home, 'project-force');
     fs.mkdirSync(projectRoot, { recursive: true });
@@ -166,6 +171,76 @@ describe('myco grove CLI', () => {
     expect(loadGroveRecord(grove.id, home)).toBeNull();
     const output = log.mock.calls.map((call) => call.join(' ')).join('\n');
     expect(output).toContain('Deleted Grove Force Me (force-me)');
+
+    log.mockRestore();
+  });
+
+  it('refuses to delete the default Grove and surfaces the refusal message', async () => {
+    const defaultGrove = createGrove('Primary', home);
+    createGrove('Secondary', home);
+
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as never);
+
+    await expect(run(['delete', defaultGrove.slug])).rejects.toThrow('exit:1');
+
+    expect(loadGroveRecord(defaultGrove.id, home)).not.toBeNull();
+    const errOut = errSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+    expect(errOut).toMatch(/reassign the default Grove first/);
+
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('refuses to delete the default Grove even with --force', async () => {
+    const defaultGrove = createGrove('Primary', home);
+    createGrove('Secondary', home);
+
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as never);
+
+    await expect(run(['delete', defaultGrove.slug, '--force'])).rejects.toThrow('exit:1');
+
+    expect(loadGroveRecord(defaultGrove.id, home)).not.toBeNull();
+
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('refuses to delete the last remaining Grove (surfaces as the default-Grove refusal since the sole Grove is always default)', async () => {
+    const grove = createGrove('Solo', home);
+    expect(listGroves(home)).toHaveLength(1);
+
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`);
+    }) as never);
+
+    await expect(run(['delete', grove.slug])).rejects.toThrow('exit:1');
+
+    expect(loadGroveRecord(grove.id, home)).not.toBeNull();
+    const errOut = errSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+    expect(errOut).toMatch(/reassign the default Grove first/);
+
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('allows deleting a Grove after the default is reassigned elsewhere', async () => {
+    const a = createGrove('Alpha', home);
+    const b = createGrove('Beta', home);
+    setDefaultGrove(b.id, home);
+
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await run(['delete', a.slug]);
+
+    expect(loadGroveRecord(a.id, home)).toBeNull();
+    const output = log.mock.calls.map((call) => call.join(' ')).join('\n');
+    expect(output).toContain(`Deleted Grove ${a.name}`);
 
     log.mockRestore();
   });

--- a/tests/daemon/api/groves-crud.test.ts
+++ b/tests/daemon/api/groves-crud.test.ts
@@ -23,10 +23,12 @@ import { resolveGroveDbPath, resolveGroveDir, resolveProjectVaultDir } from '@my
 import {
   clearGroveRegistryCaches,
   createGrove,
+  getDefaultGroveId,
   listGroves,
   listRegisteredProjects,
   loadGroveRecord,
   registerProjectInGrove,
+  setDefaultGrove,
 } from '@myco/grove/registry.js';
 
 describe('Grove CRUD API', () => {
@@ -147,6 +149,10 @@ describe('Grove CRUD API', () => {
 
   describe('DELETE /api/groves/:id', () => {
     it('deletes an empty Grove and returns 204', async () => {
+      // A second Grove keeps `grove` non-default and non-last so this
+      // test isolates the empty/non-empty behavior from the new
+      // default/last-Grove guards.
+      createGrove('Anchor');
       const grove = createGrove('Disposable');
       const response = await call(createDeleteGroveHandler(serviceDir), { params: { id: grove.id } });
       expect(response.status).toBe(204);
@@ -154,6 +160,7 @@ describe('Grove CRUD API', () => {
     });
 
     it('returns 409 grove_not_empty when projects remain', async () => {
+      createGrove('Anchor');
       const grove = createGrove('Busy');
       const projectId = createProjectId();
       registerProjectInGrove(grove.id, {
@@ -170,6 +177,7 @@ describe('Grove CRUD API', () => {
     });
 
     it('returns 409 when only archived projects remain', async () => {
+      createGrove('Anchor');
       const grove = createGrove('Archived Busy');
       const projectId = createProjectId();
       registerProjectInGrove(grove.id, {
@@ -194,6 +202,61 @@ describe('Grove CRUD API', () => {
       });
       expect(response.status).toBe(404);
       expect((response.body as { error: { code: string } }).error.code).toBe('grove_not_found');
+    });
+
+    it('returns 409 default_grove_undeletable when deleting the default Grove', async () => {
+      const defaultGrove = createGrove('Primary');
+      createGrove('Secondary');
+      expect(getDefaultGroveId(mycoHome)).toBe(defaultGrove.id);
+
+      const response = await call(createDeleteGroveHandler(serviceDir), { params: { id: defaultGrove.id } });
+
+      expect(response.status).toBe(409);
+      expect((response.body as { error: { code: string } }).error.code).toBe('default_grove_undeletable');
+      expect(loadGroveRecord(defaultGrove.id)).not.toBeNull();
+    });
+
+    it('returns 409 default_grove_undeletable when deleting the only Grove (the sole Grove is always default)', async () => {
+      const grove = createGrove('Solo');
+      expect(listGroves(mycoHome)).toHaveLength(1);
+
+      const response = await call(createDeleteGroveHandler(serviceDir), { params: { id: grove.id } });
+
+      expect(response.status).toBe(409);
+      expect((response.body as { error: { code: string } }).error.code).toBe('default_grove_undeletable');
+      expect(loadGroveRecord(grove.id)).not.toBeNull();
+    });
+
+    it('returns 409 last_grove_undeletable when deleting the only Grove with a stale/unset default pointer', async () => {
+      const grove = createGrove('Solo');
+      expect(listGroves(mycoHome)).toHaveLength(1);
+      // Simulate a stale/unset default pointer independent of the
+      // single-Grove state — the last-Grove guard must not rely on the
+      // pointer being correct.
+      const registryPath = path.join(mycoHome, 'groves', 'registry.yaml');
+      fs.writeFileSync(registryPath, '{}\n', 'utf-8');
+      clearGroveRegistryCaches();
+      expect(getDefaultGroveId(mycoHome)).toBeNull();
+
+      const response = await call(createDeleteGroveHandler(serviceDir), { params: { id: grove.id } });
+
+      expect(response.status).toBe(409);
+      expect((response.body as { error: { code: string } }).error.code).toBe('last_grove_undeletable');
+      expect(loadGroveRecord(grove.id)).not.toBeNull();
+    });
+
+    it('allows deleting a Grove after the default is reassigned elsewhere', async () => {
+      const a = createGrove('Alpha');
+      const b = createGrove('Beta');
+      expect(getDefaultGroveId(mycoHome)).toBe(a.id);
+
+      setDefaultGrove(b.id, mycoHome);
+      expect(getDefaultGroveId(mycoHome)).toBe(b.id);
+
+      const response = await call(createDeleteGroveHandler(serviceDir), { params: { id: a.id } });
+
+      expect(response.status).toBe(204);
+      expect(loadGroveRecord(a.id)).toBeNull();
     });
   });
 

--- a/tests/grove/registry.test.ts
+++ b/tests/grove/registry.test.ts
@@ -8,12 +8,14 @@ import {
   clearGroveRegistryCaches,
   archiveProjectInGrove,
   createGrove,
+  DefaultGroveUndeletableError,
   deleteGrove,
   deregisterProjectInGrove,
   ensureDefaultGrove,
   ensureGroveExistsLocally,
   ensureProjectRegistered,
   getDefaultGroveId,
+  LastGroveUndeletableError,
   listGroves,
   listRegisteredProjects,
   loadGroveRecord,
@@ -289,6 +291,9 @@ describe('Grove registry', () => {
 
   describe('deleteGrove', () => {
     it('refuses to delete a Grove with bound projects unless force is set', () => {
+      // A second Grove keeps `grove` non-default and non-last so this
+      // test isolates the bound-projects guard.
+      createGrove('Other', home);
       const grove = createGrove('Work', home);
       registerProjectInGrove(grove.id, {
         projectId: 'proj_demo',
@@ -301,6 +306,7 @@ describe('Grove registry', () => {
     });
 
     it('deletes a Grove when force is true even with bound projects', () => {
+      createGrove('Other', home);
       const grove = createGrove('Work', home);
       registerProjectInGrove(grove.id, {
         projectId: 'proj_demo',
@@ -315,19 +321,8 @@ describe('Grove registry', () => {
       expect(fs.existsSync(path.join(home, 'groves', grove.id))).toBe(false);
     });
 
-    it('clears the default pointer when the deleted Grove was the default', () => {
-      const a = createGrove('Alpha', home);
-      const b = createGrove('Beta', home);
-      setDefaultGrove(b.id, home);
-      expect(getDefaultGroveId(home)).toBe(b.id);
-
-      deleteGrove(b.id, {}, home);
-
-      expect(getDefaultGroveId(home)).toBeNull();
-      expect(loadGroveRecord(a.id, home)?.id).toBe(a.id);
-    });
-
     it('removes the on-disk Grove directory', () => {
+      createGrove('Other', home);
       const grove = createGrove('Lonely', home);
       const groveDir = path.join(home, 'groves', grove.id);
       expect(fs.existsSync(groveDir)).toBe(true);
@@ -335,6 +330,72 @@ describe('Grove registry', () => {
       deleteGrove(grove.id, {}, home);
 
       expect(fs.existsSync(groveDir)).toBe(false);
+    });
+
+    it('refuses to delete the default Grove with a typed error', () => {
+      const a = createGrove('Alpha', home);
+      createGrove('Beta', home);
+      expect(getDefaultGroveId(home)).toBe(a.id);
+
+      expect(() => deleteGrove(a.id, {}, home)).toThrow(DefaultGroveUndeletableError);
+      expect(loadGroveRecord(a.id, home)).not.toBeNull();
+    });
+
+    it('force does not bypass the default-Grove refusal', () => {
+      const a = createGrove('Alpha', home);
+      createGrove('Beta', home);
+      expect(getDefaultGroveId(home)).toBe(a.id);
+
+      expect(() => deleteGrove(a.id, { force: true }, home)).toThrow(DefaultGroveUndeletableError);
+      expect(loadGroveRecord(a.id, home)).not.toBeNull();
+    });
+
+    it('refuses to delete the last remaining Grove (surfaces as the default-Grove refusal since the sole Grove is always default)', () => {
+      const grove = createGrove('Solo', home);
+      expect(listGroves(home)).toHaveLength(1);
+
+      expect(() => deleteGrove(grove.id, {}, home)).toThrow(DefaultGroveUndeletableError);
+      expect(loadGroveRecord(grove.id, home)).not.toBeNull();
+    });
+
+    it('refuses to delete the last remaining Grove with LastGroveUndeletableError when the default pointer is stale/unset', () => {
+      const grove = createGrove('Solo', home);
+      // Simulate a stale/unset default pointer independent of the
+      // single-Grove state — the last-Grove guard must not rely on the
+      // pointer being correct.
+      const doc = YAML.parse(fs.readFileSync(path.join(home, 'groves', 'registry.yaml'), 'utf-8')) ?? {};
+      delete doc.default_grove_id;
+      fs.writeFileSync(path.join(home, 'groves', 'registry.yaml'), YAML.stringify(doc), 'utf-8');
+      clearGroveRegistryCaches();
+      expect(getDefaultGroveId(home)).toBeNull();
+
+      expect(() => deleteGrove(grove.id, {}, home)).toThrow(LastGroveUndeletableError);
+      expect(loadGroveRecord(grove.id, home)).not.toBeNull();
+    });
+
+    it('force does not bypass the last-Grove refusal even with a stale/unset default pointer', () => {
+      const grove = createGrove('Solo', home);
+      const doc = YAML.parse(fs.readFileSync(path.join(home, 'groves', 'registry.yaml'), 'utf-8')) ?? {};
+      delete doc.default_grove_id;
+      fs.writeFileSync(path.join(home, 'groves', 'registry.yaml'), YAML.stringify(doc), 'utf-8');
+      clearGroveRegistryCaches();
+
+      expect(() => deleteGrove(grove.id, { force: true }, home)).toThrow(LastGroveUndeletableError);
+      expect(loadGroveRecord(grove.id, home)).not.toBeNull();
+    });
+
+    it('allows deleting a Grove after the default is reassigned elsewhere', () => {
+      const a = createGrove('Alpha', home);
+      const b = createGrove('Beta', home);
+      expect(getDefaultGroveId(home)).toBe(a.id);
+
+      setDefaultGrove(b.id, home);
+      expect(getDefaultGroveId(home)).toBe(b.id);
+
+      deleteGrove(a.id, {}, home);
+
+      expect(loadGroveRecord(a.id, home)).toBeNull();
+      expect(getDefaultGroveId(home)).toBe(b.id);
     });
   });
 });


### PR DESCRIPTION
## Summary
Origin: 2026-07-05 grove/capability review (Chris: "we need at least one grove to operate" — the UI allowed deleting the default grove, and `deleteGrove` merely cleared `default_grove_id` afterward, leaving no default at all).

- Two typed refusals inside `deleteGrove` itself so every caller (API, CLI, future) inherits them: `default_grove_undeletable` (reassign default first) and `last_grove_undeletable` (at-least-one-grove invariant, robust to a stale/unset default pointer).
- `force: true` continues to bypass only the bound-projects guard, documented at the option.
- API maps both refusals to 409 with their codes (previously any deleteGrove throw became a generic 500).
- Groves page: delete affordance disabled-with-reason on the default grove.
- Reassign-then-delete (CLI `myco grove use` / `POST /api/groves/:id/default` / UI set-default) verified as the working escape hatch at all three layers.

## Verification
- Registry, API, and CLI test coverage for both refusals, the stale-pointer edge, force semantics, and reassign-then-delete; 77/77 focused, full suite 405 files 0 fail, `tsc` clean, `make build` green.
- Independent review: all 5 spec items pass, zero blocking findings; removal of the obsolete "clears default pointer" test adjudicated safe (importer self-elects defaults; all consumers null-tolerant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)