### PR TITLE
fix(agent): seed built-in agents and tasks into every grove database

### DIFF
--- a/packages/myco/src/agent/loader.ts
+++ b/packages/myco/src/agent/loader.ts
@@ -8,6 +8,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import { findCorePackageRoot } from '@myco/utils/find-package-root.js';
 import { errorMessage } from '@myco/utils/error-message.js';
@@ -283,19 +284,94 @@ export function resolveEffectiveConfig(
 // ---------------------------------------------------------------------------
 
 /**
- * Register the built-in agent and all built-in tasks into the database.
+ * JSON key inside `agents.config` (built-in agent row only) that stores the
+ * content hash of the definitions the last COMPLETED seed wrote. The
+ * built-in agent row's `config` column has no other writer or reader — it
+ * is seed-owned (the only other `registerAgent` caller, spores/write.ts,
+ * registers the separate MCP user-agent row and never sets config).
+ */
+const DEFINITIONS_HASH_KEY = 'definitions_hash';
+
+interface CachedDefinitions {
+  definition: AgentDefinition;
+  tasks: AgentTask[];
+  /** Stable content hash of the parsed definitions — see loadCachedDefinitions. */
+  contentHash: string;
+}
+
+/**
+ * Cached parse of the built-in agent definition + tasks, keyed by
+ * definitionsDir. The YAML is process-static — resolved once per
+ * directory and reused across every `seedBuiltInAgentsAndTasks` call
+ * (the per-grove DB-open choke point calls this on every cache miss,
+ * so re-parsing ~15 task files on each call would be wasted work).
+ *
+ * The content hash is computed once alongside the parse: SHA-256 over
+ * `JSON.stringify` of the parsed definition + tasks with the tasks array
+ * sorted by name. Sorting removes the only nondeterminism (readdir order);
+ * object key order is insertion order, which is deterministic for a given
+ * file content (taskFromParsed builds top-level keys in fixed code order,
+ * nested objects keep YAML document order). Any semantic content change —
+ * prompt, phases, config, schedule — changes the parse and therefore the
+ * hash. Hashing the parse (not the raw files) also covers the bundled
+ * Bun-virtual-path fallback, which has no files to hash. A change that
+ * only reorders YAML keys also changes the hash, which errs on the side of
+ * re-seeding (when in doubt, upsert).
+ */
+const definitionsCache = new Map<string, CachedDefinitions>();
+
+function loadCachedDefinitions(definitionsDir: string): CachedDefinitions {
+  const cached = definitionsCache.get(definitionsDir);
+  if (cached) return cached;
+  const definition = loadAgentDefinition(definitionsDir);
+  const tasks = loadAgentTasks(definitionsDir);
+  // Code-unit compare keeps the hash stable across host locales.
+  const sortedTasks = [...tasks].sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  const contentHash = createHash('sha256')
+    .update(JSON.stringify({ definition, tasks: sortedTasks }))
+    .digest('hex');
+  const loaded = { definition, tasks, contentHash };
+  definitionsCache.set(definitionsDir, loaded);
+  return loaded;
+}
+
+/**
+ * Seed the built-in agent and all built-in tasks into the database.
  *
  * Idempotent: uses upsert (ON CONFLICT DO UPDATE) for both agent and tasks.
- * Safe to call on every daemon startup.
+ * Synchronous and DB-handle-agnostic — it writes through `getDatabase()`,
+ * so callers targeting a specific Grove DB must wrap the call in
+ * `withDatabase(db, () => seedBuiltInAgentsAndTasks(...))`.
+ *
+ * Cost control: skips the upserts entirely when a cheap check shows the DB
+ * already carries the current definitions. The check has two parts:
+ * 1. Task id set (count + membership) — catches added/removed/renamed
+ *    task YAMLs and partially-seeded DBs.
+ * 2. Content marker — the SHA-256 hash of the parsed definitions, persisted
+ *    in the built-in agent row's `config` column by the last COMPLETED
+ *    seed. This catches content-only changes (same task ids, different
+ *    prompt/phases/config) so an upgrade re-seeds every DB — boot and
+ *    per-grove alike — on its next open, exactly once.
+ * The marker is written LAST, after every upsert and the sweep, and the
+ * agent upsert at the top clears it (config → null) first — so a seed
+ * interrupted mid-way leaves no marker and re-runs in full on next open.
+ * When in doubt (missing/unparseable marker, e.g. a DB last seeded by a
+ * pre-marker binary), this falls through to the full upsert path —
+ * correctness over cost savings.
  *
  * @param definitionsDir — path to the definitions directory.
  */
-export async function registerBuiltInAgentsAndTasks(definitionsDir: string, vaultDir?: string): Promise<void> {
-  const definition = loadAgentDefinition(definitionsDir);
-  const tasks = loadAgentTasks(definitionsDir);
+export function seedBuiltInAgentsAndTasks(definitionsDir: string): void {
+  const { definition, tasks, contentHash } = loadCachedDefinitions(definitionsDir);
+  const validTaskIds = tasks.map((t) => t.name);
+
+  if (isAlreadySeeded(definition.name, validTaskIds, contentHash)) return;
+
   const now = epochSeconds();
 
-  // Upsert the built-in agent
+  // Upsert the built-in agent. `config` is intentionally omitted (→ null):
+  // the upsert clears any previous content marker, so the marker only
+  // exists when the write of it below — the seed's final statement — ran.
   registerAgent({
     id: definition.name,
     name: definition.displayName,
@@ -331,7 +407,6 @@ export async function registerBuiltInAgentsAndTasks(definitionsDir: string, vaul
   }
 
   // Remove built-in tasks that no longer have YAML definitions
-  const validTaskIds = tasks.map(t => t.name);
   if (validTaskIds.length > 0) {
     const db = getDatabase();
     const placeholders = validTaskIds.map(() => '?').join(', ');
@@ -341,8 +416,80 @@ export async function registerBuiltInAgentsAndTasks(definitionsDir: string, vaul
     ).run(BUILT_IN_SOURCE, definition.name, ...validTaskIds);
   }
 
+  // Persist the content marker LAST — its presence means "this seed ran to
+  // completion against these exact definitions". The agent upsert above
+  // cleared it, so an interrupted seed leaves no marker and re-runs fully.
+  getDatabase().prepare(`UPDATE agents SET config = ? WHERE id = ? AND source = ?`)
+    .run(JSON.stringify({ [DEFINITIONS_HASH_KEY]: contentHash }), definition.name, BUILT_IN_SOURCE);
+}
+
+/**
+ * Cheap short-circuit check for `seedBuiltInAgentsAndTasks`: true only when
+ * ALL of the following hold —
+ * 1. the built-in agent row exists;
+ * 2. its persisted content marker (`config.definitions_hash`, written only
+ *    by a completed seed) matches the current definitions hash, so
+ *    content-only changes (same ids, edited prompt/phases/config) re-seed;
+ * 3. the set of built-in task ids in the DB exactly matches the current
+ *    YAML-derived task id set (count + membership) — a structural belt for
+ *    externally deleted/injected rows the marker can't see.
+ * A missing or unparseable marker (DB last seeded by a pre-marker binary,
+ * or a seed that never completed) fails the check → full upsert.
+ */
+function isAlreadySeeded(agentId: string, validTaskIds: string[], contentHash: string): boolean {
+  const db = getDatabase();
+  const agentRow = db.prepare(`SELECT config FROM agents WHERE id = ? AND source = ?`)
+    .get(agentId, BUILT_IN_SOURCE) as { config: string | null } | undefined;
+  if (!agentRow) return false;
+
+  if (!markerMatches(agentRow.config, contentHash)) return false;
+
+  const existingIds = db.prepare(
+    `SELECT id FROM agent_tasks WHERE source = ? AND agent_id = ?`,
+  ).all(BUILT_IN_SOURCE, agentId) as Array<{ id: string }>;
+
+  if (existingIds.length !== validTaskIds.length) return false;
+
+  const existingSet = new Set(existingIds.map((row) => row.id));
+  return validTaskIds.every((id) => existingSet.has(id));
+}
+
+/** True when the persisted agents.config marker carries the current hash. */
+function markerMatches(config: string | null, contentHash: string): boolean {
+  if (!config) return false;
+  try {
+    const parsed = JSON.parse(config) as Record<string, unknown>;
+    return parsed[DEFINITIONS_HASH_KEY] === contentHash;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Register the built-in agent and all built-in tasks into the database,
+ * then (if a vault dir is provided) register user tasks discovered in the
+ * vault.
+ *
+ * The built-in portion is synchronous (see `seedBuiltInAgentsAndTasks`)
+ * and shares its short-circuit: at boot this refreshes built-ins whenever
+ * the definitions' content marker (or task id set) differs from what the
+ * DB carries, and skips the writes when nothing changed — an upgrade that
+ * edits any built-in definition re-seeds on the next boot exactly once.
+ * This wrapper stays `async` only because the user-task branch below does
+ * a dynamic `import('./registry.js')`. That branch is vaultDir-dependent
+ * and stays boot/bootstrap-scoped — it is NOT called from the per-grove
+ * DB-open choke point (`grove-runtime-cache.ts`), which has no vaultDir in
+ * scope and only needs the built-in seed. Do not move it there.
+ *
+ * @param definitionsDir — path to the definitions directory.
+ */
+export async function registerBuiltInAgentsAndTasks(definitionsDir: string, vaultDir?: string): Promise<void> {
+  seedBuiltInAgentsAndTasks(definitionsDir);
+
   // Register user tasks from the vault (if vault dir provided)
   if (vaultDir) {
+    const { definition } = loadCachedDefinitions(definitionsDir);
+    const now = epochSeconds();
     const { loadAllTasks } = await import('./registry.js');
     const allTasks = loadAllTasks(definitionsDir, vaultDir);
     for (const [name, task] of allTasks) {

--- a/packages/myco/src/daemon/grove-runtime-cache.ts
+++ b/packages/myco/src/daemon/grove-runtime-cache.ts
@@ -1,6 +1,7 @@
-import { openDatabase, type Database } from '@myco/db/client.js';
+import { openDatabase, withDatabase, type Database } from '@myco/db/client.js';
 import { createSchema } from '@myco/db/schema.js';
 import { getMachineId } from '@myco/machine-id.js';
+import { resolveDefinitionsDir, seedBuiltInAgentsAndTasks } from '@myco/agent/loader.js';
 import type { EmbeddingManager, SqliteVecVectorStore } from './embedding/index.js';
 
 export interface GroveRuntimeEntry {
@@ -236,6 +237,18 @@ function openInitializedDatabase(databasePath: string): Database {
   // choke point that serves every non-boot Grove; defaulting here would
   // permanently stamp v52 with the conversion skipped.
   createSchema(db, getMachineId());
+  // Seed built-in agents/tasks for every non-boot Grove DB. Fresh Groves
+  // otherwise have empty agents/agent_tasks tables (only boot registration
+  // and the migration importer populate them), which makes every dispatch
+  // throw a FOREIGN KEY failure on agent_runs.agent_id -> agents(id). This
+  // choke point runs on every open (including re-opens of an existing,
+  // already-broken Grove), so a previously broken Grove self-heals on its
+  // next access with no separate boot sweep required.
+  // `withDatabase` scopes `getDatabase()` inside the seed call to this `db`
+  // via AsyncLocalStorage — the established per-grove write pattern used
+  // throughout daemon/ — so registerAgent/upsertTask need no signature
+  // changes to target a specific Grove's handle.
+  withDatabase(db, () => seedBuiltInAgentsAndTasks(resolveDefinitionsDir()));
   return db;
 }
 

--- a/tests/agent/loader.test.ts
+++ b/tests/agent/loader.test.ts
@@ -9,9 +9,12 @@
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { setupTestDb, cleanTestDb, teardownTestDb } from '../helpers/db';
+import { getDatabase } from '@myco/db/client.js';
 import { getAgent } from '@myco/db/queries/agents.js';
 import { listTasks, getDefaultTask } from '@myco/db/queries/tasks.js';
 import {
@@ -20,6 +23,7 @@ import {
   loadSystemPrompt,
   resolveEffectiveConfig,
   registerBuiltInAgentsAndTasks,
+  seedBuiltInAgentsAndTasks,
 } from '@myco/agent/loader.js';
 import { SKILL_EVOLVE_DEFAULT_MAX_SKILLS_PER_RUN } from '@myco/agent/instruction-builders.js';
 import type { AgentRow } from '@myco/db/queries/agents.js';
@@ -556,6 +560,202 @@ describe('agent loader', () => {
       const overrides = JSON.parse(digestOnly!.tool_overrides!) as string[];
       expect(Array.isArray(overrides)).toBe(true);
       expect(overrides).toContain('vault_write_digest');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // seedBuiltInAgentsAndTasks (sync, built-in-only body; requires PGlite)
+  // -------------------------------------------------------------------------
+
+  describe('seedBuiltInAgentsAndTasks', () => {
+    beforeAll(() => { setupTestDb(); });
+    afterAll(() => { teardownTestDb(); });
+    beforeEach(() => { cleanTestDb(); });
+
+    it('is synchronous and seeds the built-in agent + every built-in task on a fresh DB', () => {
+      const expectedTaskCount = loadAgentTasks(DEFINITIONS_DIR).length;
+
+      // No `await` — proves the built-in-only body is sync end to end.
+      seedBuiltInAgentsAndTasks(DEFINITIONS_DIR);
+
+      const agent = getAgent(BUILT_IN_AGENT_NAME);
+      expect(agent).not.toBeNull();
+      expect(agent!.source).toBe('built-in');
+
+      const tasks = listTasks({ agent_id: BUILT_IN_AGENT_NAME });
+      expect(tasks).toHaveLength(expectedTaskCount);
+    });
+
+    it('re-seeding an already-seeded DB is idempotent', () => {
+      seedBuiltInAgentsAndTasks(DEFINITIONS_DIR);
+      seedBuiltInAgentsAndTasks(DEFINITIONS_DIR);
+
+      const expectedTaskCount = loadAgentTasks(DEFINITIONS_DIR).length;
+      const tasks = listTasks({ agent_id: BUILT_IN_AGENT_NAME });
+      expect(tasks).toHaveLength(expectedTaskCount);
+    });
+
+    it('short-circuits on an already-seeded DB: the second call performs no writes', () => {
+      seedBuiltInAgentsAndTasks(DEFINITIONS_DIR);
+
+      const db = getDatabase();
+      const before = (db.prepare('SELECT total_changes() AS c').get() as { c: number }).c;
+      seedBuiltInAgentsAndTasks(DEFINITIONS_DIR);
+      const after = (db.prepare('SELECT total_changes() AS c').get() as { c: number }).c;
+
+      // The short-circuit's own SELECTs don't count toward total_changes();
+      // only INSERT/UPDATE/DELETE would move this counter, so a match here
+      // is a timing-free proof the upsert path was skipped entirely.
+      expect(after).toBe(before);
+    });
+
+    it('sweeps a built-in task row whose YAML has been removed, and only source=built-in rows', () => {
+      seedBuiltInAgentsAndTasks(DEFINITIONS_DIR);
+
+      // Simulate a task YAML that existed in a previous version and was
+      // removed, plus a user-authored task with the same agent_id that
+      // must survive the built-in-only sweep.
+      const now = Math.floor(Date.now() / 1000);
+      const db = getDatabase();
+      db.prepare(
+        `INSERT INTO agent_tasks (id, agent_id, source, display_name, description, prompt, is_default, created_at, updated_at)
+         VALUES (?, ?, 'built-in', 'Stale Task', 'stale', 'stale prompt', 0, ?, ?)`,
+      ).run('stale-removed-task', BUILT_IN_AGENT_NAME, now, now);
+      db.prepare(
+        `INSERT INTO agent_tasks (id, agent_id, source, display_name, description, prompt, is_default, created_at, updated_at)
+         VALUES (?, ?, 'user', 'User Task', 'user-authored', 'user prompt', 0, ?, ?)`,
+      ).run('user-authored-task', BUILT_IN_AGENT_NAME, now, now);
+
+      // Re-seeding must sweep the stale built-in row (its id is no longer
+      // in the current YAML-derived set) but leave the user-authored row
+      // untouched — the DELETE is scoped to source='built-in'.
+      seedBuiltInAgentsAndTasks(DEFINITIONS_DIR);
+
+      const tasks = listTasks({ agent_id: BUILT_IN_AGENT_NAME });
+      const ids = tasks.map((t) => t.id);
+      expect(ids).not.toContain('stale-removed-task');
+      expect(ids).toContain('user-authored-task');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // seedBuiltInAgentsAndTasks content marker (requires PGlite)
+  //
+  // Regression pin for review finding H1: the id-set short-circuit alone
+  // missed content-only definition changes (same task ids, edited
+  // prompt/phases/config), and because the boot delegation shares the
+  // short-circuit, no path re-upserted them. The marker — a SHA-256 of the
+  // parsed definitions persisted in the built-in agent row's config column
+  // by each completed seed — makes content changes re-seed on every path.
+  // -------------------------------------------------------------------------
+
+  describe('seedBuiltInAgentsAndTasks content marker', () => {
+    beforeAll(() => { setupTestDb(); });
+    afterAll(() => { teardownTestDb(); });
+    beforeEach(() => { cleanTestDb(); });
+
+    const FIXTURE_AGENT = 'fixture-agent';
+    const FIXTURE_TASK = 'fixture-task';
+    const fixtureDirs: string[] = [];
+
+    afterAll(() => {
+      for (const dir of fixtureDirs) fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    /**
+     * Write a minimal definitions dir whose task id set never changes —
+     * only the prompt content varies — so any re-seed between two fixture
+     * dirs can only be triggered by the content marker, never the id set.
+     */
+    function writeFixtureDefinitions(prompt: string): string {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'loader-fixture-defs-'));
+      fixtureDirs.push(dir);
+      fs.mkdirSync(path.join(dir, 'tasks'), { recursive: true });
+      fs.writeFileSync(path.join(dir, 'agent.yaml'), [
+        `name: ${FIXTURE_AGENT}`,
+        'displayName: Fixture Agent',
+        'description: Fixture agent for content-marker tests',
+        'model: sonnet',
+        'maxTurns: 5',
+        'timeoutSeconds: 60',
+        'systemPromptPath: ../prompts/agent.md',
+        'tools: []',
+        '',
+      ].join('\n'), 'utf-8');
+      fs.writeFileSync(path.join(dir, 'tasks', `${FIXTURE_TASK}.yaml`), [
+        `name: ${FIXTURE_TASK}`,
+        'displayName: Fixture Task',
+        'description: Fixture task for content-marker tests',
+        `agent: ${FIXTURE_AGENT}`,
+        `prompt: ${JSON.stringify(prompt)}`,
+        'isDefault: true',
+        '',
+      ].join('\n'), 'utf-8');
+      return dir;
+    }
+
+    function fixtureTaskPrompt(): string {
+      const row = getDatabase().prepare(
+        'SELECT prompt FROM agent_tasks WHERE id = ? AND agent_id = ?',
+      ).get(FIXTURE_TASK, FIXTURE_AGENT) as { prompt: string } | undefined;
+      expect(row).toBeDefined();
+      return row!.prompt;
+    }
+
+    it('re-seeds when task content changes but the task id set is identical', () => {
+      const v1 = writeFixtureDefinitions('prompt version one');
+      const v2 = writeFixtureDefinitions('prompt version two');
+
+      seedBuiltInAgentsAndTasks(v1);
+      expect(fixtureTaskPrompt()).toBe('prompt version one');
+
+      // Same agent name, same single task id — only the prompt differs.
+      // Without the content marker this second seed would short-circuit
+      // and the stale prompt would persist indefinitely (finding H1).
+      seedBuiltInAgentsAndTasks(v2);
+      expect(fixtureTaskPrompt()).toBe('prompt version two');
+    });
+
+    it('boot delegation re-seeds on a content-only change and short-circuits when unchanged', async () => {
+      const v1 = writeFixtureDefinitions('boot prompt one');
+      const v2 = writeFixtureDefinitions('boot prompt two');
+
+      // Boot path = registerBuiltInAgentsAndTasks (no vaultDir at the
+      // fixture level; the user-task tail is exercised elsewhere).
+      await registerBuiltInAgentsAndTasks(v1);
+      expect(fixtureTaskPrompt()).toBe('boot prompt one');
+
+      // A "restart on the upgraded binary": content changed, ids identical.
+      await registerBuiltInAgentsAndTasks(v2);
+      expect(fixtureTaskPrompt()).toBe('boot prompt two');
+
+      // A plain restart with nothing changed short-circuits (no writes).
+      const db = getDatabase();
+      const before = (db.prepare('SELECT total_changes() AS c').get() as { c: number }).c;
+      await registerBuiltInAgentsAndTasks(v2);
+      const after = (db.prepare('SELECT total_changes() AS c').get() as { c: number }).c;
+      expect(after).toBe(before);
+    });
+
+    it('a DB last seeded by a pre-marker binary (config NULL) re-seeds once and gains the marker', () => {
+      const v1 = writeFixtureDefinitions('marker upgrade prompt');
+      seedBuiltInAgentsAndTasks(v1);
+
+      // Simulate the pre-marker state: no marker, stale task content —
+      // exactly what every existing DB looks like on first open after
+      // this change ships.
+      const db = getDatabase();
+      db.prepare('UPDATE agents SET config = NULL WHERE id = ?').run(FIXTURE_AGENT);
+      db.prepare('UPDATE agent_tasks SET prompt = ? WHERE id = ?').run('stale pre-marker prompt', FIXTURE_TASK);
+
+      seedBuiltInAgentsAndTasks(v1);
+
+      expect(fixtureTaskPrompt()).toBe('marker upgrade prompt');
+      const agentConfig = (db.prepare('SELECT config FROM agents WHERE id = ?').get(FIXTURE_AGENT) as { config: string | null }).config;
+      expect(agentConfig).not.toBeNull();
+      const parsed = JSON.parse(agentConfig!) as { definitions_hash?: string };
+      expect(typeof parsed.definitions_hash).toBe('string');
+      expect(parsed.definitions_hash!.length).toBeGreaterThan(0);
     });
   });
 });

--- a/tests/daemon/grove-runtime-cache.test.ts
+++ b/tests/daemon/grove-runtime-cache.test.ts
@@ -10,6 +10,8 @@ import {
 } from '@myco/daemon/grove-runtime-cache.js';
 import { openDatabase } from '@myco/db/client.js';
 import { createSchema } from '@myco/db/schema.js';
+import { resolveDefinitionsDir, loadAgentTasks } from '@myco/agent/loader.js';
+import { DEFAULT_AGENT_ID } from '@myco/constants.js';
 
 describe('GroveRuntimeCache', () => {
   let workDir: string;
@@ -229,6 +231,191 @@ describe('GroveRuntimeCache', () => {
       const cache = new GroveRuntimeCache({ capacity: 4 });
       const out = cache.growCapacity(GROVE_RUNTIME_CACHE_CEILING + 1000);
       expect(out).toBe(GROVE_RUNTIME_CACHE_CEILING);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Built-in agent/task seeding at the DB-open choke point
+  //
+  // Regression pin for the fresh-Grove FK death: fresh Groves had empty
+  // agents/agent_tasks tables because registration only ran once at boot
+  // through the boot-default DB handle. Every dispatch on a fresh Grove
+  // threw `FOREIGN KEY constraint failed` on `agent_runs.agent_id ->
+  // agents(id)`. `openInitializedDatabase` now seeds built-ins on every
+  // open via `withDatabase` + `seedBuiltInAgentsAndTasks`.
+  // ---------------------------------------------------------------------------
+
+  describe('built-in agent/task seeding', () => {
+    it('a freshly opened Grove DB has the built-in agent + all built-in tasks', () => {
+      const cache = new GroveRuntimeCache();
+      const fresh = emptyDbPath('fresh-grove');
+
+      const db = cache.getDatabase(fresh);
+
+      const agentRow = db.prepare('SELECT id, source FROM agents WHERE id = ?').get(DEFAULT_AGENT_ID) as
+        | { id: string; source: string }
+        | undefined;
+      expect(agentRow?.id).toBe(DEFAULT_AGENT_ID);
+      expect(agentRow?.source).toBe('built-in');
+
+      const expectedTaskCount = loadAgentTasks(resolveDefinitionsDir()).length;
+      const taskRows = db.prepare(
+        "SELECT id FROM agent_tasks WHERE source = 'built-in' AND agent_id = ?",
+      ).all(DEFAULT_AGENT_ID) as Array<{ id: string }>;
+      expect(taskRows).toHaveLength(expectedTaskCount);
+
+      cache.closeAll();
+    });
+
+    it('re-opening an existing Grove DB is idempotent (self-heals a previously broken Grove)', () => {
+      const cache = new GroveRuntimeCache();
+      const target = emptyDbPath('reopen-grove');
+
+      const first = cache.getDatabase(target);
+      const expectedTaskCount = loadAgentTasks(resolveDefinitionsDir()).length;
+      const firstCount = first.prepare(
+        "SELECT COUNT(*) AS c FROM agent_tasks WHERE source = 'built-in'",
+      ).get() as { c: number };
+      expect(firstCount.c).toBe(expectedTaskCount);
+
+      // Evict and re-open, simulating a fresh process opening a Grove DB
+      // that was already seeded on a prior open (or, for a pre-existing
+      // broken Grove, a DB the importer never touched).
+      cache.evict(target);
+      const second = cache.getDatabase(target);
+      const secondCount = second.prepare(
+        "SELECT COUNT(*) AS c FROM agent_tasks WHERE source = 'built-in'",
+      ).get() as { c: number };
+      expect(secondCount.c).toBe(expectedTaskCount);
+
+      cache.closeAll();
+    });
+
+    it('short-circuits on a re-open of an already-seeded Grove DB: rows are not rewritten', () => {
+      const cache = new GroveRuntimeCache();
+      const target = emptyDbPath('short-circuit-grove');
+
+      const first = cache.getDatabase(target);
+
+      // Plant a sentinel `updated_at` far in the past. If the short-circuit
+      // does NOT fire on the next open, the upsert path recomputes
+      // `updated_at` via `epochSeconds()` (current time) and this sentinel
+      // is overwritten — a deterministic, timing-independent tell distinct
+      // from comparing two "now" timestamps that could collide within the
+      // same second.
+      const sentinel = 1;
+      first.prepare('UPDATE agents SET updated_at = ? WHERE id = ?').run(sentinel, DEFAULT_AGENT_ID);
+
+      // Evict (closes the handle, exactly as the cache's LRU eviction
+      // would) and re-open through the cache — this re-runs
+      // `openInitializedDatabase`, which re-invokes the seed on every
+      // open.
+      cache.evict(target);
+      const second = cache.getDatabase(target);
+      const stamp = second.prepare(
+        'SELECT updated_at FROM agents WHERE id = ?',
+      ).get(DEFAULT_AGENT_ID) as { updated_at: number };
+
+      expect(stamp.updated_at).toBe(sentinel);
+
+      cache.closeAll();
+    });
+
+    it('sweeps only source=built-in task rows when a built-in task is removed from YAML', () => {
+      const cache = new GroveRuntimeCache();
+      const target = emptyDbPath('sweep-grove');
+
+      const db = cache.getDatabase(target);
+      const now = Math.floor(Date.now() / 1000);
+      db.prepare(
+        `INSERT INTO agent_tasks (id, agent_id, source, display_name, description, prompt, is_default, created_at, updated_at)
+         VALUES (?, ?, 'built-in', 'Stale', 'stale', 'stale prompt', 0, ?, ?)`,
+      ).run('removed-from-yaml', DEFAULT_AGENT_ID, now, now);
+      db.prepare(
+        `INSERT INTO agent_tasks (id, agent_id, source, display_name, description, prompt, is_default, created_at, updated_at)
+         VALUES (?, ?, 'user', 'User Task', 'user', 'user prompt', 0, ?, ?)`,
+      ).run('user-task-survives', DEFAULT_AGENT_ID, now, now);
+
+      // Re-open (evict + getDatabase) to re-run the choke point's seed.
+      cache.evict(target);
+      const reopened = cache.getDatabase(target);
+
+      const ids = (reopened.prepare('SELECT id, source FROM agent_tasks').all() as Array<{ id: string; source: string }>);
+      expect(ids.some((r) => r.id === 'removed-from-yaml')).toBe(false);
+      expect(ids.some((r) => r.id === 'user-task-survives' && r.source === 'user')).toBe(true);
+
+      cache.closeAll();
+    });
+
+    it('re-seeds through the cache path when the stored content marker is stale (upgrade skew)', () => {
+      const cache = new GroveRuntimeCache();
+      const target = emptyDbPath('skew-grove');
+
+      const db = cache.getDatabase(target);
+      const current = db.prepare(
+        "SELECT prompt FROM agent_tasks WHERE id = 'vault-evolve'",
+      ).get() as { prompt: string };
+
+      // Simulate a DB last seeded by an OLDER binary whose definitions had
+      // the same task ids but different content: stale prompt + a marker
+      // hash the current binary's definitions won't match. The id-set
+      // check alone would pass here — only the content marker forces the
+      // re-seed (review finding H1).
+      db.prepare(
+        "UPDATE agent_tasks SET prompt = 'stale prompt from an older binary' WHERE id = 'vault-evolve'",
+      ).run();
+      db.prepare('UPDATE agents SET config = ? WHERE id = ?').run(
+        JSON.stringify({ definitions_hash: 'stale-hash-from-older-binary' }),
+        DEFAULT_AGENT_ID,
+      );
+
+      cache.evict(target);
+      const reopened = cache.getDatabase(target);
+
+      const after = reopened.prepare(
+        "SELECT prompt FROM agent_tasks WHERE id = 'vault-evolve'",
+      ).get() as { prompt: string };
+      expect(after.prompt).toBe(current.prompt);
+
+      const config = (reopened.prepare('SELECT config FROM agents WHERE id = ?').get(DEFAULT_AGENT_ID) as {
+        config: string | null;
+      }).config;
+      expect(config).not.toBeNull();
+      const parsed = JSON.parse(config!) as { definitions_hash?: string };
+      expect(parsed.definitions_hash).toBeDefined();
+      expect(parsed.definitions_hash).not.toBe('stale-hash-from-older-binary');
+
+      cache.closeAll();
+    });
+
+    it('regression pin: dispatch on a freshly created Grove no longer FK-fails on agent_runs.agent_id', () => {
+      // This is the exact failure mode from Evidence: `agent_runs.agent_id
+      // -> agents(id)` FK violation on a fresh Grove DB whose `agents`
+      // table was never seeded. A full executor dispatch is too heavy for
+      // this unit-level regression pin (it needs a running harness,
+      // provider config, etc.) — inserting an `agent_runs` row is the
+      // exact statement that threw in production (`insertRun`,
+      // executor.ts), so reproducing that one INSERT against a Grove DB
+      // opened through the real cache path is a faithful, minimal pin for
+      // this specific bug class.
+      const cache = new GroveRuntimeCache();
+      const fresh = emptyDbPath('dispatch-grove');
+      const db = cache.getDatabase(fresh);
+
+      const now = Math.floor(Date.now() / 1000);
+      expect(() => {
+        db.prepare(
+          `INSERT INTO agent_runs (id, project_id, agent_id, task, status, started_at)
+           VALUES (?, ?, ?, ?, 'running', ?)`,
+        ).run('test-run-1', 'test-project', DEFAULT_AGENT_ID, 'vault-evolve', now);
+      }).not.toThrow();
+
+      const row = db.prepare('SELECT agent_id FROM agent_runs WHERE id = ?').get('test-run-1') as
+        | { agent_id: string }
+        | undefined;
+      expect(row?.agent_id).toBe(DEFAULT_AGENT_ID);
+
+      cache.closeAll();
     });
   });
 });

--- a/tests/daemon/rc4-scheduler-config-refresh.test.ts
+++ b/tests/daemon/rc4-scheduler-config-refresh.test.ts
@@ -9,7 +9,11 @@
  * grove-tier toggle on disk between ticks, and asserts the gate sees it.
  *
  * Uses mock.module — keep this file's mocks self-contained (per-file
- * isolation, PR #466 rule).
+ * isolation, PR #466 rule). `@myco/db/client.js` is deliberately NOT
+ * mocked: the scheduler tick opens a real per-Grove DB file through
+ * `GroveRuntimeCache`, and `openInitializedDatabase` seeds built-in
+ * agents/tasks on that real handle (Plan B Task 1) — a fake `getDatabase`
+ * stub would break that seed call, not just this test's own assertions.
  */
 import { describe, it, expect, mock } from 'bun:test';
 import { vi } from '../helpers/vi-shim.js';
@@ -31,13 +35,6 @@ mock.module('@myco/agent/registry.js', () => ({
       schedule: { enabled: true, intervalSeconds: 300, runIn: ['idle'] },
     }],
   ]),
-}));
-
-mock.module('@myco/db/client.js', () => ({
-  getDatabase: () => ({
-    prepare: () => ({ all: () => [], get: () => undefined }),
-  }),
-  withDatabase: <T,>(_db: unknown, fn: () => T) => fn(),
 }));
 
 import { registerScheduledTasks } from '@myco/daemon/task-scheduling.js';


### PR DESCRIPTION
## Summary
Found by the first-ever vault-seed brownfield smoke (hermetic MYCO_HOME, cold vault): groves created after daemon boot never received built-in `agents`/`agent_tasks` rows — registration ran once at boot through the boot-default DB handle, restart did not heal, and only the machine-scoped migration importer seeded existing groves. Every dispatch on a fresh grove died on the `agent_runs.agent_id → agents(id)` FK, triple-silently (API said "Agent started", error logged once, no run row/status/notification). This is the state every fresh install's first grove is in at the opt-in moment.

- Extracted the built-in-only registration body into a sync `seedBuiltInAgentsAndTasks`; the async boot entry point delegates to it.
- Called at the per-grove DB-open choke point (`openInitializedDatabase`) inside the established `withDatabase` AsyncLocalStorage scope — every tenant DB is prepared unconditionally; already-broken groves self-heal on next access.
- Cost control without a staleness hole: memoized parsed definitions + a persisted definitions-hash marker (sha256, locale-independent sort) in the built-in agent row's `config` column; crash-safe two-phase (upsert clears, final statement writes), so content-only YAML edits re-seed on every path and unchanged opens short-circuit.

## Verification
- 70 focused tests (loader + grove-runtime-cache) incl. the FK regression pin on the real cache path, idempotency, source-scoped sweep, content-change re-seed via both boot and cache paths, pre-marker heal; full suite green; `tsc` clean; `make build` green on the squashed tip.
- Independent review + focused re-review: approved; concurrency (sync-only scope, sync seed body — no cross-DB leak), crash-safety ordering, and `agents.config` exclusivity all verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)