### PR TITLE
feat(agent): capability gating for manual dispatch, harness-health, and pre-row failure surfacing

### DIFF
--- a/packages/myco/src/config/capabilities.ts
+++ b/packages/myco/src/config/capabilities.ts
@@ -22,7 +22,11 @@ export interface CapabilityDef {
   masterGate: string;
   /** Other config leaves this capability governs (UI grouping / demote). */
   memberGates: string[];
-  /** Agent task names this capability gates (consumed by the gate-honoring plan). */
+  /**
+   * Agent task names this capability governs. May include scheduleless,
+   * manual-only tasks — a scheduleless entry has zero scheduler effect and
+   * only wires manual-dispatch gating (governingCapability/capabilityForTask).
+   */
   scheduledTasks: string[];
   /** Settings route for advanced knobs (deep-linked from the panel; finalized in the UI plan). */
   advancedSettingsLink: string;
@@ -58,7 +62,8 @@ export const CAPABILITIES: Record<CapabilityId, CapabilityDef> = {
     label: 'Vault Evolution',
     masterGate: 'vault_evolution.enabled',
     memberGates: [],
-    scheduledTasks: ['vault-evolve'],
+    // vault-seed has no schedule block; listed here only for manual-dispatch gating.
+    scheduledTasks: ['vault-evolve', 'vault-seed'],
     advancedSettingsLink: '/settings#scheduled-tasks',
   },
 };

--- a/packages/myco/src/daemon/api/agent-runs.ts
+++ b/packages/myco/src/daemon/api/agent-runs.ts
@@ -13,8 +13,11 @@ import {
   getRun,
   findNewerCompletedEquivalentRun,
   applyRunUpdate,
+  insertRun,
   RESUME_STATUS_SUPERSEDED,
+  STATUS_FAILED,
 } from '@myco/db/queries/runs.js';
+import { epochSeconds } from '@myco/constants.js';
 import { getRunActivityBuckets, getRunBranches } from '@myco/db/queries/activity-buckets.js';
 import { listReports } from '@myco/db/queries/reports.js';
 import { listTurnsByRun } from '@myco/db/queries/turns.js';
@@ -24,6 +27,8 @@ import { runDurationMs } from '@myco/agent/run-accounting.js';
 import { buildTaskInstruction, isInstructionRequiredTask, SKILL_SURVEY_TASK } from '@myco/agent/instruction-builders.js';
 import { hasConfiguredProvider, resolveTaskDefinitionExecution } from '@myco/agent/config-resolver.js';
 import { loadMergedConfig } from '@myco/config/loader.js';
+import { CAPABILITIES, capabilityEnabled, governingCapability } from '@myco/config/capabilities.js';
+import type { MycoConfig } from '@myco/config/schema.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { notify } from '@myco/notifications/notify.js';
 import { agentRunNotificationLink } from '@myco/notifications/links.js';
@@ -38,6 +43,7 @@ import type { DaemonLogger } from '../logger.js';
 import type { TeamSyncClient } from '../team-sync.js';
 import { projectScopeFromRequestContext } from '@myco/grove/request-context.js';
 import { DEFAULT_AGENT_ID } from '@myco/constants.js';
+import { errorMessage } from '@myco/utils/error-message.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -100,6 +106,29 @@ function sanitizeExecutionOverrides(
     stripBaseUrlForRemoteProviders,
   );
   return result as unknown as z.infer<typeof ExecutionOverrideBody>;
