### PR TITLE
fix(daemon): supersede resumable runs by scheduled-job identity, not dynamic instruction

### DIFF
--- a/packages/myco/src/agent/executor.ts
+++ b/packages/myco/src/agent/executor.ts
@@ -702,18 +702,18 @@ export async function runAgent(
 
     // Part 1 (supersede) primary enforcement: this run just completed, so
     // any OTHER resumable failed run for the same (agent, task, project
-    // scope, dry_run, instruction) is stale by definition — its checkpoints,
-    // gate verdicts, and watermarks are superseded by this completion.
-    // Terminal-mark it now rather than let the scheduler re-admit it. The
-    // instruction/dry_run pinning in the equivalence key is load-bearing:
-    // without it, this completion would wrongly sweep an unrelated
-    // instruction-scoped failed run (see supersedeEquivalentResumableRuns).
+    // scope, dry_run) — the same scheduled job — is stale by definition —
+    // its checkpoints, gate verdicts, and watermarks are superseded by this
+    // completion. Terminal-mark it now rather than let the scheduler
+    // re-admit it. `instruction` is intentionally excluded from the
+    // equivalence key (see appendSupersedeEquivalenceCondition): tasks like
+    // skill-evolve build their instruction dynamically per run, so keying
+    // on it would prevent this sweep from ever retiring that job's zombies.
     supersedeEquivalentResumableRuns(runId, {
       agentId,
       taskName: config.taskName,
       scope,
       dryRun: options?.dryRun ?? false,
-      instruction: options?.instruction ?? null,
     });
 
     return {

--- a/packages/myco/src/daemon/api/agent-runs.ts
+++ b/packages/myco/src/daemon/api/agent-runs.ts
@@ -517,19 +517,18 @@ export function createAgentRunHandlers(deps: AgentRunDeps) {
     }
 
     // Belt for the manual endpoint (Part 1 secondary): a newer completed
-    // equivalent run (same agent/task/project scope/dry_run/instruction)
-    // makes this run's checkpoints stale even though nothing has swept it
-    // yet (race with the completion-time sweep, or a legacy row from
-    // before the sweep existed). Terminal-mark here — same write this
-    // endpoint already owns via the 400 above — and refuse with 409,
-    // naming the superseding run and pointing at "Rerun with same
+    // equivalent run (same agent/task/project scope/dry_run — same
+    // scheduled job) makes this run's checkpoints stale even though
+    // nothing has swept it yet (race with the completion-time sweep, or a
+    // legacy row from before the sweep existed). Terminal-mark here — same
+    // write this endpoint already owns via the 400 above — and refuse with
+    // 409, naming the superseding run and pointing at "Rerun with same
     // settings" as the intent-preserving path (RunDetail.tsx).
     const superseding = findNewerCompletedEquivalentRun(run, {
       agentId: run.agent_id,
       taskName: run.task ?? '',
       scope,
       dryRun: run.dry_run,
-      instruction: run.instruction,
     });
     if (superseding) {
       applyRunUpdate(run.id, {

--- a/packages/myco/src/daemon/task-scheduling.ts
+++ b/packages/myco/src/daemon/task-scheduling.ts
@@ -181,8 +181,8 @@ export interface ScheduledResumeGateInput {
  * Decide whether a resumable run may consume another scheduled resume.
  *
  * - Superseded belt (Part 1 secondary): if a completed equivalent run
- *   (same agent/task/project scope/dry_run/instruction) finished AFTER this
- *   run's own ORIGINAL dispatch (`started_at`), terminal-marks
+ *   (same agent/task/project scope/dry_run — same scheduled job) finished
+ *   AFTER this run's own ORIGINAL dispatch (`started_at`), terminal-marks
  *   (`resumable=0`, `resume_status='superseded'`) and returns 'superseded'
  *   — the caller falls through to a fresh dispatch. Defends legacy rows
  *   written before the completion-time sweep existed, and any race the
@@ -205,7 +205,6 @@ export function gateScheduledResume(input: ScheduledResumeGateInput): 'resume' |
     taskName,
     scope,
     dryRun: run.dry_run,
-    instruction: run.instruction,
   })) {
     applyRunUpdate(run.id, {
       resumable: 0,

--- a/packages/myco/src/db/queries/runs.ts
+++ b/packages/myco/src/db/queries/runs.ts
@@ -57,9 +57,9 @@ export const RESUME_STATUS_EXHAUSTED = 'exhausted';
 
 /**
  * Resume status used when a newer, equivalent run (same agent/task/project
- * scope/dry_run/instruction) has since completed. A resumable failed run
- * left behind by an OLDER dispatch is stale by definition once an
- * equivalent run finishes — resuming it would re-execute work against
+ * scope/dry_run — same scheduled job) has since completed. A resumable
+ * failed run left behind by an OLDER dispatch is stale by definition once
+ * an equivalent run finishes — resuming it would re-execute work against
  * checkpoints, gates, and watermarks superseded by the completion. See
  * `supersedeEquivalentResumableRuns` (completion-time sweep) and the
  * `gateScheduledResume` belt (task-scheduling.ts) for the two enforcement
@@ -716,43 +716,42 @@ export function getLatestResumableRunForTask(
 /**
  * Append the supersede equivalence-key predicate to an in-progress
  * WHERE-clause builder: same `agent_id` + `task` + project scope (via
- * `appendProjectCondition`) + `dry_run`, and `instruction` equal OR both
- * NULL. Shared by the completion-time sweep and the gate-time belt so the
- * two enforcement points can never drift apart on what counts as
- * "equivalent" — the instruction/dry_run pinning is load-bearing:
- * `getLatestResumableRunForTask` doesn't filter on either, and the executor
- * restores `instruction`/`dryRun` on resume, so without this key a
- * completed run for a DIFFERENT candidate/instruction would wrongly
- * supersede or block an unrelated instruction-scoped failed run.
+ * `appendProjectCondition`) + `dry_run`. Shared by the completion-time
+ * sweep and the gate-time belt so the two enforcement points can never
+ * drift apart on what counts as "equivalent" — this is the natural
+ * identity of "the same scheduled job": a manual and a scheduled run of
+ * the same task+project+scope+dry_run ARE the same job and are meant to
+ * supersede one another. `instruction` is deliberately EXCLUDED: tasks
+ * like skill-evolve build their instruction dynamically per run (it
+ * embeds live skill state), so two runs of the same scheduled job never
+ * share an instruction string — keying equivalence on it meant a
+ * completed run could never retire that job's resumable failed runs, and
+ * they accumulated forever. `dry_run` pinning is still load-bearing: the
+ * executor restores `dryRun` on resume, so without it a completed live
+ * run would wrongly supersede or block a dry-run-scoped failed run.
  */
 function appendSupersedeEquivalenceCondition(
   conditions: string[],
   params: unknown[],
-  match: { agentId: string; taskName: string; scope: ProjectScope; dryRun: boolean; instruction: string | null },
+  match: { agentId: string; taskName: string; scope: ProjectScope; dryRun: boolean },
 ): void {
   conditions.push('agent_id = ?', 'task = ?');
   params.push(match.agentId, match.taskName);
   appendProjectCondition(conditions, params, match.scope);
   conditions.push('dry_run = ?');
   params.push(match.dryRun ? 1 : 0);
-  if (match.instruction === null) {
-    conditions.push('instruction IS NULL');
-  } else {
-    conditions.push('instruction = ?');
-    params.push(match.instruction);
-  }
 }
 
 /**
  * Completion-time supersede sweep (Part 1 primary). Called from the
  * executor's success path immediately after a run completes, with that
- * run's own (agentId, taskName, scope, dryRun, instruction) as the
- * equivalence key. Terminal-marks (`resumable=0`,
- * `resume_status='superseded'`) every OTHER currently-resumable failed run
- * matching the key — structural, no timestamp comparison needed: anything
- * still resumable when an equivalent run completes is stale BY DEFINITION,
- * because the just-completed run's dispatch necessarily started no earlier
- * than the failed run's most recent attempt. Swept runs hit the existing
+ * run's own (agentId, taskName, scope, dryRun) as the equivalence key.
+ * Terminal-marks (`resumable=0`, `resume_status='superseded'`) every OTHER
+ * currently-resumable failed run matching the key — structural, no
+ * timestamp comparison needed: anything still resumable when an
+ * equivalent run completes is stale BY DEFINITION, because the
+ * just-completed run's dispatch necessarily started no earlier than the
+ * failed run's most recent attempt. Swept runs hit the existing
  * resumable-guard 400 at the manual resume endpoint automatically
  * (agent-runs.ts).
  *
@@ -760,7 +759,7 @@ function appendSupersedeEquivalenceCondition(
  */
 export function supersedeEquivalentResumableRuns(
   excludeRunId: string,
-  match: { agentId: string; taskName: string; scope: ProjectScope; dryRun: boolean; instruction: string | null },
+  match: { agentId: string; taskName: string; scope: ProjectScope; dryRun: boolean },
 ): number {
   const db = getDatabase();
   const conditions = ['id != ?', 'resumable = 1', 'status = ?'];
@@ -793,7 +792,7 @@ export function supersedeEquivalentResumableRuns(
  */
 export function findNewerCompletedEquivalentRun(
   failedRun: Pick<RunRow, 'id' | 'started_at' | 'completed_at'>,
-  match: { agentId: string; taskName: string; scope: ProjectScope; dryRun: boolean; instruction: string | null },
+  match: { agentId: string; taskName: string; scope: ProjectScope; dryRun: boolean },
 ): RunRow | null {
   const db = getDatabase();
   const conditions = ['id != ?', 'status = ?', 'completed_at IS NOT NULL'];
@@ -816,7 +815,7 @@ export function findNewerCompletedEquivalentRun(
  */
 export function hasNewerCompletedEquivalentRun(
   failedRun: Pick<RunRow, 'id' | 'started_at' | 'completed_at'>,
-  match: { agentId: string; taskName: string; scope: ProjectScope; dryRun: boolean; instruction: string | null },
+  match: { agentId: string; taskName: string; scope: ProjectScope; dryRun: boolean },
 ): boolean {
   return findNewerCompletedEquivalentRun(failedRun, match) !== null;
 }
@@ -827,16 +826,15 @@ export function hasNewerCompletedEquivalentRun(
  * resumable rows that predate the sweep's existence (or were left behind by
  * a daemon crash before the completing run's success path ran). Terminal-
  * marks every resumable failed run F for which ANY completed run C shares
- * F's equivalence key (agent_id, task, project scope, dry_run, instruction
- * equal or both NULL) and has `completed_at` newer than F's ORIGINAL
- * dispatch (`started_at`) — same predicate as the gate-time belt
- * (`hasNewerCompletedEquivalentRun`), expressed as a single
- * correlated-EXISTS UPDATE so the whole scope sweeps in one SQL pass. A
- * completed equivalent newer than the failed run's original dispatch
- * supersedes it, resumed or not — `started_at` is stable dispatch-order
- * evidence because a resume never re-stamps it (see executor.ts).
- * `COALESCE(F.started_at, 0)` only guards a pathological NULL. Safe to run
- * on every boot: a fully-swept vault matches zero rows.
+ * F's equivalence key (agent_id, task, project scope, dry_run) and has
+ * `completed_at` newer than F's ORIGINAL dispatch (`started_at`) — same
+ * predicate as the gate-time belt (`hasNewerCompletedEquivalentRun`),
+ * expressed as a single correlated-EXISTS UPDATE so the whole scope sweeps
+ * in one SQL pass. A completed equivalent newer than the failed run's
+ * original dispatch supersedes it, resumed or not — `started_at` is stable
+ * dispatch-order evidence because a resume never re-stamps it (see
+ * executor.ts). `COALESCE(F.started_at, 0)` only guards a pathological
+ * NULL. Safe to run on every boot: a fully-swept vault matches zero rows.
  */
 export function sweepStaleSupersededRuns(scope: ProjectScope): number {
   const db = getDatabase();
@@ -861,7 +859,6 @@ export function sweepStaleSupersededRuns(scope: ProjectScope): number {
            AND C.task = F.task
            AND COALESCE(C.project_id, '') = COALESCE(F.project_id, '')
            AND C.dry_run = F.dry_run
-           AND (C.instruction = F.instruction OR (C.instruction IS NULL AND F.instruction IS NULL))
            AND C.completed_at > COALESCE(F.started_at, 0)
        )`,
   ).run(RESUME_STATUS_SUPERSEDED, STATUS_FAILED, STATUS_COMPLETED, ...outerParams);

--- a/tests/daemon/scheduled-resume-gate.test.ts
+++ b/tests/daemon/scheduled-resume-gate.test.ts
@@ -206,10 +206,9 @@ describe('gateScheduledResume', () => {
   describe('supersede belt', () => {
     it('terminal-marks a resumable run as superseded when a newer equivalent run completed, without consuming resume_attempts', () => {
       const run = insertResumableRun('run-stale-legacy', 0);
-      // A newer COMPLETED equivalent run — same agent/task/scope/dry_run/
-      // instruction (both null here), completed after the failed run's
-      // own completed_at. Simulates a legacy row written before the
-      // completion-time sweep existed.
+      // A newer COMPLETED equivalent run — same agent/task/scope/dry_run,
+      // completed after the failed run's own completed_at. Simulates a
+      // legacy row written before the completion-time sweep existed.
       insertRun({
         id: 'run-newer-completed',
         agent_id: TEST_AGENT_ID,
@@ -239,7 +238,7 @@ describe('gateScheduledResume', () => {
       expect(getLatestResumableRunForTask(TEST_AGENT_ID, TEST_TASK, ALL_PROJECTS_SCOPE)).toBeNull();
     });
 
-    it('does NOT supersede when the newer completed run has a DIFFERENT instruction', () => {
+    it('supersedes even when the newer completed run has a DIFFERENT instruction (same scheduled job, dynamic per-run instruction)', () => {
       const run = insertResumableRun('run-instr-scoped', 0);
       applyRunUpdate(run.id, { instruction: 'candidate X' }, ALL_PROJECTS_SCOPE);
       const refreshed = getRun(run.id, ALL_PROJECTS_SCOPE)!;
@@ -254,10 +253,10 @@ describe('gateScheduledResume', () => {
         completed_at: refreshed.completed_at! + 20,
       });
 
-      expect(gate(refreshed)).toBe('resume');
+      expect(gate(refreshed)).toBe('superseded');
       const after = getRun('run-instr-scoped', ALL_PROJECTS_SCOPE)!;
-      expect(after.resumable).toBe(1);
-      expect(after.resume_status).toBe(RESUME_STATUS_READY);
+      expect(after.resumable).toBe(0);
+      expect(after.resume_status).toBe(RESUME_STATUS_SUPERSEDED);
     });
 
     it('does NOT supersede a live run using a completed DRY run as the equivalent', () => {

--- a/tests/db/queries/runs-supersede.test.ts
+++ b/tests/db/queries/runs-supersede.test.ts
@@ -65,7 +65,6 @@ describe('supersedeEquivalentResumableRuns (completion-time sweep)', () => {
       taskName: TEST_TASK,
       scope: ALL_PROJECTS_SCOPE,
       dryRun: false,
-      instruction: null,
     });
 
     expect(swept).toBe(1);
@@ -85,28 +84,31 @@ describe('supersedeEquivalentResumableRuns (completion-time sweep)', () => {
       taskName: TEST_TASK,
       scope: ALL_PROJECTS_SCOPE,
       dryRun: false,
-      instruction: null,
     });
 
     expect(swept).toBe(0);
   });
 
-  it('does NOT supersede a resumable run for a DIFFERENT instruction (candidate-scoped work stays isolated)', () => {
-    const stale = insertRun(makeResumableFailed({ id: 'run-candidate-x', instruction: 'candidate X' }));
-    const completing = insertRun(makeRun({ id: 'run-candidate-y', status: 'completed', instruction: 'candidate Y' }));
+  it('PROD SCENARIO: supersedes a resumable run of the same scheduled job even when instructions differ (dynamic per-run instruction, e.g. skill-evolve embeds live skill state)', () => {
+    // Verified live on prod 1.2.12: a completed skill-evolve run retired
+    // none of 3 equivalent-job zombies because every run — completed and
+    // failed alike — carried a different dynamically-built instruction
+    // string. The scheduled-job identity is (agent_id, task, project scope,
+    // dry_run) — instruction body must NOT gate equivalence.
+    const stale = insertRun(makeResumableFailed({ id: 'run-dynamic-instr-zombie', instruction: 'Live skill state snapshot A' }));
+    const completing = insertRun(makeRun({ id: 'run-dynamic-instr-complete', status: 'completed', instruction: 'Live skill state snapshot B (different run, same job)' }));
 
     const swept = supersedeEquivalentResumableRuns(completing.id, {
       agentId: TEST_AGENT_ID,
       taskName: TEST_TASK,
       scope: ALL_PROJECTS_SCOPE,
       dryRun: false,
-      instruction: 'candidate Y',
     });
 
-    expect(swept).toBe(0);
+    expect(swept).toBe(1);
     const after = getRun(stale.id, ALL_PROJECTS_SCOPE)!;
-    expect(after.resumable).toBe(1);
-    expect(after.resume_status).toBe(RESUME_STATUS_READY);
+    expect(after.resumable).toBe(0);
+    expect(after.resume_status).toBe(RESUME_STATUS_SUPERSEDED);
   });
 
   it('supersedes when both the stale run and the completing run have NULL instruction', () => {
@@ -118,7 +120,6 @@ describe('supersedeEquivalentResumableRuns (completion-time sweep)', () => {
       taskName: TEST_TASK,
       scope: ALL_PROJECTS_SCOPE,
       dryRun: false,
-      instruction: null,
     });
 
     expect(swept).toBe(1);
@@ -134,7 +135,6 @@ describe('supersedeEquivalentResumableRuns (completion-time sweep)', () => {
       taskName: TEST_TASK,
       scope: ALL_PROJECTS_SCOPE,
       dryRun: true,
-      instruction: null,
     });
 
     expect(swept).toBe(0);
@@ -151,7 +151,6 @@ describe('supersedeEquivalentResumableRuns (completion-time sweep)', () => {
       taskName: TEST_TASK,
       scope: ALL_PROJECTS_SCOPE,
       dryRun: false,
-      instruction: null,
     });
 
     expect(getRun(otherTaskRun.id, ALL_PROJECTS_SCOPE)!.resumable).toBe(1);
@@ -167,7 +166,6 @@ describe('supersedeEquivalentResumableRuns (completion-time sweep)', () => {
       taskName: TEST_TASK,
       scope: ALL_PROJECTS_SCOPE,
       dryRun: false,
-      instruction: null,
     });
 
     expect(swept).toBe(2);
@@ -202,7 +200,7 @@ describe('sweepStaleSupersededRuns (boot-time backfill)', () => {
     expect(sweepStaleSupersededRuns(ALL_PROJECTS_SCOPE)).toBe(0);
   });
 
-  it('does not sweep a resumable run whose instruction differs from the completed run', () => {
+  it('sweeps a resumable run even when its instruction differs from the completed run (same scheduled job, dynamic per-run instruction)', () => {
     const stale = insertRun(makeResumableFailed({
       id: 'run-boot-instr-x',
       instruction: 'candidate X',
@@ -215,8 +213,8 @@ describe('sweepStaleSupersededRuns (boot-time backfill)', () => {
       completed_at: epochNow() - 50,
     }));
 
-    expect(sweepStaleSupersededRuns(ALL_PROJECTS_SCOPE)).toBe(0);
-    expect(getRun(stale.id, ALL_PROJECTS_SCOPE)!.resumable).toBe(1);
+    expect(sweepStaleSupersededRuns(ALL_PROJECTS_SCOPE)).toBe(1);
+    expect(getRun(stale.id, ALL_PROJECTS_SCOPE)!.resumable).toBe(0);
   });
 
   it('handles an interrupted run (NULL completed_at) via COALESCE fallback to started_at', () => {


### PR DESCRIPTION
## Summary
Verified live on prod 1.2.12: a completed skill-evolve retired NONE of its equivalent-job failed+resumable zombies. Root cause: `appendSupersedeEquivalenceCondition` keyed run equivalence on the full `instruction` string, but dynamic-instruction tasks (skill-evolve embeds live skill state) never produce two identical instructions — so the completion-time supersede sweep and boot sweep can never match them, and their zombies accumulate forever.

Fix: drop `instruction` from the supersede equivalence key. The identity of "the same scheduled job" is `(agent_id, task, project, scope, dry_run)`. A completed run now supersedes equivalent resumable runs regardless of instruction body.

Call sites updated: executor.ts (completion sweep), task-scheduling.ts (gate belt), agent-runs.ts (manual-resume 409 belt). `instruction` is still used to restore/store/run the task — only removed from the equivalence path.

## Over-supersede analysis (the risk)
No work is lost. The one candidate — skill-generate, where different candidates are different work — was traced: a superseded candidate stays `status='approved'` in the serialized queue (only `vault_finalize_skill` flips it), so a fresh dispatch re-picks and regenerates it; worst case is redoing a partial checkpoint. Different task/project/scope/dry_run stay isolated; `executionOverrides` was never in the key.

## Verification
- Prod-scenario test proven fail→pass (completed + resumable, same job, different instruction → superseded); over-supersede guards intact; full suite green; `make build` clean; independent review approved.
- Will be baked on prod (custom binary) and verified against unifi-mcp before the release is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)