### PR TITLE
fix(agent): validate skill-evolve inventory/assess freshness by run evidence, not model run_id

### DIFF
--- a/packages/myco/src/agent/phase-postconditions.skill-evolve.test.ts
+++ b/packages/myco/src/agent/phase-postconditions.skill-evolve.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+import { withDatabase, openDatabase, type Database } from '@myco/db/client.js';
+import { createSchema } from '@myco/db/schema.js';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { insertRun } from '@myco/db/queries/runs.js';
+import { insertRunEvent } from '@myco/db/queries/agent-run-events.js';
+import { insertReport } from '@myco/db/queries/reports.js';
+import { setState } from '@myco/db/queries/agent-state.js';
+import { insertWriteIntent } from '@myco/db/queries/write-intents.js';
+import { epochSeconds } from '@myco/constants.js';
+import { checkPhasePostCondition, type PhasePostConditionInput } from './phase-postconditions.js';
+import {
+  SKILL_EVOLVE_ASSESS_PHASE_NAME,
+  SKILL_EVOLVE_ASSESS_REPORT_ACTION,
+  SKILL_EVOLVE_CLASSIFICATIONS_STATE_KEY,
+  SKILL_EVOLVE_INVENTORY_PHASE_NAME,
+  SKILL_EVOLVE_INVENTORY_REPORT_ACTION,
+  SKILL_EVOLVE_INVENTORY_STATE_KEY,
+} from './skill-evolve-output.js';
+
+/**
+ * Coverage for the skill-evolve inventory/assess phase postconditions.
+ * Freshness is proved by harness event evidence (a successful
+ * `vault_set_state` call in the relevant phase this run, or a run-scoped
+ * write intent on dry runs) rather than a model-supplied `run_id` — the
+ * model intermittently omits `run_id` from its JSON payload, and
+ * `stampRunIdInPayload` only rewrites an existing key, never adds one.
+ */
+describe('skill-evolve phase postconditions', () => {
+  let db: Database;
+  const agentId = 'test-agent';
+  const runId = 'test-run-1';
+  const projectId = 'proj-1';
+
+  beforeEach(() => {
+    db = openDatabase(':memory:');
+    createSchema(db);
+    withDatabase(db, () => {
+      registerAgent({ id: agentId, name: 'Test Agent', created_at: epochSeconds() });
+      insertRun({ id: runId, agent_id: agentId, project_id: projectId });
+    });
+  });
+
+  function input(overrides: Partial<PhasePostConditionInput> = {}): PhasePostConditionInput {
+    return { runId, agentId, projectId, dryRun: false, ...overrides };
+  }
+
+  function insertInventoryReport(): void {
+    insertReport({
+      run_id: runId,
+      agent_id: agentId,
+      action: SKILL_EVOLVE_INVENTORY_REPORT_ACTION,
+      summary: 'inventory done',
+      created_at: epochSeconds(),
+    });
+  }
+
+  function writeInventoryStateEvent(): void {
+    insertRunEvent({
+      runId,
+      phaseName: SKILL_EVOLVE_INVENTORY_PHASE_NAME,
+      eventType: 'post_tool_use',
+      toolName: 'vault_set_state',
+      outcome: 'success',
+    });
+  }
+
+  function writeAssessStateEvent(): void {
+    insertRunEvent({
+      runId,
+      phaseName: SKILL_EVOLVE_ASSESS_PHASE_NAME,
+      eventType: 'post_tool_use',
+      toolName: 'vault_set_state',
+      outcome: 'success',
+    });
+  }
+
+  describe('skill-evolve-inventory', () => {
+    test('PASSES: run_id-less inventory state written this run + report + success event in inventory phase', () => {
+      withDatabase(db, () => {
+        insertInventoryReport();
+        writeInventoryStateEvent();
+        setState(
+          agentId,
+          projectId,
+          SKILL_EVOLVE_INVENTORY_STATE_KEY,
+          JSON.stringify({ merge_candidates: [], narrow_candidates: [] }),
+          epochSeconds(),
+        );
+        const result = checkPhasePostCondition('skill-evolve-inventory', input());
+        expect(result.passed).toBe(true);
+      });
+    });
+
+    test('FAILS: missing inventory report', () => {
+      withDatabase(db, () => {
+        writeInventoryStateEvent();
+        setState(
+          agentId,
+          projectId,
+          SKILL_EVOLVE_INVENTORY_STATE_KEY,
+          JSON.stringify({ merge_candidates: [], narrow_candidates: [] }),
+          epochSeconds(),
+        );
+        const result = checkPhasePostCondition('skill-evolve-inventory', input());
+        expect(result.passed).toBe(false);
+        expect(result.reason).toContain('skill-evolve-inventory report');
+      });
+    });
+
+    test('FAILS (freshness): no inventory-phase vault_set_state success event this run, even though a stale prior-run inventory-shaped state exists', () => {
+      withDatabase(db, () => {
+        insertInventoryReport();
+        // Simulates a prior run's state value still sitting in agent_state —
+        // no write event was recorded for THIS run.
+        setState(
+          agentId,
+          projectId,
+          SKILL_EVOLVE_INVENTORY_STATE_KEY,
+          JSON.stringify({ merge_candidates: [], narrow_candidates: [] }),
+          epochSeconds(),
+        );
+        const result = checkPhasePostCondition('skill-evolve-inventory', input());
+        expect(result.passed).toBe(false);
+        expect(result.reason).toContain('wrote no skill-evolve-inventory state this run');
+      });
+    });
+
+    test('FAILS (structure): inventory-phase state write happened this run but the value is not inventory-shaped', () => {
+      withDatabase(db, () => {
+        insertInventoryReport();
+        writeInventoryStateEvent();
+        setState(
+          agentId,
+          projectId,
+          SKILL_EVOLVE_INVENTORY_STATE_KEY,
+          JSON.stringify({ some_other_shape: true }),
+          epochSeconds(),
+        );
+        const result = checkPhasePostCondition('skill-evolve-inventory', input());
+        expect(result.passed).toBe(false);
+        expect(result.reason).toContain('valid skill-evolve-inventory state');
+      });
+    });
+
+    test('PASSES even when the state payload DOES carry a run_id (backward compatible)', () => {
+      withDatabase(db, () => {
+        insertInventoryReport();
+        writeInventoryStateEvent();
+        setState(
+          agentId,
+          projectId,
+          SKILL_EVOLVE_INVENTORY_STATE_KEY,
+          JSON.stringify({ run_id: runId, merge_candidates: [], narrow_candidates: [] }),
+          epochSeconds(),
+        );
+        const result = checkPhasePostCondition('skill-evolve-inventory', input());
+        expect(result.passed).toBe(true);
+      });
+    });
+
+    test('dry-run PASSES: run_id-less write intent for skill-evolve-inventory this run + report', () => {
+      withDatabase(db, () => {
+        insertInventoryReport();
+        insertWriteIntent({
+          runId,
+          projectId: null,
+          toolName: 'vault_set_state',
+          toolInput: JSON.stringify({ key: SKILL_EVOLVE_INVENTORY_STATE_KEY, value: JSON.stringify({ merge_candidates: [], narrow_candidates: [] }) }),
+          syntheticOutput: JSON.stringify({ ok: true }),
+        });
+        const result = checkPhasePostCondition('skill-evolve-inventory', input({ dryRun: true }));
+        expect(result.passed).toBe(true);
+      });
+    });
+
+    test('dry-run FAILS: no skill-evolve-inventory write intent recorded this run', () => {
+      withDatabase(db, () => {
+        insertInventoryReport();
+        const result = checkPhasePostCondition('skill-evolve-inventory', input({ dryRun: true }));
+        expect(result.passed).toBe(false);
+        expect(result.reason).toContain('write intent');
+      });
+    });
+  });
+
+  describe('skill-evolve-assess', () => {
+    const classifications = [
+      { skill_id: 'skill-a', name: 'skill-a', classification: 'CURRENT', target_skill: null, details: 'still accurate' },
+    ];
+
+    function insertAssessReport(overrideClassifications = classifications): void {
+      insertReport({
+        run_id: runId,
+        agent_id: agentId,
+        action: SKILL_EVOLVE_ASSESS_REPORT_ACTION,
+        summary: 'assess done',
+        details: JSON.stringify({ classifications: overrideClassifications, deferred_skills: [] }),
+        created_at: epochSeconds(),
+      });
+    }
+
+    test('PASSES: run_id-less classifications state + assess report + assess-phase success event + matching payloads', () => {
+      withDatabase(db, () => {
+        insertAssessReport();
+        writeAssessStateEvent();
+        setState(
+          agentId,
+          projectId,
+          SKILL_EVOLVE_CLASSIFICATIONS_STATE_KEY,
+          JSON.stringify({ classifications, deferred_skills: [] }),
+          epochSeconds(),
+        );
+        const result = checkPhasePostCondition('skill-evolve-assess', input());
+        expect(result.passed).toBe(true);
+      });
+    });
+
+    test('FAILS: missing assess report', () => {
+      withDatabase(db, () => {
+        writeAssessStateEvent();
+        setState(
+          agentId,
+          projectId,
+          SKILL_EVOLVE_CLASSIFICATIONS_STATE_KEY,
+          JSON.stringify({ classifications, deferred_skills: [] }),
+          epochSeconds(),
+        );
+        const result = checkPhasePostCondition('skill-evolve-assess', input());
+        expect(result.passed).toBe(false);
+        expect(result.reason).toContain('assess report');
+      });
+    });
+
+    test('FAILS: classifications state does not match the assess report', () => {
+      withDatabase(db, () => {
+        insertAssessReport();
+        writeAssessStateEvent();
+        setState(
+          agentId,
+          projectId,
+          SKILL_EVOLVE_CLASSIFICATIONS_STATE_KEY,
+          JSON.stringify({
+            classifications: [
+              { skill_id: 'skill-a', name: 'skill-a', classification: 'STALE', target_skill: null, details: 'differs' },
+            ],
+            deferred_skills: [],
+          }),
+          epochSeconds(),
+        );
+        const result = checkPhasePostCondition('skill-evolve-assess', input());
+        expect(result.passed).toBe(false);
+        expect(result.reason).toContain('does not match assess report');
+      });
+    });
+
+    test('FAILS (freshness): no assess-phase state write this run even though a stale prior-run classifications state matches the report', () => {
+      withDatabase(db, () => {
+        insertAssessReport();
+        // No writeAssessStateEvent() — simulates a prior run's leftover state.
+        setState(
+          agentId,
+          projectId,
+          SKILL_EVOLVE_CLASSIFICATIONS_STATE_KEY,
+          JSON.stringify({ classifications, deferred_skills: [] }),
+          epochSeconds(),
+        );
+        const result = checkPhasePostCondition('skill-evolve-assess', input());
+        expect(result.passed).toBe(false);
+        expect(result.reason).toContain('wrote no skill-evolve-classifications state this run');
+      });
+    });
+
+    test('PASSES even when both report and state DO carry a run_id (backward compatible)', () => {
+      withDatabase(db, () => {
+        insertReport({
+          run_id: runId,
+          agent_id: agentId,
+          action: SKILL_EVOLVE_ASSESS_REPORT_ACTION,
+          summary: 'assess done',
+          details: JSON.stringify({ run_id: runId, classifications, deferred_skills: [] }),
+          created_at: epochSeconds(),
+        });
+        writeAssessStateEvent();
+        setState(
+          agentId,
+          projectId,
+          SKILL_EVOLVE_CLASSIFICATIONS_STATE_KEY,
+          JSON.stringify({ run_id: runId, classifications, deferred_skills: [] }),
+          epochSeconds(),
+        );
+        const result = checkPhasePostCondition('skill-evolve-assess', input());
+        expect(result.passed).toBe(true);
+      });
+    });
+
+    test('dry-run PASSES: run_id-less classifications write intent this run + assess report + matching payloads', () => {
+      withDatabase(db, () => {
+        insertAssessReport();
+        insertWriteIntent({
+          runId,
+          projectId: null,
+          toolName: 'vault_set_state',
+          toolInput: JSON.stringify({ key: SKILL_EVOLVE_CLASSIFICATIONS_STATE_KEY, value: JSON.stringify({ classifications, deferred_skills: [] }) }),
+          syntheticOutput: JSON.stringify({ ok: true }),
+        });
+        const result = checkPhasePostCondition('skill-evolve-assess', input({ dryRun: true }));
+        expect(result.passed).toBe(true);
+      });
+    });
+
+    test('dry-run FAILS: no skill-evolve-classifications write intent recorded this run', () => {
+      withDatabase(db, () => {
+        insertAssessReport();
+        const result = checkPhasePostCondition('skill-evolve-assess', input({ dryRun: true }));
+        expect(result.passed).toBe(false);
+        expect(result.reason).toContain('write intent');
+      });
+    });
+  });
+});