+}
+
+/**
+ * Rejects a manual dispatch/resume when the task's governing capability is
+ * off. Tasks with no governing capability always pass through.
+ */
+function capabilityGateError(
+  config: MycoConfig | null | undefined,
+  task: string | undefined,
+): RouteResponse | null {
+  if (!task) return null;
+  const capId = governingCapability(task);
+  if (!capId) return null;
+  if (capabilityEnabled(config, capId)) return null;
+  return {
+    status: 400,
+    body: {
+      ok: false,
+      error: 'capability_disabled',
+      capability: capId,
+      message: `Enable ${CAPABILITIES[capId].label} for this project to run ${task}`,
+    },
+  };
 }
 
 const AgentRunBody = z.object({
@@ -207,6 +236,11 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
     // Guard: ensure a provider is configured before allowing a run.
     // Uses the same per-task-over-global precedence as the executor's resolver.
     const mycoConfig = loadMergedConfig(runVaultDir, { groveId: req.requestContext?.groveId ?? null });
+
+    // Governed-task admission check, before the provider check.
+    const capabilityError = capabilityGateError(mycoConfig, task);
+    if (capabilityError) return capabilityError;
+
     // User-initiated manual run: the default claude-sdk harness (subscription
     // auth via the Claude Code CLI) is runnable with no explicit provider. The
     // automatic Cortex path keeps the strict check (no auto-default per grove).
@@ -337,10 +371,61 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
         }
       })
       .catch((err) => {
-        logger.error(LOG_KINDS.AGENT_ERROR, 'Agent run threw unhandled error', {
-          error: (err as Error).message ?? String(err),
-          stack: (err as Error).stack?.split('\n').slice(0, 3).join(' | '),
-        });
+        // Executor threw before creating the run row. Persists a failed row
+        // so the runId already returned to the caller resolves to an
+        // inspectable outcome; falls back to a log + notification if the
+        // insert itself fails.
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        const projectId = req.requestContext?.projectId;
+        try {
+          insertRun({
+            id: runId,
+            project_id: projectId ?? null,
+            agent_id: effectiveAgentId,
+            task: task ?? null,
+            instruction: instruction ?? null,
+            status: STATUS_FAILED,
+            started_at: epochSeconds(),
+            completed_at: epochSeconds(),
+            error: errorMsg,
+            dryRun: dryRun ?? false,
+          });
+          const notificationOptions = projectId ? { projectId } : undefined;
+          notify(runVaultDir, {
+            domain: 'agents',
+            type: 'agent.task.failure',
+            title: `Task failed: ${task ?? 'agent run'}`,
+            message: errorMsg,
+            link: agentRunNotificationLink(runId),
+            metadata: { taskName: task ?? null, runId },
+          }, mycoConfig, notificationOptions);
+          logger.error(LOG_KINDS.AGENT_ERROR, 'Agent run threw before its run row was created', {
+            runId,
+            task: task ?? null,
+            project_id: projectId ?? null,
+            error: errorMsg,
+            stack: (err as Error).stack?.split('\n').slice(0, 3).join(' | '),
+          });
+        } catch (insertErr) {
+          // Failed-row insert also failed; no row will exist for this runId.
+          logger.error(LOG_KINDS.AGENT_ERROR, 'Agent run threw unhandled error', {
+            runId,
+            task: task ?? null,
+            project_id: projectId ?? null,
+            error: errorMsg,
+            stack: (err as Error).stack?.split('\n').slice(0, 3).join(' | '),
+            insertError: errorMessage(insertErr),
+          });
+          const notificationOptions = projectId ? { projectId } : undefined;
+          notify(runVaultDir, {
+            domain: 'agents',
+            type: 'agent.task.failure',
+            title: `Task failed: ${task ?? 'agent run'}`,
+            message: errorMsg,
+            link: agentRunNotificationLink(runId),
+            metadata: { taskName: task ?? null, runId },
+          }, mycoConfig, notificationOptions);
+        }
       });
 
     return { body: { ok: true, message: 'Agent started', runId } };
@@ -463,6 +548,13 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
     const { mode } = ResumeRunBody.parse(req.body ?? {});
     const embeddingManager = resolveEmbeddingManager(req.requestContext);
     const runVaultDir = vaultDirForRequest(req);
