### PR TITLE
fix(tests): gate 21 colocated src test files in the default runner

### DIFF
--- a/tests/agent/executor-state.test.ts
+++ b/tests/agent/executor-state.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
-import { aggregateUsage } from './executor-state.js';
-import { analyzeRuntimeTokenBudget } from './run-accounting.js';
-import type { RuntimeUsage } from './types.js';
+import { aggregateUsage } from '@myco/agent/executor-state.js';
+import { analyzeRuntimeTokenBudget } from '@myco/agent/run-accounting.js';
+import type { RuntimeUsage } from '@myco/agent/types.js';
 
 describe('aggregateUsage requestUsageEntries merging', () => {
   test('concatenates entries across phases rather than dropping or overwriting them', () => {

--- a/tests/agent/harness/claude.test.ts
+++ b/tests/agent/harness/claude.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
-import { consumeClaudeMessageStream } from './claude.js';
+import { consumeClaudeMessageStream } from '@myco/agent/harness/claude.js';
 import { analyzeRuntimeTokenBudget } from '@myco/agent/run-accounting.js';
 
 /**

--- a/tests/agent/phase-loop-reasoning.test.ts
+++ b/tests/agent/phase-loop-reasoning.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { resolvePhaseExecution } from './phase-resolver.js';
-import type { EffectiveConfig, PhaseDefinition } from './types.js';
+import { resolvePhaseExecution } from '@myco/agent/phase-resolver.js';
+import type { EffectiveConfig, PhaseDefinition } from '@myco/agent/types.js';
 
 /**
  * Regression guard for the reasoningLevel plumbing gap this plan closes:

--- a/tests/agent/phase-postconditions.skill-evolve.test.ts
+++ b/tests/agent/phase-postconditions.skill-evolve.test.ts
@@ -8,7 +8,7 @@ import { insertReport } from '@myco/db/queries/reports.js';
 import { setState } from '@myco/db/queries/agent-state.js';
 import { insertWriteIntent } from '@myco/db/queries/write-intents.js';
 import { epochSeconds } from '@myco/constants.js';
-import { checkPhasePostCondition, type PhasePostConditionInput } from './phase-postconditions.js';
+import { checkPhasePostCondition, type PhasePostConditionInput } from '@myco/agent/phase-postconditions.js';
 import {
   SKILL_EVOLVE_ASSESS_PHASE_NAME,
   SKILL_EVOLVE_ASSESS_REPORT_ACTION,
@@ -16,7 +16,7 @@ import {
   SKILL_EVOLVE_INVENTORY_PHASE_NAME,
   SKILL_EVOLVE_INVENTORY_REPORT_ACTION,
   SKILL_EVOLVE_INVENTORY_STATE_KEY,
-} from './skill-evolve-output.js';
+} from '@myco/agent/skill-evolve-output.js';
 
 /**
  * Coverage for the skill-evolve inventory/assess phase postconditions.

--- a/tests/agent/phase-postconditions.vault-seed.test.ts
+++ b/tests/agent/phase-postconditions.vault-seed.test.ts
@@ -6,7 +6,7 @@ import { insertRun } from '@myco/db/queries/runs.js';
 import { insertRunEvent } from '@myco/db/queries/agent-run-events.js';
 import { insertReport } from '@myco/db/queries/reports.js';
 import { epochSeconds } from '@myco/constants.js';
-import { checkPhasePostCondition, type PhasePostConditionInput } from './phase-postconditions.js';
+import { checkPhasePostCondition, type PhasePostConditionInput } from '@myco/agent/phase-postconditions.js';
 
 /**
  * Coverage for the four vault-seed phase postconditions. Each check reads

--- a/tests/agent/reasoning-levels.test.ts
+++ b/tests/agent/reasoning-levels.test.ts
@@ -4,8 +4,8 @@ import {
   resolveReasoningModel,
   resolveThinkingConfig,
   resolveModelSettings,
-} from './reasoning-levels.js';
-import type { ProviderConfig } from './types.js';
+} from '@myco/agent/reasoning-levels.js';
+import type { ProviderConfig } from '@myco/agent/types.js';
 
 describe('resolveThinkingConfig', () => {
   test('maps low to a fixed small budget by default', () => {

--- a/tests/agent/schemas-phase-purpose-field.test.ts
+++ b/tests/agent/schemas-phase-purpose-field.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { AgentTaskSchema, PhaseDefinitionSchema } from './schemas.js';
+import { AgentTaskSchema, PhaseDefinitionSchema } from '@myco/agent/schemas.js';
 
 /**
  * Coverage for the authored `purpose` field on PhaseDefinitionSchema. The

--- a/tests/agent/task-postconditions.skill-evolve.test.ts
+++ b/tests/agent/task-postconditions.skill-evolve.test.ts
@@ -7,7 +7,7 @@ import { insertRunEvent } from '@myco/db/queries/agent-run-events.js';
 import { insertReport } from '@myco/db/queries/reports.js';
 import { setState } from '@myco/db/queries/agent-state.js';
 import { epochSeconds } from '@myco/constants.js';
-import { validateTaskPostconditions } from './task-postconditions.js';
+import { validateTaskPostconditions } from '@myco/agent/task-postconditions.js';
 import {
   SKILL_EVOLVE_ASSESS_PHASE_NAME,
   SKILL_EVOLVE_ASSESS_REPORT_ACTION,
@@ -16,7 +16,7 @@ import {
   SKILL_EVOLVE_INVENTORY_REPORT_ACTION,
   SKILL_EVOLVE_INVENTORY_STATE_KEY,
   SKILL_EVOLVE_TASK_NAME,
-} from './skill-evolve-output.js';
+} from '@myco/agent/skill-evolve-output.js';
 
 /**
  * Run-end validator coverage for skill-evolve. `validateSkillEvolveRun`

--- a/tests/agent/task-postconditions.vault-seed.test.ts
+++ b/tests/agent/task-postconditions.vault-seed.test.ts
@@ -7,7 +7,7 @@ import { insertRunEvent } from '@myco/db/queries/agent-run-events.js';
 import { insertTurn } from '@myco/db/queries/turns.js';
 import { insertReport } from '@myco/db/queries/reports.js';
 import { epochSeconds } from '@myco/constants.js';
-import { validateTaskPostconditions } from './task-postconditions.js';
+import { validateTaskPostconditions } from '@myco/agent/task-postconditions.js';
 
 /**
  * Run-end validator coverage for vault-seed's skip-XOR-seed contract.

--- a/tests/agent/tools/observability-tools.test.ts
+++ b/tests/agent/tools/observability-tools.test.ts
@@ -8,8 +8,8 @@ import { listReports } from '@myco/db/queries/reports.js';
 import { epochSeconds } from '@myco/constants.js';
 import { assertGroveProjectId, createProjectId } from '@myco/grove/ids.js';
 import type { MycoRequestContext } from '@myco/grove/request-context.js';
-import { createObservabilityTools } from './observability-tools.js';
-import type { VaultToolDeps } from './types.js';
+import { createObservabilityTools } from '@myco/agent/tools/observability-tools.js';
+import type { VaultToolDeps } from '@myco/agent/tools/types.js';
 
 /**
  * Coverage for vault_report's server-side spores_created stamping. Drives

--- a/tests/agent/tools/types.test.ts
+++ b/tests/agent/tools/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { stampSporeCountInPayload } from './types.js';
+import { stampSporeCountInPayload } from '@myco/agent/tools/types.js';
 
 describe('stampSporeCountInPayload', () => {
   test('replaces spores_created when present with a different value', () => {

--- a/tests/agent/vault-seed-task.wiring.test.ts
+++ b/tests/agent/vault-seed-task.wiring.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
-import { loadAgentTasks, resolveDefinitionsDir } from './loader.js';
-import { PHASE_POSTCONDITION_KINDS } from './phase-postcondition-kinds.js';
-import { computeWaves } from './wave-computation.js';
+import { loadAgentTasks, resolveDefinitionsDir } from '@myco/agent/loader.js';
+import { PHASE_POSTCONDITION_KINDS } from '@myco/agent/phase-postcondition-kinds.js';
+import { computeWaves } from '@myco/agent/wave-computation.js';
 
 /**
  * vault-seed.yaml phase-graph wiring coverage. Asserts each phase binds

--- a/tests/cli/restart.test.ts
+++ b/tests/cli/restart.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { supervisorStatusHint } from './restart.js';
+import { supervisorStatusHint } from '@myco/cli/restart.js';
 
 const LABEL = 'co.goondocks.myco';
 

--- a/tests/config/schema-provider-override.test.ts
+++ b/tests/config/schema-provider-override.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { MycoConfigSchema } from './schema.js';
+import { MycoConfigSchema } from '@myco/config/schema.js';
 
 describe('ProviderOverrideSchema (via MycoConfigSchema.agent.provider)', () => {
   test('keeps thinking_budget_map and effort_map (Zod v4 default-strips unknown keys otherwise)', () => {

--- a/tests/config/secrets-relocate-legacy-project.test.ts
+++ b/tests/config/secrets-relocate-legacy-project.test.ts
@@ -21,7 +21,7 @@ import {
   readSecrets,
   writeSecret,
   relocateLegacyProjectSecrets,
-} from './secrets.js';
+} from '@myco/config/secrets.js';
 
 const cleanups: Array<() => void> = [];
 afterEach(() => {

--- a/tests/db/queries/agent-run-events.test.ts
+++ b/tests/db/queries/agent-run-events.test.ts
@@ -8,7 +8,7 @@ import {
   countPhaseToolCallsByOutcome,
   countRunToolCallsByOutcome,
   insertRunEvent,
-} from './agent-run-events.js';
+} from '@myco/db/queries/agent-run-events.js';
 
 describe('countRunToolCallsByOutcome', () => {
   let db: Database;

--- a/tests/grove/global-install-migration-teardown.test.ts
+++ b/tests/grove/global-install-migration-teardown.test.ts
@@ -7,9 +7,9 @@ import { describe, test, expect, afterEach } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { migrateProjectToGlobalInstall } from './global-install-migration.js';
-import { loadManifests, resolvePackageRoot } from '../symbionts/detect.js';
-import { MYCO_HOME_ENV } from './paths.js';
+import { migrateProjectToGlobalInstall } from '@myco/grove/global-install-migration.js';
+import { loadManifests, resolvePackageRoot } from '@myco/symbionts/detect.js';
+import { MYCO_HOME_ENV } from '@myco/grove/paths.js';
 
 const GEMINI_MYCO_SETTINGS = {
   hooks: {

--- a/tests/service/launchd-plist-program-arguments-spacing.test.ts
+++ b/tests/service/launchd-plist-program-arguments-spacing.test.ts
@@ -11,8 +11,8 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { renderLaunchdPlist } from './launchd-plist.js';
-import type { ServiceSpec } from './types.js';
+import { renderLaunchdPlist } from '@myco/service/launchd-plist.js';
+import type { ServiceSpec } from '@myco/service/types.js';
 
 function specWith(overrides: Partial<ServiceSpec>): ServiceSpec {
   return {

--- a/tests/service/systemd-unit-execstart-quoting.test.ts
+++ b/tests/service/systemd-unit-execstart-quoting.test.ts
@@ -9,8 +9,8 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { renderSystemdUnit } from './systemd-unit.js';
-import type { ServiceSpec } from './types.js';
+import { renderSystemdUnit } from '@myco/service/systemd-unit.js';
+import type { ServiceSpec } from '@myco/service/types.js';
 
 function specWith(overrides: Partial<ServiceSpec>): ServiceSpec {
   return {

--- a/tests/symbionts/detect-path-lookup-program.test.ts
+++ b/tests/symbionts/detect-path-lookup-program.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { pathLookupProgram } from './detect.js';
+import { pathLookupProgram } from '@myco/symbionts/detect.js';
 
 describe('pathLookupProgram', () => {
   test('uses `where` on Windows', () => {

--- a/tests/symbionts/installer/project-files.test.ts
+++ b/tests/symbionts/installer/project-files.test.ts
@@ -22,7 +22,7 @@ import {
   reconcileProjectSkillSymlinks,
   resolveEnabledSkillTargets,
   syncSkillSymlinks,
-} from './project-files.js';
+} from '@myco/symbionts/installer/project-files.js';
 
 const CLAUDE = { home: '.claude', target: '.claude/skills', name: 'claude-code' };
 const CLINE = { home: '.cline', target: '.cline/skills', name: 'cline' };


### PR DESCRIPTION
Moves 21 test files that were colocated under `packages/myco/src/` into their `tests/` mirrors so the default runner discovers and executes them (they were silently skipped). Rename-only: 21 files, +34/-34 (import-path depth adjustments only, no logic change).

Verified: full suite green on the branch — 405 pass / 0 fail across 81 files (the newly-discovered tests run and pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)