--- a/packages/myco/src/agent/phase-postconditions.ts
+++ b/packages/myco/src/agent/phase-postconditions.ts
@@ -41,8 +41,10 @@ import {
   parseSkillEvolveClassificationPayload,
   parseSkillEvolveInventoryPayload,
   skillEvolveClassificationPayloadsEqual,
+  SKILL_EVOLVE_ASSESS_PHASE_NAME,
   SKILL_EVOLVE_ASSESS_REPORT_ACTION,
   SKILL_EVOLVE_CLASSIFICATIONS_STATE_KEY,
+  SKILL_EVOLVE_INVENTORY_PHASE_NAME,
   SKILL_EVOLVE_INVENTORY_REPORT_ACTION,
   SKILL_EVOLVE_INVENTORY_STATE_KEY,
   SKILL_EVOLVE_TASK_NAME,
@@ -131,11 +133,28 @@ function findLatestIntentByToolName(
   return undefined;
 }
 
+/**
+ * True when this run's harness events prove a live `vault_set_state` call
+ * succeeded in `phaseName` — the only evidence that `getState`'s
+ * global-latest-value read reflects this run rather than a stale prior run.
+ * Dry runs never reach this: `readStatePayloadValue`'s dry-run branch reads
+ * `listWriteIntents(runId, ...)`, which is already run-scoped, so a
+ * recorded intent is itself the freshness proof.
+ */
+function hasFreshStateWrite(input: PhasePostConditionInput, phaseName: string): boolean {
+  if (input.dryRun) return true;
+  return countPhaseToolCallsByOutcome(input.runId, phaseName, 'vault_set_state', 'success') > 0;
+}
+
 function checkSkillEvolveInventory(input: PhasePostConditionInput): PhasePostConditionResult {
   const reports = listReports(input.runId, { scope: ALL_PROJECTS_SCOPE });
   const inventoryReport = reports.find((report) => report.action === SKILL_EVOLVE_INVENTORY_REPORT_ACTION);
   if (!inventoryReport) {
     return failed('skill-evolve completed without a skill-evolve-inventory report');
+  }
+
+  if (!hasFreshStateWrite(input, SKILL_EVOLVE_INVENTORY_PHASE_NAME)) {
+    return failed('skill-evolve inventory phase wrote no skill-evolve-inventory state this run');
   }
 
   const stateValue = readStatePayloadValue(input, SKILL_EVOLVE_INVENTORY_STATE_KEY, SKILL_EVOLVE_TASK_NAME);
@@ -146,11 +165,6 @@ function checkSkillEvolveInventory(input: PhasePostConditionInput): PhasePostCon
     return failed(input.dryRun
       ? 'skill-evolve dry-run completed without a valid skill-evolve-inventory write intent'
       : 'skill-evolve completed without valid skill-evolve-inventory state');
-  }
-  if (inventoryPayload.run_id !== input.runId) {
-    return failed(input.dryRun
-      ? 'skill-evolve inventory write intent run_id does not match the run'
-      : 'skill-evolve inventory state run_id does not match the run');
   }
   return PASSED;
 }