+
+    // Same governed-task admission as handleRun: resuming a governed task
+    // must not bypass a capability the project has since disabled.
+    const resumeMycoConfig = loadMergedConfig(runVaultDir, { groveId: req.requestContext?.groveId ?? null });
+    const capabilityError = capabilityGateError(resumeMycoConfig, run.task ?? undefined);
+    if (capabilityError) return capabilityError;
+
     const { dispatchAgentRun } = await import('@myco/agent/runner-host.js');
     const resultPromise = dispatchAgentRun(runVaultDir, {
       agentId: run.agent_id,
@@ -498,6 +590,8 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
       .catch((err) => {
         logger.error(LOG_KINDS.AGENT_ERROR, 'Agent run resume threw unhandled error', {
           runId: run.id,
+          task: run.task ?? null,
+          project_id: req.requestContext?.projectId ?? null,
           error: err instanceof Error ? err.message : String(err),
         });
       });

--- a/packages/myco/src/daemon/api/agent-tasks.ts
+++ b/packages/myco/src/daemon/api/agent-tasks.ts
@@ -68,6 +68,9 @@ const HTTP_CONFLICT = 409;
  * List all tasks: built-in definitions merged with user-created overrides.
  *
  * Optionally filtered by `?source=user` or `?source=built-in`.
+ *
+ * Each task carries `governingCapability` (or `null`), resolved server-side
+ * from `config/capabilities.ts`.
  */
 export async function handleListTasks(
   req: RouteRequest,
@@ -82,7 +85,12 @@ export async function handleListTasks(
     tasks = tasks.filter((t) => t.source === sourceFilter);
   }
 
-  return { status: HTTP_OK, body: { tasks } };
+  const tasksWithCapability = tasks.map((task) => ({
+    ...task,
+    governingCapability: governingCapability(task.name),
+  }));
+
+  return { status: HTTP_OK, body: { tasks: tasksWithCapability } };
 }
 
 /**

--- a/packages/myco/src/daemon/task-scheduling.ts
+++ b/packages/myco/src/daemon/task-scheduling.ts
@@ -41,7 +41,7 @@ import { HARNESS_HEALTH_TASK_NAME, notifyHarnessHealthFindings } from '@myco/not
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 import { DEFAULT_AGENT_ID, MS_PER_DAY } from '@myco/constants.js';
 import { errorMessage } from '@myco/utils/error-message.js';
-import { effectiveTaskScheduleEnabled } from '@myco/config/capabilities.js';
+import { effectiveTaskScheduleEnabled, isCaptureOnly } from '@myco/config/capabilities.js';
 import {
   forEachGrove,
   forEachRegisteredProject,
@@ -374,6 +374,26 @@ async function seedInitialLastRuns(
 }
 
 // ---------------------------------------------------------------------------
+// Task-admission gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Effective schedule-enablement for one (project config, task) pair.
+ *
+ * harness-health has no governing capability in the capability map, so
+ * `effectiveTaskScheduleEnabled` fails open for it; this additionally
+ * disables it on a capture-only project (every opt-in capability off).
+ */
+export function resolveTaskScheduleEnabled(
+  config: MycoConfig | null,
+  taskName: string,
+  yamlScheduleEnabled: boolean,
+): boolean {
+  if (taskName === HARNESS_HEALTH_TASK_NAME && isCaptureOnly(config)) return false;
+  return effectiveTaskScheduleEnabled(config, taskName, yamlScheduleEnabled);
+}
+
+// ---------------------------------------------------------------------------
 // Registration
 // ---------------------------------------------------------------------------
 
@@ -661,8 +681,17 @@ export async function registerScheduledTasks(
       if (!config) return { schedule: { enabled: false } };
       return config.agent.tasks?.[taskName];
     },
-    getTaskScheduleEnabled: (scope, taskName, yamlScheduleEnabled) =>
-      effectiveTaskScheduleEnabled(resolveProjectConfig(scope), taskName, yamlScheduleEnabled),
+    getTaskScheduleEnabled: (scope, taskName, yamlScheduleEnabled) => {
+      const config = resolveProjectConfig(scope);
+      const enabled = resolveTaskScheduleEnabled(config, taskName, yamlScheduleEnabled);
+      if (!enabled && taskName === HARNESS_HEALTH_TASK_NAME && isCaptureOnly(config)) {
+        logger.debug(LOG_KINDS.AGENT_RUN, 'Skipping harness-health — project is capture-only', {
+          grove_id: scope.grove.id,
+          project_id: scope.projectId,
+        });
+      }
+      return enabled;
+    },
     isTaskRunning: (groveId, projectId, name) =>
       runningTasks.has(runningKey(groveId, projectId, name)),
     setTaskRunning: (groveId, projectId, name, running) => {

--- a/packages/myco/ui/src/components/agent/RunTaskDialog.tsx
+++ b/packages/myco/ui/src/components/agent/RunTaskDialog.tsx
@@ -42,6 +42,9 @@ import {
 } from '../../hooks/use-providers';
 import { useTaskExecutionDefaults } from '../../hooks/use-task-execution-defaults';
 import { useModels } from '../../hooks/use-models';
+import { useScopedConfig } from '../../hooks/use-scoped-config';
+import { CAPABILITIES, capabilityEnabled } from '@myco/config/capabilities';
+import type { MycoConfig } from '@myco/config/schema';
 import type { HarnessId, ReasoningLevel } from '@myco/agent/types';
 import {
   buildExecutionOverrides,
@@ -119,6 +122,7 @@ export function RunTaskDialog({
   const { mutate: triggerRun, isPending, error } = useTriggerRun();
   const { data: providersData, isPending: isLoadingProviders } = useProviders();
   const providers = providersData?.providers ?? [];
+  const { effective: effectiveConfig } = useScopedConfig();
 
   // Resolve the active task row
   const availableTasks: TaskRow[] = tasksData?.tasks ?? [];
@@ -141,6 +145,15 @@ export function RunTaskDialog({
     draftDefaults: providerDraftDefaults,
   } = useTaskExecutionDefaults(effectiveSelection || undefined);
   const activeTaskRow = preselectedTask ?? resolvedTaskRow;
+
+  // Disables the Run action with a reason when the task's governing
+  // capability is off. `governingCapability` comes from the tasks-listing API.
+  const activeCapId = activeTaskRow?.governingCapability;
+  const capabilityOff = activeCapId != null
+    && !capabilityEnabled(effectiveConfig as MycoConfig | undefined, activeCapId);
+  const capabilityDisabledReason = capabilityOff
+    ? `Enable ${CAPABILITIES[activeCapId].label} for this project to run ${activeTaskRow?.name ?? effectiveSelection}`
+    : undefined;
 
   const {
     draft,
@@ -653,25 +666,33 @@ export function RunTaskDialog({
               {runNotice}
             </p>
           )}
+
+          {capabilityDisabledReason && (
+            <p className="rounded-md bg-surface-container-low px-3 py-2 font-sans text-xs text-on-surface-variant">
+              {capabilityDisabledReason}
+            </p>
+          )}
         </div>
 
         <DialogFooter>
           <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)} disabled={isPending}>
             Cancel
           </Button>
-          <Button size="sm" className="gap-2" onClick={handleRun} disabled={isPending}>
-            {isPending ? (
-              <>
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                Starting...
-              </>
-            ) : (
-              <>
-                <Play className="h-3.5 w-3.5" />
-                Run
-              </>
-            )}
-          </Button>
+          <span title={capabilityDisabledReason}>
+            <Button size="sm" className="gap-2" onClick={handleRun} disabled={isPending || capabilityOff}>
+              {isPending ? (
+                <>
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  Starting...
+                </>
+              ) : (
+                <>
+                  <Play className="h-3.5 w-3.5" />
+                  Run
+                </>
+              )}
+            </Button>
+          </span>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/packages/myco/ui/src/components/agent/TaskActions.tsx
+++ b/packages/myco/ui/src/components/agent/TaskActions.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 import { useCopyTask, useDeleteTask, type TaskRow } from '../../hooks/use-agent';
 import { TASK_SOURCE_BUILTIN, TASK_SOURCE_USER } from '../../lib/constants';
+import { CAPABILITIES, capabilityEnabled } from '@myco/config/capabilities';
+import type { MycoConfig } from '@myco/config/schema';
+import { useScopedConfig } from '../../hooks/use-scoped-config';
 import { Button } from '../ui/button';
 import { RunTaskDialog } from './RunTaskDialog';
 
@@ -18,14 +21,25 @@ interface TaskActionsProps {
 export function TaskActions({ task, onRunTriggered, onDeleted, onCustomized }: TaskActionsProps) {
   const copyTask = useCopyTask();
   const deleteTask = useDeleteTask();
+  const { effective } = useScopedConfig();
 
   const [runDialogOpen, setRunDialogOpen] = useState(false);
 
+  // Disables the Run Now action with a reason when the task's governing
+  // capability is off. `governingCapability` comes from the tasks-listing API.
+  const capId = task.governingCapability;
+  const capabilityOff = capId != null && !capabilityEnabled(effective as MycoConfig | undefined, capId);
+  const disabledReason = capabilityOff
+    ? `Enable ${CAPABILITIES[capId].label} for this project to run ${task.name}`
+    : undefined;
+
   return (
     <div className="flex gap-2">
-      <Button size="sm" onClick={() => setRunDialogOpen(true)}>
-        Run Now
-      </Button>
+      <span title={disabledReason}>
+        <Button size="sm" onClick={() => setRunDialogOpen(true)} disabled={capabilityOff}>
+          Run Now
+        </Button>
+      </span>
 
       {task.source === TASK_SOURCE_BUILTIN && (
         <Button

--- a/packages/myco/ui/src/hooks/use-agent.ts
+++ b/packages/myco/ui/src/hooks/use-agent.ts
@@ -8,6 +8,7 @@ import type { PhaseAudit, PhaseAuditEntry } from '@myco/services/phase-audit';
 import type { WriteIntentRow } from '@myco/db/queries/write-intents';
 import type { DigestExtractRevisionRow } from '@myco/db/queries/digest-extracts';
 import type { HarnessId, ReasoningLevel } from '@myco/agent/types';
+import type { CapabilityId } from '@myco/config/scope';
 
 /* ---------- Re-exported backend types ---------- */
 
@@ -245,6 +246,8 @@ export interface TaskRow {
   schedule?: { enabled: boolean; intervalSeconds: number; runIn: ('active' | 'idle' | 'sleep')[]; preCondition?: string };
   params?: Record<string, string | number | boolean>;
   schemaVersion?: number;
+  /** The capability that governs manual dispatch of this task, or `null` when ungoverned. */
+  governingCapability?: CapabilityId | null;
 }
 
 export interface TriggerRunPayload {

--- a/tests/config/capability-scheduled-task-enumeration.test.ts
+++ b/tests/config/capability-scheduled-task-enumeration.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Goondocks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Structural sync test: every built-in task YAML with a `schedule` block
+ * must be either mapped under some CAPABILITIES[*].scheduledTasks entry or
+ * listed in EXEMPT_SCHEDULED_TASKS with a documented reason.
+ */
+import { describe, expect, it } from 'bun:test';
+import { loadAgentTasks, resolveDefinitionsDir } from '../../packages/myco/src/agent/loader';
+import { CAPABILITIES } from '../../packages/myco/src/config/capabilities';
+import { HARNESS_HEALTH_TASK_NAME } from '../../packages/myco/src/notifications/harness-health-consumer';
+
+/**
+ * Scheduled tasks intentionally left out of the capability map. Each entry
+ * must document why — a bare exemption defeats the point of this test.
+ */
+const EXEMPT_SCHEDULED_TASKS: Record<string, string> = {
+  [HARNESS_HEALTH_TASK_NAME]:
+    'Gated on isCaptureOnly at the scheduler admission seam, not a single capability master gate.',
+};
+
+function allGovernedTaskNames(): Set<string> {
+  const governed = new Set<string>();
+  for (const cap of Object.values(CAPABILITIES)) {
+    for (const taskName of cap.scheduledTasks) governed.add(taskName);
+  }
+  return governed;
+}
+
+describe('scheduled-task governance enumeration (structural sync test)', () => {
+  const tasks = loadAgentTasks(resolveDefinitionsDir());
+  const scheduledTasks = tasks.filter((t) => t.schedule !== undefined);
+
+  it('finds at least one scheduled task (sanity check the loader worked)', () => {
+    expect(scheduledTasks.length).toBeGreaterThan(0);
+  });
+
+  it('every schedule-bearing task is governed by a capability or explicitly exempt', () => {
+    const governed = allGovernedTaskNames();
+    const ungoverned = scheduledTasks
+      .map((t) => t.name)
+      .filter((name) => !governed.has(name) && !(name in EXEMPT_SCHEDULED_TASKS));
+
+    expect(ungoverned).toEqual([]);
+  });
+
+  it('every exempt task actually exists and actually has a schedule block (no stale exemptions)', () => {
+    const scheduledNames = new Set(scheduledTasks.map((t) => t.name));
+    for (const name of Object.keys(EXEMPT_SCHEDULED_TASKS)) {
+      expect(scheduledNames.has(name)).toBe(true);
+    }
+  });
+
+  it('audits to exactly the known set today (harness-health) — update this list deliberately, not by silencing the test above', () => {
+    const governed = allGovernedTaskNames();
+    const ungovernedOrExempt = scheduledTasks
+      .map((t) => t.name)
+      .filter((name) => !governed.has(name));
+    expect(ungovernedOrExempt.sort()).toEqual([HARNESS_HEALTH_TASK_NAME]);
+  });
+});

--- a/tests/daemon/api/agent-runs-capability-gate.test.ts
+++ b/tests/daemon/api/agent-runs-capability-gate.test.ts
@@ -1,0 +1,187 @@
+/**
+ * `handleRun` and `handleResumeRun` reject a governed task before dispatch
+ * when its capability is off, with an actionable `capability_disabled` error.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterAll, mock } from 'bun:test';
+import { vi } from '../../helpers/vi-shim.js';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { insertRun } from '@myco/db/queries/runs.js';
+import { createAgentRunHandlers } from '@myco/daemon/api/agent-runs';
+import type { RouteRequest } from '@myco/daemon/router';
+import { makeTestRequestContext } from '../../helpers/request-context';
+import { DEFAULT_AGENT_ID } from '@myco/constants.js';
+import { _clearNotifyDedupForTests } from '@myco/notifications/notify.js';
+
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+const BASE_YAML = 'version: 3\nembedding:\n  provider: ollama\n  model: bge-m3\n';
+
+/**
+ * `vault_evolution.enabled` is grove-scoped; writing it into project-tier
+ * myco.yaml gets silently pruned by the scope-aware sparse merge, so toggle
+ * it via local.yaml instead.
+ */
+function writeConfig(vaultDir: string, vaultEvolutionEnabled: boolean) {
+  fs.writeFileSync(path.join(vaultDir, 'myco.yaml'), BASE_YAML, 'utf-8');
+  fs.writeFileSync(
+    path.join(vaultDir, 'local.yaml'),
+    `vault_evolution:\n  enabled: ${vaultEvolutionEnabled}\n`,
+    'utf-8',
+  );
+}
+
+const runAgentSpy = vi.fn(async () => ({ runId: 'stub', status: 'completed' as const }));
+mock.module('@myco/agent/executor.js', () => ({
+  runAgent: (...args: unknown[]) => runAgentSpy(...args),
+}));
+mock.module('@myco/agent/config-resolver.js', () => ({
+  hasConfiguredProvider: () => true,
+  resolveTaskDefinitionExecution: () => ({}),
+}));
+
+function makeRequest(vaultDir: string, overrides: Partial<RouteRequest> = {}): RouteRequest {
+  return {
+    params: {},
+    query: {},
+    body: undefined,
+    pathname: '/',
+    requestContext: makeTestRequestContext({ vaultDir }),
+    ...overrides,
+  } as RouteRequest;
+}
+
+function makeHandlers(vaultDir: string) {
+  const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  return createAgentRunHandlers({
+    vaultDir,
+    resolveEmbeddingManager: () => ({} as never),
+    logger: logger as never,
+  });
+}
+
+describe('POST /api/agent/run — capability gate', () => {
+  let vaultDir: string;
+
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    _clearNotifyDedupForTests();
+    runAgentSpy.mockClear();
+    registerAgent({ id: DEFAULT_AGENT_ID, name: 'Test', created_at: epochNow() });
+    vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-agent-runs-cap-'));
+  });
+
+  it('rejects manual vault-seed dispatch with capability_disabled when vault_evolution is off', async () => {
+    writeConfig(vaultDir, false);
+    const { handleRun } = makeHandlers(vaultDir);
+    const response = await handleRun(makeRequest(vaultDir, {
+      body: { task: 'vault-seed', instruction: 'seed it' },
+    }));
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: 'capability_disabled',
+      capability: 'vault_evolution',
+    });
+    expect(runAgentSpy).not.toHaveBeenCalled();
+  });
+
+  it('admits manual vault-seed dispatch once vault_evolution is enabled', async () => {
+    writeConfig(vaultDir, true);
+    const { handleRun } = makeHandlers(vaultDir);
+    const response = await handleRun(makeRequest(vaultDir, {
+      body: { task: 'vault-seed', instruction: 'seed it' },
+    }));
+
+    expect(response.body).toMatchObject({ ok: true, message: 'Agent started' });
+    expect(runAgentSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves an ungoverned task (title-summary) unaffected by vault_evolution being off', async () => {
+    writeConfig(vaultDir, false);
+    const { handleRun } = makeHandlers(vaultDir);
+    const response = await handleRun(makeRequest(vaultDir, {
+      body: { task: 'title-summary', instruction: 'go' },
+    }));
+
+    expect(response.body).toMatchObject({ ok: true, message: 'Agent started' });
+    expect(runAgentSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects vault-evolve dispatch too (pattern applies to every governed task, not a vault-seed special case)', async () => {
+    writeConfig(vaultDir, false);
+    const { handleRun } = makeHandlers(vaultDir);
+    const response = await handleRun(makeRequest(vaultDir, {
+      body: { task: 'vault-evolve', instruction: 'go' },
+    }));
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({ error: 'capability_disabled', capability: 'vault_evolution' });
+    expect(runAgentSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/agent/runs/:id/resume — capability gate', () => {
+  let vaultDir: string;
+
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    _clearNotifyDedupForTests();
+    runAgentSpy.mockClear();
+    registerAgent({ id: DEFAULT_AGENT_ID, name: 'Test', created_at: epochNow() });
+    vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-agent-runs-cap-resume-'));
+  });
+
+  it('gates resume of a governed task identically — capability disabled since dispatch must not bypass it', async () => {
+    writeConfig(vaultDir, false);
+    insertRun({
+      id: 'run-resume-gate-off',
+      agent_id: DEFAULT_AGENT_ID,
+      task: 'vault-seed',
+      instruction: 'seed it',
+      status: 'failed',
+      resumable: 1,
+      started_at: epochNow(),
+    });
+
+    const { handleResumeRun } = makeHandlers(vaultDir);
+    const response = await handleResumeRun(makeRequest(vaultDir, {
+      params: { id: 'run-resume-gate-off' },
+      body: { mode: 'manual' },
+    }));
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({ error: 'capability_disabled', capability: 'vault_evolution' });
+    expect(runAgentSpy).not.toHaveBeenCalled();
+  });
+
+  it('admits resume of a governed task once the capability is enabled', async () => {
+    writeConfig(vaultDir, true);
+    insertRun({
+      id: 'run-resume-gate-on',
+      agent_id: DEFAULT_AGENT_ID,
+      task: 'vault-seed',
+      instruction: 'seed it',
+      status: 'failed',
+      resumable: 1,
+      started_at: epochNow(),
+    });
+
+    const { handleResumeRun } = makeHandlers(vaultDir);
+    const response = await handleResumeRun(makeRequest(vaultDir, {
+      params: { id: 'run-resume-gate-on' },
+      body: { mode: 'manual' },
+    }));
+
+    expect(response.body).toMatchObject({ ok: true, message: 'Agent resume started' });
+    expect(runAgentSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/daemon/api/agent-runs-pre-row-failure.test.ts
+++ b/tests/daemon/api/agent-runs-pre-row-failure.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Covers the executor-throws-before-row-creation path in handleRun's catch:
+ *   (a) a non-FK pre-row throw with the agents FK healthy -> persists a
+ *       `failed` row with the pre-generated runId and fires an
+ *       `agent.task.failure` notification.
+ *   (b) the failed-row insert itself also faults -> falls back to an
+ *       enriched ERROR log (runId + task + project) and a notification,
+ *       with no row ever created.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterAll, mock } from 'bun:test';
+import { vi } from '../../helpers/vi-shim.js';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
+import { getDatabase } from '@myco/db/client.js';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { getRun } from '@myco/db/queries/runs.js';
+import { createAgentRunHandlers } from '@myco/daemon/api/agent-runs';
+import type { RouteRequest } from '@myco/daemon/router';
+import { makeTestRequestContext } from '../../helpers/request-context';
+import { DEFAULT_AGENT_ID } from '@myco/constants.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
+import { _clearNotifyDedupForTests } from '@myco/notifications/notify.js';
+
+const epochNow = () => Math.floor(Date.now() / 1000);
+
+// Real (unmocked) vault dir: loadMergedConfig needs a myco.yaml to read.
+const VAULT_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-agent-runs-pre-row-'));
+fs.writeFileSync(
+  path.join(VAULT_DIR, 'myco.yaml'),
+  'version: 3\nembedding:\n  provider: ollama\n  model: bge-m3\nnotifications:\n  enabled: true\n',
+  'utf-8',
+);
+
+// Simulates a pre-row throw from the executor (e.g. provider resolution).
+const DISPATCH_ERROR_MESSAGE = 'provider resolution blew up before the run row existed';
+const runAgentSpy = vi.fn(async () => {
+  throw new Error(DISPATCH_ERROR_MESSAGE);
+});
+mock.module('@myco/agent/executor.js', () => ({
+  runAgent: (...args: unknown[]) => runAgentSpy(...args),
+}));
+mock.module('@myco/agent/config-resolver.js', () => ({
+  hasConfiguredProvider: () => true,
+  resolveTaskDefinitionExecution: () => ({}),
+}));
+
+function makeRequest(overrides: Partial<RouteRequest> = {}): RouteRequest {
+  return {
+    params: {},
+    query: {},
+    body: undefined,
+    pathname: '/',
+    requestContext: makeTestRequestContext({ vaultDir: VAULT_DIR }),
+    ...overrides,
+  } as RouteRequest;
+}
+
+function makeHandlers(logger: { debug: ReturnType<typeof vi.fn>; info: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> }) {
+  return createAgentRunHandlers({
+    vaultDir: VAULT_DIR,
+    resolveEmbeddingManager: () => ({} as never),
+    logger: logger as never,
+  });
+}
+
+// resultPromise.catch runs on a microtask after handleRun returns — flush it.
+async function flushMicrotasks() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('POST /api/agent/run — pre-row dispatch failure surfacing', () => {
+  beforeAll(() => { setupTestDb(); });
+  afterAll(() => { teardownTestDb(); });
+  beforeEach(() => {
+    cleanTestDb();
+    _clearNotifyDedupForTests();
+    runAgentSpy.mockClear();
+  });
+
+  it('(a) persists a failed row with the pre-generated runId when a non-FK throw happens before row creation', async () => {
+    registerAgent({ id: DEFAULT_AGENT_ID, name: 'Test', created_at: epochNow() });
+
+    const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const { handleRun } = makeHandlers(logger);
+    const response = await handleRun(makeRequest({
+      body: { task: 'custom-pre-row-smoke', instruction: 'go' },
+    }));
+    const runId = (response.body as { runId?: string }).runId;
+    expect(typeof runId).toBe('string');
+
+    expect(response.body).toMatchObject({ ok: true, message: 'Agent started' });
+
+    await flushMicrotasks();
+
+    const row = getRun(runId!, ALL_PROJECTS_SCOPE);
+    expect(row).not.toBeNull();
+    expect(row?.status).toBe('failed');
+    expect(row?.task).toBe('custom-pre-row-smoke');
+    expect(row?.error).toBe(DISPATCH_ERROR_MESSAGE);
+
+    const errorCalls = logger.error.mock.calls as unknown as Array<[string, string, Record<string, unknown>]>;
+    const enriched = errorCalls.find(([, message]) => message === 'Agent run threw before its run row was created');
+    expect(enriched).toBeDefined();
+    expect(enriched?.[2]).toMatchObject({ runId, task: 'custom-pre-row-smoke' });
+  });
+
+  it('(c) fires the run-outcome notification for the persisted-row case — a consumer keyed off run outcomes now has a row to find', async () => {
+    registerAgent({ id: DEFAULT_AGENT_ID, name: 'Test', created_at: epochNow() });
+
+    const projectId = 'proj_44444444444444444444444444444444';
+    const groveId = 'grove_44444444444444444444444444444444';
+    const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const { handleRun } = makeHandlers(logger);
+    const response = await handleRun(makeRequest({
+      requestContext: makeTestRequestContext({ vaultDir: VAULT_DIR, projectId, groveId }),
+      body: { task: 'custom-pre-row-notify-smoke', instruction: 'go' },
+    }));
+    const runId = (response.body as { runId?: string }).runId;
+
+    await flushMicrotasks();
+
+    const notificationRow = getDatabase().prepare(
+      `SELECT project_id, type FROM notifications WHERE type = ?`,
+    ).get('agent.task.failure') as { project_id: string; type: string } | undefined;
+    expect(notificationRow).toEqual({ project_id: projectId, type: 'agent.task.failure' });
+
+    const row = getRun(runId!, ALL_PROJECTS_SCOPE);
+    expect(row?.status).toBe('failed');
+  });
+
+  it('(b) falls back to enriched log + notification when the failed-row insert itself also faults', async () => {
+    const projectId = 'proj_55555555555555555555555555555555';
+    const groveId = 'grove_55555555555555555555555555555555';
+    const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const { handleRun } = makeHandlers(logger);
+    const response = await handleRun(makeRequest({
+      requestContext: makeTestRequestContext({ vaultDir: VAULT_DIR, projectId, groveId }),
+      body: { task: 'custom-pre-row-fallback-smoke', instruction: 'go' },
+    }));
+    const runId = (response.body as { runId?: string }).runId;
+    expect(response.body).toMatchObject({ ok: true, message: 'Agent started' });
+
+    await flushMicrotasks();
+
+    const row = getRun(runId!, ALL_PROJECTS_SCOPE);
+    expect(row).toBeNull();
+
+    const errorCalls = logger.error.mock.calls as unknown as Array<[string, string, Record<string, unknown>]>;
+    const fallback = errorCalls.find(([, message]) => message === 'Agent run threw unhandled error');
+    expect(fallback).toBeDefined();
+    expect(fallback?.[2]).toMatchObject({
+      runId,
+      task: 'custom-pre-row-fallback-smoke',
+      project_id: projectId,
+    });
+
+    const notificationRow = getDatabase().prepare(
+      `SELECT project_id, type FROM notifications WHERE type = ?`,
+    ).get('agent.task.failure') as { project_id: string; type: string } | undefined;
+    expect(notificationRow).toEqual({ project_id: projectId, type: 'agent.task.failure' });
+  });
+});

--- a/tests/daemon/harness-health-schedule-gate.test.ts
+++ b/tests/daemon/harness-health-schedule-gate.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Goondocks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * harness-health has no governing capability, so `effectiveTaskScheduleEnabled`
+ * alone fails open for it. Covers `resolveTaskScheduleEnabled`, which additionally
+ * gates it on capture-only status.
+ */
+import { describe, expect, it } from 'bun:test';
+import { resolveTaskScheduleEnabled } from '@myco/daemon/task-scheduling.js';
+import { MycoConfigSchema } from '@myco/config/schema.js';
+import { HARNESS_HEALTH_TASK_NAME } from '@myco/notifications/harness-health-consumer.js';
+import type { MycoConfig } from '@myco/config/schema.js';
+
+function captureOnlyConfig(): MycoConfig {
+  const cfg = MycoConfigSchema.parse({ version: 3 });
+  cfg.cortex.enabled = false;
+  cfg.cortex.canopy.enabled = false;
+  cfg.skills.enabled = false;
+  cfg.vault_evolution.enabled = false;
+  return cfg;
+}
+
+describe('resolveTaskScheduleEnabled — harness-health capture-only gate', () => {
+  it('skips harness-health on a capture-only project even though the YAML default is enabled', () => {
+    expect(
+      resolveTaskScheduleEnabled(captureOnlyConfig(), HARNESS_HEALTH_TASK_NAME, true),
+    ).toBe(false);
+  });
+
+  it('runs harness-health when at least one capability is on', () => {
+    const cfg = captureOnlyConfig();
+    cfg.vault_evolution.enabled = true;
+    expect(
+      resolveTaskScheduleEnabled(cfg, HARNESS_HEALTH_TASK_NAME, true),
+    ).toBe(true);
+  });
+
+  it('runs harness-health with every capability on (default config)', () => {
+    const cfg = MycoConfigSchema.parse({ version: 3 });
+    expect(
+      resolveTaskScheduleEnabled(cfg, HARNESS_HEALTH_TASK_NAME, true),
+    ).toBe(true);
+  });
+
+  it('fails closed on missing config (existing capabilityEnabled contract)', () => {
+    expect(resolveTaskScheduleEnabled(null, HARNESS_HEALTH_TASK_NAME, true)).toBe(false);
+  });
+
+  it('does not affect ungoverned, non-harness-health tasks (capture-only has no bearing)', () => {
+    expect(
+      resolveTaskScheduleEnabled(captureOnlyConfig(), 'title-summary', true),
+    ).toBe(true);
+  });
+
+  it('still gates vault-evolve on its own capability regardless of capture-only status', () => {
+    const cfg = captureOnlyConfig();
+    expect(resolveTaskScheduleEnabled(cfg, 'vault-evolve', true)).toBe(false);
+    cfg.vault_evolution.enabled = true;
+    expect(resolveTaskScheduleEnabled(cfg, 'vault-evolve', true)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Completes the capability model surfaced by the vault-seed brownfield smoke. Three related gaps:

- **Manual dispatch honors the governing capability.** `handleRun`/`handleResumeRun` reject a governed task before any side effect with an actionable `capability_disabled` error when its capability is off; vault-seed joins Vault Evolution. This is a single gate over every governed task, not a vault-seed special case. The run affordance disables with the same reason, sourced from a server-computed field on the tasks listing (the `CAPABILITIES` map stays the single source of truth — no client-side task→capability map).
- **harness-health no longer runs on capture-only projects.** It observes agent activity broadly rather than mapping to one capability, so it is gated on not-capture-only in the scheduler. A new enumeration test fails if any scheduled task is missing from the capability map or an explicit exempt list — so the next cost-bearing scheduled task can't silently inherit capture-only bypass (the regression that let harness-health run everywhere).
- **Dispatch failures before a run row exists are no longer silent.** A throw before/at run-row creation now persists a `failed` row for the pre-generated runId; if even that insert fails, an enriched error log (runId + task + project) plus a notification surface it. The API stays async-ack.

## Verification
- New tests: capability gate (6), YAML enumeration (4), harness-health gate (6), pre-row failure (3, incl. a non-FK pre-row throw and the insert-failure fallback); full suite green; `tsc` clean; `make build` green.
- Independent review: all three tasks pass spec, gate-runs-before-side-effects and enumeration-test-fails-on-mutation verified against source; 3 cosmetic Minors recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)