@@ -166,8 +180,9 @@ function checkSkillEvolveAssess(input: PhasePostConditionInput): PhasePostCondit
   if (!assessPayload) {
     return failed('skill-evolve assess report details are invalid');
   }
-  if (assessPayload.run_id !== input.runId) {
-    return failed('skill-evolve assess report run_id does not match the run');
+
+  if (!hasFreshStateWrite(input, SKILL_EVOLVE_ASSESS_PHASE_NAME)) {
+    return failed('skill-evolve assess phase wrote no skill-evolve-classifications state this run');
   }
 
   const stateValue = readStatePayloadValue(input, SKILL_EVOLVE_CLASSIFICATIONS_STATE_KEY, SKILL_EVOLVE_TASK_NAME);
@@ -178,11 +193,6 @@ function checkSkillEvolveAssess(input: PhasePostConditionInput): PhasePostCondit
     return failed(input.dryRun
       ? 'skill-evolve dry-run completed without a valid skill-evolve-classifications write intent'
       : 'skill-evolve completed without valid skill-evolve-classifications state');
-  }
-  if (classificationPayload.run_id !== input.runId) {
-    return failed(input.dryRun
-      ? 'skill-evolve classifications write intent run_id does not match the run'
-      : 'skill-evolve classifications state run_id does not match the run');
   }
   if (!skillEvolveClassificationPayloadsEqual(classificationPayload, assessPayload)) {
     return failed(input.dryRun

--- a/packages/myco/src/agent/skill-evolve-output.ts
+++ b/packages/myco/src/agent/skill-evolve-output.ts
@@ -19,6 +19,10 @@ export const SKILL_EVOLVE_INVENTORY_STATE_KEY = 'skill-evolve-inventory';
 export const SKILL_EVOLVE_CLASSIFICATIONS_STATE_KEY = 'skill-evolve-classifications';
 export const SKILL_EVOLVE_INVENTORY_REPORT_ACTION = 'skill-evolve-inventory';
 export const SKILL_EVOLVE_ASSESS_REPORT_ACTION = 'assess';
+/** Matches the `name:` field of the `inventory` phase in skill-evolve.yaml. */
+export const SKILL_EVOLVE_INVENTORY_PHASE_NAME = 'inventory';
+/** Matches the `name:` field of the `assess` phase in skill-evolve.yaml. */
+export const SKILL_EVOLVE_ASSESS_PHASE_NAME = 'assess';
 
 const CLASSIFICATION_VALUES = new Set([
   'CURRENT',
@@ -37,13 +41,15 @@ export interface SkillEvolveClassification {
 }
 
 export interface SkillEvolveClassificationPayload {
-  run_id: string;
+  /** Omitted when the model dropped the field; freshness is proved by harness event evidence, not this value. */
+  run_id?: string;
   classifications: SkillEvolveClassification[];
   deferred_skills: string[];
 }
 
 export interface SkillEvolveInventoryPayload {
-  run_id: string;
+  /** Omitted when the model dropped the field; freshness is proved by harness event evidence, not this value. */
+  run_id?: string;
   merge_candidates: Array<{
     source: string;
     target: string;
@@ -122,8 +128,7 @@ function normalizeClassificationPayload(value: unknown): SkillEvolveClassificati
   const record = asRecord(value);
   if (!record) return null;
 
-  const runId = asString(record.run_id);
-  if (!runId || !Array.isArray(record.classifications)) return null;
+  if (!Array.isArray(record.classifications)) return null;
 
   const classifications = record.classifications.map(normalizeClassification);
   if (classifications.some((item) => item === null)) return null;
@@ -132,7 +137,7 @@ function normalizeClassificationPayload(value: unknown): SkillEvolveClassificati
   if (!deferredSkills) return null;
 
   return {
-    run_id: runId,
+    run_id: asString(record.run_id) ?? undefined,
     classifications: classifications as SkillEvolveClassification[],
     deferred_skills: deferredSkills,
   };
@@ -164,12 +169,18 @@ function normalizeNarrowCandidate(value: unknown): SkillEvolveInventoryPayload['
   };
 }
 
+/**
+ * Structural parse only — validates shape (`merge_candidates` and
+ * `narrow_candidates` arrays of well-formed entries), not run attribution.
+ * `run_id` is carried through when present but never required for a
+ * non-null result: callers that need this-run freshness prove it from
+ * harness event evidence, not from a model-supplied field.
+ */
 export function parseSkillEvolveInventoryPayload(value: unknown): SkillEvolveInventoryPayload | null {
   const record = asRecord(value);
   if (!record) return null;
 
-  const runId = asString(record.run_id);
-  if (!runId || !Array.isArray(record.merge_candidates) || !Array.isArray(record.narrow_candidates)) {
+  if (!Array.isArray(record.merge_candidates) || !Array.isArray(record.narrow_candidates)) {
     return null;
   }
 
@@ -180,12 +191,19 @@ export function parseSkillEvolveInventoryPayload(value: unknown): SkillEvolveInv
   }
 
   return {
-    run_id: runId,
+    run_id: asString(record.run_id) ?? undefined,
     merge_candidates: mergeCandidates as SkillEvolveInventoryPayload['merge_candidates'],
     narrow_candidates: narrowCandidates as SkillEvolveInventoryPayload['narrow_candidates'],
   };
 }
 
+/**
+ * Structural parse only — validates shape (`classifications` array of
+ * well-formed entries plus `deferred_skills`), not run attribution.
+ * `run_id` is carried through when present but never required for a
+ * non-null result: callers that need this-run freshness prove it from
+ * harness event evidence, not from a model-supplied field.
+ */
 export function parseSkillEvolveClassificationPayload(value: unknown): SkillEvolveClassificationPayload | null {
   return normalizeClassificationPayload(value);
 }

--- a/packages/myco/src/agent/task-postconditions.skill-evolve.test.ts
+++ b/packages/myco/src/agent/task-postconditions.skill-evolve.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+import { withDatabase, openDatabase, type Database } from '@myco/db/client.js';
+import { createSchema } from '@myco/db/schema.js';
+import { registerAgent } from '@myco/db/queries/agents.js';
+import { insertRun } from '@myco/db/queries/runs.js';
+import { insertRunEvent } from '@myco/db/queries/agent-run-events.js';
+import { insertReport } from '@myco/db/queries/reports.js';
+import { setState } from '@myco/db/queries/agent-state.js';
+import { epochSeconds } from '@myco/constants.js';
+import { validateTaskPostconditions } from './task-postconditions.js';
+import {
+  SKILL_EVOLVE_ASSESS_PHASE_NAME,
+  SKILL_EVOLVE_ASSESS_REPORT_ACTION,
+  SKILL_EVOLVE_CLASSIFICATIONS_STATE_KEY,
+  SKILL_EVOLVE_INVENTORY_PHASE_NAME,
+  SKILL_EVOLVE_INVENTORY_REPORT_ACTION,
+  SKILL_EVOLVE_INVENTORY_STATE_KEY,
+  SKILL_EVOLVE_TASK_NAME,
+} from './skill-evolve-output.js';
+
+/**
+ * Run-end validator coverage for skill-evolve. `validateSkillEvolveRun`
+ * delegates to the same phase postconditions the phase-boundary gates run
+ * (belt and suspenders), so this exercises the run-end entry point rather
+ * than re-deriving the postcondition logic.
+ */
+describe('validateTaskPostconditions — skill-evolve', () => {
+  let db: Database;
+  const agentId = 'test-agent';
+  const runId = 'skill-evolve-run-1';
+  const projectId = 'proj-1';
+  const taskName = SKILL_EVOLVE_TASK_NAME;
+
+  const classifications = [
+    { skill_id: 'skill-a', name: 'skill-a', classification: 'CURRENT', target_skill: null, details: 'still accurate' },
+  ];
+
+  beforeEach(() => {
+    db = openDatabase(':memory:');
+    createSchema(db);
+    withDatabase(db, () => {
+      registerAgent({ id: agentId, name: 'Test Agent', created_at: epochSeconds() });
+      insertRun({ id: runId, agent_id: agentId, project_id: projectId });
+    });
+  });
+
+  function seedPassingRun(): void {
+    insertReport({
+      run_id: runId,
+      agent_id: agentId,
+      action: SKILL_EVOLVE_INVENTORY_REPORT_ACTION,
+      summary: 'inventory done',
+      created_at: epochSeconds(),
+    });
+    insertRunEvent({
+      runId,
+      phaseName: SKILL_EVOLVE_INVENTORY_PHASE_NAME,
+      eventType: 'post_tool_use',
+      toolName: 'vault_set_state',
+      outcome: 'success',
+    });
+    setState(
+      agentId,
+      projectId,
+      SKILL_EVOLVE_INVENTORY_STATE_KEY,
+      JSON.stringify({ merge_candidates: [], narrow_candidates: [] }),
+      epochSeconds(),
+    );
+    insertReport({
+      run_id: runId,
+      agent_id: agentId,
+      action: SKILL_EVOLVE_ASSESS_REPORT_ACTION,
+      summary: 'assess done',
+      details: JSON.stringify({ classifications, deferred_skills: [] }),
+      created_at: epochSeconds(),
+    });
+    insertRunEvent({
+      runId,
+      phaseName: SKILL_EVOLVE_ASSESS_PHASE_NAME,
+      eventType: 'post_tool_use',
+      toolName: 'vault_set_state',
+      outcome: 'success',
+    });
+    setState(
+      agentId,
+      projectId,
+      SKILL_EVOLVE_CLASSIFICATIONS_STATE_KEY,
+      JSON.stringify({ classifications, deferred_skills: [] }),
+      epochSeconds(),
+    );
+  }
+
+  test('passes: run_id-less inventory and assess state, both freshly written this run', () => {
+    withDatabase(db, () => {
+      seedPassingRun();
+      const error = validateTaskPostconditions({ runId, taskName });
+      expect(error).toBeNull();
+    });
+  });
+
+  test('fails: inventory state is stale (no inventory-phase write event this run)', () => {
+    withDatabase(db, () => {
+      seedPassingRun();
+      // Overwrite: pretend the inventory-phase event never happened, by
+      // starting a run with only the assess-side evidence.
+      const staleRunId = 'skill-evolve-run-stale';
+      insertRun({ id: staleRunId, agent_id: agentId, project_id: projectId });
+      insertReport({
+        run_id: staleRunId,
+        agent_id: agentId,
+        action: SKILL_EVOLVE_INVENTORY_REPORT_ACTION,
+        summary: 'inventory done',
+        created_at: epochSeconds(),
+      });
+      // No vault_set_state success event recorded for staleRunId's inventory phase.
+      const error = validateTaskPostconditions({ runId: staleRunId, taskName });
+      expect(error).not.toBeNull();
+      expect(error).toContain('wrote no skill-evolve-inventory state this run');
+    });
+  });
+
+  test('fails: missing assess report even though inventory passed', () => {
+    withDatabase(db, () => {
+      insertReport({
+        run_id: runId,
+        agent_id: agentId,
+        action: SKILL_EVOLVE_INVENTORY_REPORT_ACTION,
+        summary: 'inventory done',
+        created_at: epochSeconds(),
+      });
+      insertRunEvent({
+        runId,
+        phaseName: SKILL_EVOLVE_INVENTORY_PHASE_NAME,
+        eventType: 'post_tool_use',
+        toolName: 'vault_set_state',
+        outcome: 'success',
+      });
+      setState(
+        agentId,
+        projectId,
+        SKILL_EVOLVE_INVENTORY_STATE_KEY,
+        JSON.stringify({ merge_candidates: [], narrow_candidates: [] }),
+        epochSeconds(),
+      );
+      const error = validateTaskPostconditions({ runId, taskName });
+      expect(error).not.toBeNull();
+      expect(error).toContain('assess report');
+    });
+  });
+
+  test('other task names are unaffected by the skill-evolve rule', () => {
+    withDatabase(db, () => {
+      const error = validateTaskPostconditions({ runId, taskName: 'some-other-task' });
+      expect(error).toBeNull();
+    });
+  });
+});

--- a/tests/agent/task-postconditions.test.ts
+++ b/tests/agent/task-postconditions.test.ts
@@ -4,9 +4,14 @@ import { registerAgent } from '@myco/db/queries/agents.js';
 import { setState } from '@myco/db/queries/agent-state.js';
 import { insertReport } from '@myco/db/queries/reports.js';
 import { insertRun } from '@myco/db/queries/runs.js';
+import { insertRunEvent } from '@myco/db/queries/agent-run-events.js';
 import { insertTurn } from '@myco/db/queries/turns.js';
 import { insertWriteIntent } from '@myco/db/queries/write-intents.js';
 import { validateTaskPostconditions } from '@myco/agent/task-postconditions.js';
+import {
+  SKILL_EVOLVE_ASSESS_PHASE_NAME,
+  SKILL_EVOLVE_INVENTORY_PHASE_NAME,
+} from '@myco/agent/skill-evolve-output.js';
 import { DEFAULT_AGENT_ID, epochSeconds } from '@myco/constants.js';
 
 const TEST_PROJECT_ID = 'proj_skill_evolve_postconditions';
@@ -57,6 +62,24 @@ function seedRun(options: { dryRun?: boolean; agentId?: string } = {}) {
   });
 }
 
+/** Records the freshness evidence a live skill-evolve run leaves behind: a successful `vault_set_state` call in each phase. */
+function writeSkillEvolveStateEvents(runId = TEST_RUN_ID) {
+  insertRunEvent({
+    runId,
+    phaseName: SKILL_EVOLVE_INVENTORY_PHASE_NAME,
+    eventType: 'post_tool_use',
+    toolName: 'vault_set_state',
+    outcome: 'success',
+  });
+  insertRunEvent({
+    runId,
+    phaseName: SKILL_EVOLVE_ASSESS_PHASE_NAME,
+    eventType: 'post_tool_use',
+    toolName: 'vault_set_state',
+    outcome: 'success',
+  });
+}
+
 function insertSkillEvolveReports(
   runId = TEST_RUN_ID,
   assessPayload = classificationPayload(runId),
@@ -91,16 +114,76 @@ describe('task postconditions', () => {
   it('accepts skill-evolve when reports and persisted state agree', () => {
     seedRun();
     insertSkillEvolveReports();
+    writeSkillEvolveStateEvents();
     setState(DEFAULT_AGENT_ID, TEST_PROJECT_ID, 'skill-evolve-inventory', JSON.stringify(inventoryPayload()), epochSeconds());
     setState(DEFAULT_AGENT_ID, TEST_PROJECT_ID, 'skill-evolve-classifications', JSON.stringify(classificationPayload()), epochSeconds());
 
     expect(validateTaskPostconditions({ runId: TEST_RUN_ID, taskName: 'skill-evolve' })).toBeNull();
   });
 
+  it('accepts skill-evolve when the model omits run_id from state and report payloads', () => {
+    seedRun();
+    insertReport({
+      run_id: TEST_RUN_ID,
+      agent_id: DEFAULT_AGENT_ID,
+      action: 'skill-evolve-inventory',
+      summary: 'Inventory complete',
+      details: JSON.stringify({ merge_count: 1, narrow_count: 1 }),
+      created_at: epochSeconds(),
+    });
+    insertReport({
+      run_id: TEST_RUN_ID,
+      agent_id: DEFAULT_AGENT_ID,
+      action: 'assess',
+      summary: 'Assess complete',
+      details: JSON.stringify({
+        classifications: classificationPayload().classifications,
+        deferred_skills: classificationPayload().deferred_skills,
+      }),
+      created_at: epochSeconds() + 1,
+    });
+    writeSkillEvolveStateEvents();
+    setState(
+      DEFAULT_AGENT_ID,
+      TEST_PROJECT_ID,
+      'skill-evolve-inventory',
+      JSON.stringify({
+        merge_candidates: inventoryPayload().merge_candidates,
+        narrow_candidates: inventoryPayload().narrow_candidates,
+      }),
+      epochSeconds(),
+    );
+    setState(
+      DEFAULT_AGENT_ID,
+      TEST_PROJECT_ID,
+      'skill-evolve-classifications',
+      JSON.stringify({
+        classifications: classificationPayload().classifications,
+        deferred_skills: classificationPayload().deferred_skills,
+      }),
+      epochSeconds(),
+    );
+
+    expect(validateTaskPostconditions({ runId: TEST_RUN_ID, taskName: 'skill-evolve' })).toBeNull();
+  });
+
+  it('fails skill-evolve when the inventory phase wrote no state this run (stale prior-run state present)', () => {
+    seedRun();
+    insertSkillEvolveReports();
+    // No writeSkillEvolveStateEvents() call: simulates a prior run's leftover
+    // agent_state row with no fresh write this run.
+    setState(DEFAULT_AGENT_ID, TEST_PROJECT_ID, 'skill-evolve-inventory', JSON.stringify(inventoryPayload()), epochSeconds());
+    setState(DEFAULT_AGENT_ID, TEST_PROJECT_ID, 'skill-evolve-classifications', JSON.stringify(classificationPayload()), epochSeconds());
+
+    expect(validateTaskPostconditions({ runId: TEST_RUN_ID, taskName: 'skill-evolve' }))
+      .toBe('skill-evolve inventory phase wrote no skill-evolve-inventory state this run');
+  });
+
   it('validates persisted skill-evolve state under the run agent', () => {
     registerAgent({ id: CUSTOM_AGENT_ID, name: 'Custom Agent', created_at: epochSeconds() });
     seedRun({ agentId: CUSTOM_AGENT_ID });
     insertSkillEvolveReports(TEST_RUN_ID, classificationPayload(TEST_RUN_ID, 'STALE'), CUSTOM_AGENT_ID);
+    writeSkillEvolveStateEvents();
     setState(
       DEFAULT_AGENT_ID,
       TEST_PROJECT_ID,
@@ -143,6 +226,7 @@ describe('task postconditions', () => {
   it('fails skill-evolve when classification state does not match the assess report', () => {
     seedRun();
     insertSkillEvolveReports(TEST_RUN_ID, classificationPayload(TEST_RUN_ID, 'STALE'));
+    writeSkillEvolveStateEvents();
     setState(DEFAULT_AGENT_ID, TEST_PROJECT_ID, 'skill-evolve-inventory', JSON.stringify(inventoryPayload()), epochSeconds());
     setState(DEFAULT_AGENT_ID, TEST_PROJECT_ID, 'skill-evolve-classifications', JSON.stringify(classificationPayload(TEST_RUN_ID, 'CURRENT')), epochSeconds());
 


### PR DESCRIPTION
## Summary
Prod skill-evolve fails intermittently (unifi-mcp; verified live on 1.2.11). Root cause: `checkSkillEvolveInventory`/`checkSkillEvolveAssess` proved this-run freshness by requiring a model-supplied `run_id` inside the state payload. The prompt tells the model to write it, but the model **intermittently omits the key** — and #617's stamp only rewrites an existing `run_id` (never adds one), so an omitted key stays omitted, the parse returns invalid, and the phase fails with "completed without valid skill-evolve-inventory state." Same anti-pattern as the vault-seed count gate: a gate depending on a value the model must reliably supply.

Fix (option B): prove freshness from **harness event evidence** the model can't drop.

- Freshness = a successful `vault_set_state` occurred in the phase *this run* (`countPhaseToolCallsByOutcome(runId, phase, 'vault_set_state', 'success')`; dry-run uses the already-run-scoped write-intent). Replaces the `run_id`-in-state equality check.
- The `run_id`-in-**report** checks are dropped as redundant — `listReports(runId)` already scopes to this run.
- `parseSkillEvolve{Inventory,Classification}Payload` relax `run_id` to optional (structure-only); the sole other consumer (phase-recovery.ts) does its own run_id check and degrades safely.
- assess keeps the `skillEvolveClassificationPayloadsEqual(state, report)` state-vs-report match as a second guard.

Applies to **both** inventory and assess (identical fragility). The run-end validator inherits it via delegation.

## Verification
- 16 new tests (the exact prod payload — no run_id — now passes with the event; stale prior-run state without this-run event fails; malformed structure fails; assess parallels; dry-run) + updated the pre-existing task-postcondition suite; full suite green; `tsc` clean; `make build` green.
- Independent review confirmed no run false-passes in a way that ships wrong data (`vault_set_state` success = row persisted; inventory writes one key; assess double-guarded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)