### PR TITLE
feat(skills): DB-resident content read path — lineage-latest is canonical

### DIFF
--- a/.agents/skills/author-harness-task/SKILL.md
+++ b/.agents/skills/author-harness-task/SKILL.md
@@ -230,8 +230,10 @@ Every phase execution writes to `agent_runs`:
 | Column | What it tells you |
 |--------|-------------------|
 | `exit_reason` | `budget_exhausted` / `short_circuit` / `complete` / `error` |
-| `turn_count` | LLM turns used |
+| `turn_count` | LLM turns used — for tool-heavy phases this counts API requests, not SDK turns; `actions_taken.phases[].turnsUsed` can legitimately show 21 for a 10-turn-cap phase |
 | `tool_output_summary` | Concatenated tool outputs (truncated) |
+
+For failed runs, `agent_turns.tool_input` is a fully recoverable audit trail — use it to reconstruct exactly which tool calls a phase made even when `tool_output_summary` is truncated.
 
 ### Silent failure patterns
 
@@ -240,6 +242,14 @@ Every phase execution writes to `agent_runs`:
 | `exit_reason = 'complete'` but no state change | Sentinel triggered incorrectly |
 | `turn_count = 1`, empty `tool_output_summary` | Malformed prompt or injected context |
 | Task never appears in `agent_runs` | TaskDefinition export malformed |
+
+### Postcondition gates vs. clean exit
+
+A clean `exit_reason = 'complete'` only proves the model didn't error — it does not prove the model made the load-bearing tool call. Deterministic postcondition gates (asserting a specific write occurred) catch silent-completion failures that exit-reason monitoring alone misses. A single postcondition failure can be noise; a **cluster** of postcondition failures across runs signals a prompt regression, not a one-off fluke.
+
+### STOP after terminal tool call
+
+Phases with a single terminal tool (e.g., `write_plan`, `vault_report`) need an explicit "STOP once the tool returns ok" instruction in the system prompt. Without it, the model burns remaining turn budget re-verifying an already-successful write instead of exiting cleanly.
 
 ## Procedure 8: Advanced Harness Integration
 
@@ -317,7 +327,7 @@ This prevents inconsistent or divergent behavior across the delegation hierarchy
 
 1. **Scan for installed agents**: Check agent-specific hook configurations in `.myco/`
 2. **Validate hook implementations**: Check that hook files exist and are executable
-3. **Cross-platform deployment**: Use `join(resolveMycoHome(), 'launcher.cjs')` for the cross-platform hook guard (`.agents/myco-run.cjs` is a retired project-local path)
+3. **Cross-platform deployment**: Use `join(resolveMycoHome(), 'launcher.cjs')` for the cross-platform hook guard (`.agents/myco-run.cjs` was retired by the global-install migration)
 4. **Transport protocol setup**: Configure capture channels based on agent type
 5. **Scope validation**: Ensure captured content belongs to current project
 6. **Permission checks**: Verify agent has capture rights for target files/directories
@@ -363,6 +373,6 @@ This prevents inconsistent or divergent behavior across the delegation hierarchy
 - **Session state consistency** → Always validate session status before operations — intelligence tasks must gate on session-terminal state (completed/processed) as active sessions produce stale artifacts.
 - **Cortex instructions requirement** → Lead agent MUST call `myco_cortex({op:"instructions"})` before delegating to sub-agents — delegation without instructions causes sub-agents to operate with inconsistent scope.
 - **Cortex injection uniformity** → All task phases must receive cortex context via unified injection path. Tasks that bypass cortex context propagation or re-acquire it per-phase introduce inconsistency.
-- **Cross-platform hook deployment** → The cross-platform hook guard is `join(resolveMycoHome(), 'launcher.cjs')` (exported from `packages/myco/src/grove/paths.ts`). The old `.agents/myco-run.cjs` project-local path is retired. MCP children inherit `cwd=/` from some agents — use `resolveVaultDir()` with `MYCO_VAULT_DIR` fallback.
+- **Cross-platform hook deployment** → The cross-platform hook guard is `join(resolveMycoHome(), 'launcher.cjs')` (exported from `packages/myco/src/grove/paths.ts`). The old `.agents/myco-run.cjs` project-local path was retired by the global-install migration. MCP children inherit `cwd=/` from some agents — use `resolveVaultDir()` with `MYCO_VAULT_DIR` fallback.
 - **Runtime resource management** → Agent harness execution consumes resources — implement proper cleanup. Concurrent sessions must coordinate vault database access to prevent corruption.
 - **Cortex injection is capability-gated at two levels**: A task that depends on cortex context must verify two conditions before assuming injection happened: (1) `capabilityEnabled(config, 'cortex')` from `packages/myco/src/config/capabilities.ts` returns true — the gate is fail-closed (null config → false) and reads the `cortex` capability's masterGate config leaf; (2) the relevant injection flag in the `cortex.instructions` config block — either `inject_on_session_start` or `inject_on_subagent_start` — is enabled. Both must be true. A task that assumes cortex context exists will silently operate without it when the capability is disabled or the injection flags are off.

--- a/packages/myco-collective/worker/package-lock.json
+++ b/packages/myco-collective/worker/package-lock.json
@@ -2447,7 +2447,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"

--- a/packages/myco-team/worker/package-lock.json
+++ b/packages/myco-team/worker/package-lock.json
@@ -2447,7 +2447,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"

--- a/packages/myco/src/agent/instruction-builders.ts
+++ b/packages/myco/src/agent/instruction-builders.ts
@@ -9,7 +9,6 @@
  * Each builder corresponds to a task that needs pre-assembled context.
  */
 
-import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { promises as fsPromises } from 'node:fs';
 import type { MycoConfig } from '@myco/config/schema.js';
@@ -38,6 +37,7 @@ import { getSpore, listSpores, type SporeRow } from '@myco/db/queries/spores.js'
 import { getSession } from '@myco/db/queries/sessions.js';
 import { listSkillRecords, updateSkillRecord } from '@myco/db/queries/skill-records.js';
 import { listLineageForSkill } from '@myco/db/queries/skill-lineage.js';
+import { resolveSkillContent } from '@myco/skills/content.js';
 import { listRecentSupersessions, listSupersedingSporeIds } from '@myco/db/queries/spore-supersession.js';
 import { epochSeconds } from '@myco/constants.js';
 import { shortlistSemanticIds, type SemanticShortlistProvider } from '@myco/agent/semantic-shortlist.js';
@@ -608,17 +608,17 @@ export async function buildSkillEvolveInstruction(
   }
 
   // ----- Structural analysis: section counts + heading extraction -----
-  // Read each skill's content from disk and extract H2 headings.
-  // This gives the inventory phase mechanical signals for narrow/merge
-  // detection that don't depend on LLM judgment.
+  // Read each skill's content and extract H2 headings. This gives the
+  // inventory phase mechanical signals for narrow/merge detection that
+  // don't depend on LLM judgment. Content is cached per skill id because
+  // the drift inputs below reuse it.
   const structures: SkillStructure[] = [];
   const skillHeadings = new Map<string, string[]>();
+  const skillContents = new Map<string, string>();
   if (projectRoot) {
     for (const skill of allSkills) {
-      let content = '';
-      if (skill.path) {
-        try { content = readFileSync(resolve(projectRoot, skill.path), 'utf-8'); } catch { /* missing */ }
-      }
+      const content = resolveSkillContent({ record: skill, projectRoot }) ?? '';
+      skillContents.set(skill.id, content);
       const headings = extractHeadings(content);
       skillHeadings.set(skill.name, headings);
       structures.push({
@@ -675,7 +675,10 @@ export async function buildSkillEvolveInstruction(
       const tsB = typeof propsB.last_verified_at === 'number' ? propsB.last_verified_at : 0;
       return tsA - tsB;
     })
-    .slice(0, 5);
+    .slice(0, 5)
+    // Drift verifies the same content the structural pass read; projectRoot
+    // stays in the call for codebase claim/symbol verification.
+    .map((skill) => ({ ...skill, content: skillContents.get(skill.id) }));
   const drift = projectRoot
     ? detectDrift(oldestForVerify, projectRoot, nowEpoch)
     : {

--- a/packages/myco/src/agent/skill-drift.ts
+++ b/packages/myco/src/agent/skill-drift.ts
@@ -7,6 +7,13 @@ export interface SkillDriftInput {
   description: string;
   path: string;
   properties: string;
+  /**
+   * Skill body to verify — lineage-latest from the caller. When absent, the
+   * published file at `path` is read instead (legacy records with no
+   * lineage). `projectRoot` is still required either way: claim and symbol
+   * verification greps the codebase, not the skill.
+   */
+  content?: string;
 }
 
 export interface SkillFileFingerprint {
@@ -354,12 +361,13 @@ export function detectDrift(
   const allSymbols = new Set<string>();
 
   for (const skill of skills) {
-    const absPath = resolve(projectRoot, skill.path);
-    let content = '';
-    try {
-      content = readFileSync(absPath, 'utf-8');
-    } catch {
-      content = '';
+    let content = skill.content ?? '';
+    if (!content) {
+      try {
+        content = readFileSync(resolve(projectRoot, skill.path), 'utf-8');
+      } catch {
+        content = '';
+      }
     }
     skillContents.set(skill.id, content);
     const claims = extractClaims(content);

--- a/packages/myco/src/agent/tools/skill-tools.ts
+++ b/packages/myco/src/agent/tools/skill-tools.ts
@@ -29,8 +29,7 @@
  */
 
 import crypto from 'node:crypto';
-import { readFileSync, existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync } from 'node:fs';
 import { z } from 'zod/v4';
 import { tool } from '@anthropic-ai/claude-agent-sdk';
 import { epochSeconds, DEFAULT_LIST_LIMIT } from '@myco/constants.js';
@@ -46,6 +45,7 @@ import {
   type SkillRecordRow,
 } from '@myco/db/queries/skill-records.js';
 import { insertLineage } from '@myco/db/queries/skill-lineage.js';
+import { resolveSkillContent } from '@myco/skills/content.js';
 import { notify } from '@myco/notifications/notify.js';
 import {
   CANDIDATE_STATUS,
@@ -1562,15 +1562,10 @@ export function createSkillTools(deps: VaultToolDeps) {
           if (!args.id) return textResult({ error: 'id is required for get action' });
           const record = getSkillRecord(args.id, scope) ?? getSkillRecordByName(args.id, scope);
           if (!record) return textResult({ error: `Skill record not found: ${args.id}` });
-          // Include file content so evolve/merge operations can read skill bodies
+          // Include content so evolve/merge operations can read skill bodies.
           const result: Record<string, unknown> = { ...record };
-          if (record.path && projectRoot) {
-            try {
-              result.content = readFileSync(resolve(projectRoot, record.path), 'utf-8');
-            } catch {
-              // File missing — return record without content
-            }
-          }
+          const content = resolveSkillContent({ record, projectRoot });
+          if (content !== null) result.content = content;
           return textResult(result);
         }
 
@@ -1687,11 +1682,10 @@ export function createSkillTools(deps: VaultToolDeps) {
 
         const root = projectRoot ?? process.cwd();
 
-        // Look up the on-disk prior content the same way vault_write_skill does.
-        const resolvedPaths = resolvePublishedSkillPaths(root, args.name);
-        const priorContent = resolvedPaths.ok && existsSync(resolvedPaths.paths.skillPath)
-          ? readFileSync(resolvedPaths.paths.skillPath, 'utf-8')
-          : undefined;
+        // Resolve prior content the same way vault_write_skill does.
+        const gateRecord = getSkillRecordByName(args.name, scope);
+        const priorContent = resolveSkillContent({ record: gateRecord, name: args.name, projectRoot: root })
+          ?? undefined;
 
         const { issues, violations, claim, descWindow } = collectSkillWriteIssues({
           content: args.content,
@@ -1741,7 +1735,8 @@ export function createSkillTools(deps: VaultToolDeps) {
     async (args) => {
       // Traversal guard — must run before ANY filesystem access.
       // publishedSkillRelativePath() is unsanitized string interpolation;
-      // a name with '..' must never reach resolvePublishedSkillPaths or readFileSync.
+      // a name with '..' must never reach resolvePublishedSkillPaths or
+      // any filesystem read.
       if (!args.name || /[/\\]|\.\./.test(args.name)) {
         return textResult({
           error: 'Invalid skill name: must be a simple directory name without path separators or ".."',
@@ -1770,11 +1765,12 @@ export function createSkillTools(deps: VaultToolDeps) {
         return textResult({ error: 'Invalid skill name: resolved path escapes .agents/skills' });
       }
 
-      // Read prior content once — used by the preservation gate, the description
-      // window, the fabrication gate, and the evolve-path rollback.
-      const priorContent = existsSync(resolvedPaths.paths.skillPath)
-        ? readFileSync(resolvedPaths.paths.skillPath, 'utf-8')
-        : undefined;
+      // Resolve prior content once — used by the preservation gate, the
+      // description window, the fabrication gate, and the evolve-path
+      // rollback. Lineage-latest is canonical for managed skills; a
+      // hand-edited or missing file never becomes the gate/rollback baseline.
+      const priorContent = resolveSkillContent({ record: existing, name: args.name, projectRoot: root })
+        ?? undefined;
 
       // Run all content-validation gates in one pass and batch every failure.
       // The agent previously saw at most one class of error per attempt; now it
@@ -1873,17 +1869,20 @@ export function createSkillTools(deps: VaultToolDeps) {
       }
 
       // Evolve path: delegate to the shared writeEvolvedSkill helper.
-      // priorContent was already read above; reuse it to avoid a second
-      // disk read. If the file was absent despite a DB record existing
-      // (orphan), fall back to re-reading — this will throw if still
-      // missing, preserving the same behavior as before.
-      const priorSkillContent = priorContent ?? readFileSync(resolvedPaths.paths.skillPath, 'utf-8');
+      // priorContent covers a record whose SKILL.md is missing locally
+      // (synced from another machine); a record with no content anywhere
+      // has nothing to evolve from.
+      if (priorContent === undefined) {
+        return textResult({
+          error: `Skill "${args.name}" has no stored content and no on-disk SKILL.md — cannot evolve.`,
+        });
+      }
 
       const evolveResult = await writeEvolvedSkill({
         existing,
         name: args.name,
         content: args.content,
-        priorContent: priorSkillContent,
+        priorContent,
         display_name: args.display_name,
         description: args.description,
         source_ids: args.source_ids,
@@ -2150,11 +2149,12 @@ export function createSkillTools(deps: VaultToolDeps) {
       }
 
       const root = projectRoot ?? process.cwd();
-      const resolvedPaths = resolvePublishedSkillPaths(root, args.name);
-      if (!resolvedPaths.ok || !existsSync(resolvedPaths.paths.skillPath)) {
-        return textResult({ error: `Skill "${args.name}" has no on-disk SKILL.md to edit.` });
+      // Edit base: lineage-latest is canonical, so a record whose SKILL.md
+      // is missing locally (synced from another machine) is still editable.
+      const priorContent = resolveSkillContent({ record: existing, projectRoot: root });
+      if (priorContent === null) {
+        return textResult({ error: `Skill "${args.name}" has no stored content and no on-disk SKILL.md to edit.` });
       }
-      const priorContent = readFileSync(resolvedPaths.paths.skillPath, 'utf-8');
 
       // Shared per-skill circuit breaker — mirror vault_write_skill's check-before-increment
       // ordering: check the count first, then increment on failure. Defers on the 4th failure.

--- a/packages/myco/src/agent/tools/skill-validator.ts
+++ b/packages/myco/src/agent/tools/skill-validator.ts
@@ -67,6 +67,29 @@ function normalizeFrontmatterValue(value: unknown): string | undefined {
 }
 
 /**
+ * Extract every frontmatter field from SKILL.md content as a normalized
+ * string map (arrays join to comma-separated lists, scalars stringify).
+ * Returns an empty map when no parseable frontmatter block exists. This is
+ * the same YAML parse the write gates use, so read-side consumers (e.g. the
+ * daemon skill-detail endpoint) see the fields exactly as validation does.
+ */
+export function extractFrontmatterFields(content: string): Record<string, string> {
+  const fields: Record<string, string> = {};
+  let parsed: ParsedFrontmatter | null = null;
+  try {
+    parsed = parseFrontmatter(content);
+  } catch {
+    return fields;
+  }
+  if (!parsed) return fields;
+  for (const [key, value] of Object.entries(parsed)) {
+    const normalized = normalizeFrontmatterValue(value);
+    if (normalized !== undefined) fields[key] = normalized;
+  }
+  return fields;
+}
+
+/**
  * Extract a frontmatter field value from SKILL.md content.
  * Returns the raw value string, or undefined if not found.
  */

--- a/packages/myco/src/daemon/api/skills.ts
+++ b/packages/myco/src/daemon/api/skills.ts
@@ -31,12 +31,13 @@ import {
   getSkillRecordByName,
   deleteSkillRecordCascade,
 } from '@myco/db/queries/skill-records.js';
-import { listLineageForSkill } from '@myco/db/queries/skill-lineage.js';
+import { getPublishedSkillContent, listLineageForSkill } from '@myco/db/queries/skill-lineage.js';
 import { countUsageForSkill } from '@myco/db/queries/skill-usage.js';
 import { CANDIDATE_STATUS, REST_SETTABLE_STATUSES } from '@myco/constants/skill-candidate-status.js';
 import { parseCsvList } from '@myco/utils/parse-csv-list.js';
 import { projectScope, type GroveProjectId, type ProjectScope } from '@myco/grove/ids.js';
 import { validateSkillCandidateQualityContract } from '@myco/agent/skill-candidate-quality.js';
+import { extractFrontmatterFields } from '@myco/agent/tools/skill-validator.js';
 import { isSafeSkillNameForFs } from '@myco/skills/names.js';
 import {
   removePublishedSkillFileOrDirectory,
@@ -308,22 +309,15 @@ export async function handleGetSkillRecord(req: RouteRequest, principal: Request
   const lineage = listLineageForSkill(record.id, scope, 50);
   const usage_total = countUsageForSkill(record.id);
 
-  // Parse frontmatter from latest lineage snapshot so the UI avoids client-side regex
-  const latestSnapshot = lineage[0]?.content_snapshot;
-  const frontmatterFields: Record<string, string> = {};
-  if (latestSnapshot) {
-    const fmMatch = latestSnapshot.match(/^---\n([\s\S]*?)\n---/);
-    if (fmMatch) {
-      for (const line of fmMatch[1].split('\n')) {
-        const colonIdx = line.indexOf(':');
-        if (colonIdx > 0) {
-          const key = line.slice(0, colonIdx).trim();
-          const val = line.slice(colonIdx + 1).trim();
-          if (key && val) frontmatterFields[key] = val;
-        }
-      }
-    }
-  }
+  // Parse frontmatter from the latest snapshot with the same YAML parse the
+  // write gates use, so the UI shows the fields exactly as validation sees
+  // them. The tenant-scoped history list already holds the latest row in
+  // the dominant path; the unscoped-by-id read recovers content when legacy
+  // lineage rows carry a project_id the tenant scope filters out.
+  const latestSnapshot = lineage[0]?.content_snapshot ?? getPublishedSkillContent(record) ?? undefined;
+  const frontmatterFields: Record<string, string> = latestSnapshot
+    ? extractFrontmatterFields(latestSnapshot)
+    : {};
 
   return { status: 200, body: { ...record, lineage, usage_total, frontmatter: frontmatterFields } };
 }

--- a/packages/myco/src/daemon/api/team-connect.ts
+++ b/packages/myco/src/daemon/api/team-connect.ts
@@ -21,7 +21,9 @@ import {
   LOCAL_ONLY_OUTBOX_TABLES,
   LOCAL_ONLY_SYNC_COLUMNS,
   LOCAL_ONLY_RATIONALES,
+  RECONCILE_ELIGIBLE_TABLES,
 } from '@myco/db/queries/team-outbox.js';
+import { tablesGatedByWorkerProtocol } from '@myco/db/schema-ddl.js';
 import { markSelfMemberUnsynced } from '@myco/db/queries/team-members.js';
 import { searchLogs, type LogEntryRow } from '@myco/db/queries/logs.js';
 import { readJsonConfig, resolveVaultConfigPath } from '@myco-deploy/index.js';
@@ -659,6 +661,14 @@ export function createTeamHandlers(deps: TeamHandlerDeps) {
         daemon_protocol_version: SYNC_PROTOCOL_VERSION,
         worker_protocol_version: client?.getWorkerProtocolVersion() ?? null,
         worker_min_client_version: client?.getWorkerMinClientVersion() ?? null,
+        // Tables the reconcile pass is skipping because the deployed worker
+        // predates them — computed by the SAME helper the reconcile gate
+        // uses, so this disclosure and the actual behavior cannot drift.
+        // Empty when the worker is current or unprobed.
+        reconcile_gated_tables: tablesGatedByWorkerProtocol(
+          RECONCILE_ELIGIBLE_TABLES,
+          client?.getWorkerProtocolVersion(),
+        ),
         mcp_token: client?.getMcpToken() ?? null,
         mcp_endpoint: client?.getMcpEndpoint() ?? null,
         mcp_healthy: healthy && workerHasMcpToken,

--- a/packages/myco/src/daemon/team-sync-init.ts
+++ b/packages/myco/src/daemon/team-sync-init.ts
@@ -56,7 +56,7 @@ import {
   sanitizeSyncPayload,
   RECONCILE_ELIGIBLE_TABLES,
 } from '@myco/db/queries/team-outbox.js';
-import { tableMinSyncProtocol } from '@myco/db/schema-ddl.js';
+import { tablesGatedByWorkerProtocol } from '@myco/db/schema-ddl.js';
 import {
   reconcilePartition as reconcilePartitionImplDefault,
   createReconcileFlushMutex,
@@ -958,12 +958,10 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
         // handling applies, same as before.
         await teamVersionStatus(teamId, client);
         const workerProtocol = client.getWorkerProtocolVersion();
-        const skippedTables: string[] = [];
+        const skippedTables = tablesGatedByWorkerProtocol(RECONCILE_ELIGIBLE_TABLES, workerProtocol);
+        const gatedTables = new Set(skippedTables);
         for (const table of RECONCILE_ELIGIBLE_TABLES) {
-          if (workerProtocol !== undefined && tableMinSyncProtocol(table) > workerProtocol) {
-            skippedTables.push(table);
-            continue;
-          }
+          if (gatedTables.has(table)) continue;
           try {
             await reconcilePartition(
               { ...baseDeps, client },

--- a/packages/myco/src/daemon/team-sync-init.ts
+++ b/packages/myco/src/daemon/team-sync-init.ts
@@ -56,6 +56,7 @@ import {
   sanitizeSyncPayload,
   RECONCILE_ELIGIBLE_TABLES,
 } from '@myco/db/queries/team-outbox.js';
+import { tableMinSyncProtocol } from '@myco/db/schema-ddl.js';
 import {
   reconcilePartition as reconcilePartitionImplDefault,
   createReconcileFlushMutex,
@@ -946,7 +947,23 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
         // No reachable/configured team worker for this project this pass — skip
         // (its rows stay as-is for a later pass), never delete on a missing peer.
         if (!client) continue;
+
+        // Version-floor obedience, per table (mirrors the drain gate): a
+        // worker deployed before a table's protocol version rejects its name
+        // with 400 "Unknown or ineligible table" on every manifest request,
+        // so skip those tables this pass — they self-heal on the first cycle
+        // after the worker updates. teamVersionStatus probes health() (cached)
+        // so the advertised protocol is populated; an unprobed/unreachable
+        // worker leaves it undefined and the normal per-partition error
+        // handling applies, same as before.
+        await teamVersionStatus(teamId, client);
+        const workerProtocol = client.getWorkerProtocolVersion();
+        const skippedTables: string[] = [];
         for (const table of RECONCILE_ELIGIBLE_TABLES) {
+          if (workerProtocol !== undefined && tableMinSyncProtocol(table) > workerProtocol) {
+            skippedTables.push(table);
+            continue;
+          }
           try {
             await reconcilePartition(
               { ...baseDeps, client },
@@ -960,6 +977,19 @@ export function initTeamSync(deps: TeamSyncDeps): TeamSyncResult {
               error: (partitionErr as Error).message,
             });
           }
+        }
+        if (skippedTables.length > 0) {
+          logger.warn(
+            LOG_KINDS.TEAM_SYNC_ERROR,
+            'Skipping reconcile for tables newer than the worker protocol (self-heals after worker update)',
+            {
+              team_id: teamId,
+              project_id: projectId,
+              skipped_tables: skippedTables,
+              daemon_protocol: SYNC_PROTOCOL_VERSION,
+              worker_protocol: workerProtocol,
+            },
+          );
         }
       }
     } catch (err) {

--- a/packages/myco/src/db/queries/skill-lineage.ts
+++ b/packages/myco/src/db/queries/skill-lineage.ts
@@ -11,6 +11,7 @@
 
 import { getDatabase } from '@myco/db/client.js';
 import { appendProjectCondition, type ProjectScope } from '@myco/db/queries/project-scope.js';
+import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
 import { syncRow } from '@myco/db/queries/team-outbox.js';
 import { getTeamMachineId } from '@myco/team/context.js';
 
@@ -130,8 +131,9 @@ export function insertLineage(data: LineageInsert): LineageRow {
 }
 
 /**
- * List all lineage entries for a skill, ordered by generation DESC
- * (newest generation first).
+ * List all lineage entries for a skill, newest generation first. The
+ * created_at/id tiebreakers keep the order deterministic when team sync
+ * lands two rows with the same generation from different machines.
  */
 export function listLineageForSkill(
   skillId: string,
@@ -147,9 +149,28 @@ export function listLineageForSkill(
     `SELECT ${SELECT_COLUMNS}
      FROM skill_lineage
      WHERE ${conditions.join(' AND ')}
-     ORDER BY generation DESC
+     ORDER BY generation DESC, created_at DESC, id DESC
      LIMIT ?`,
   ).all(...params, limit) as Record<string, unknown>[];
 
   return rows.map(toLineageRow);
+}
+
+/**
+ * Canonical published content for a skill: the latest lineage snapshot.
+ *
+ * Lineage is the source of truth for skill content (`skill_records` carries
+ * only metadata + path; the on-disk SKILL.md is a materialization). The read
+ * is deliberately unscoped: `skill_id` is a UUID foreign key to a record the
+ * caller already fetched under its own tenancy scope, and lineage
+ * `project_id` is denormalized routing metadata that legacy backfills can
+ * leave NULL — a project filter here can only hide this skill's own history.
+ *
+ * Returns null when the skill has no lineage rows or the latest snapshot is
+ * empty (callers fall back to the published file for those).
+ */
+export function getPublishedSkillContent(record: { id: string }): string | null {
+  const rows = listLineageForSkill(record.id, ALL_PROJECTS_SCOPE, 1);
+  const snapshot = rows[0]?.content_snapshot;
+  return snapshot ? snapshot : null;
 }

--- a/packages/myco/src/db/schema-ddl.ts
+++ b/packages/myco/src/db/schema-ddl.ts
@@ -1114,6 +1114,23 @@ export function tableMinSyncProtocol(table: string): number {
 }
 
 /**
+ * The subset of `tables` a worker at `workerProtocol` cannot serve (its
+ * deployment predates them). Single source for BOTH the reconcile gate
+ * (skip these tables this pass) and the Team status disclosure
+ * (`reconcile_gated_tables`) — the behavior and what the UI reports come
+ * from one computation and cannot drift. An unprobed worker (undefined /
+ * null) gates nothing: reachability problems surface through the normal
+ * per-partition error handling, not this filter.
+ */
+export function tablesGatedByWorkerProtocol(
+  tables: readonly string[],
+  workerProtocol: number | undefined | null,
+): string[] {
+  if (workerProtocol === undefined || workerProtocol === null) return [];
+  return tables.filter((table) => tableMinSyncProtocol(table) > workerProtocol);
+}
+
+/**
  * Team-sync delete triggers — one per synced table.
  *
  * Auto-journal every local delete into `team_outbox` so the one-way push

--- a/packages/myco/src/db/schema-ddl.ts
+++ b/packages/myco/src/db/schema-ddl.ts
@@ -1092,6 +1092,28 @@ export const TEAM_SYNC_OBSERVED_TABLES = [
 export type TeamSyncObservedTable = (typeof TEAM_SYNC_OBSERVED_TABLES)[number];
 
 /**
+ * Sync-protocol version each synced table first shipped in. Any per-table
+ * request to the team worker (reconcile manifests, rebuilds) must skip
+ * tables newer than the worker's advertised protocol — an older deployed
+ * worker rejects unknown table names (400 "Unknown or ineligible table"),
+ * and retrying them every cycle churns until the worker is redeployed.
+ * Tables absent from this map predate versioned table additions (protocol 1).
+ * Every SYNC_PROTOCOL_VERSION bump that adds tables MUST add them here
+ * (see the version history on SYNC_PROTOCOL_VERSION in constants.ts).
+ */
+export const TABLE_MIN_SYNC_PROTOCOL: Readonly<Record<string, number>> = {
+  skill_lineage: 3,
+  okf_generations: 3,
+  okf_pages: 3,
+  okf_page_revisions: 3,
+};
+
+/** Minimum worker sync-protocol version required to reference `table`. */
+export function tableMinSyncProtocol(table: string): number {
+  return TABLE_MIN_SYNC_PROTOCOL[table] ?? 1;
+}
+
+/**
  * Team-sync delete triggers — one per synced table.
  *
  * Auto-journal every local delete into `team_outbox` so the one-way push

--- a/packages/myco/src/skills/content.ts
+++ b/packages/myco/src/skills/content.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Goondocks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { getPublishedSkillContent } from '@myco/db/queries/skill-lineage.js';
+import { resolvePublishedSkillPaths } from './publication.js';
+
+/**
+ * Single resolution rule for published skill content.
+ *
+ * Lineage-latest is canonical when the skill has a record; the materialized
+ * SKILL.md covers hand-authored skills (no record) and legacy records with
+ * no lineage rows. The disk read uses the canonical name-derived path —
+ * `skill_records.path` is metadata, and every managed writer sets it to the
+ * same derived value, so the name is the one source the file lookup trusts.
+ *
+ * Returns null when the skill has no content anywhere.
+ */
+export function resolveSkillContent(params: {
+  record?: { id: string; name: string } | null;
+  /** Skill directory name for record-less (hand-authored) disk reads. */
+  name?: string;
+  projectRoot?: string | null;
+}): string | null {
+  const snapshot = params.record ? getPublishedSkillContent(params.record) : null;
+  if (snapshot) return snapshot;
+
+  const name = params.record?.name ?? params.name;
+  if (!params.projectRoot || !name) return null;
+
+  const resolved = resolvePublishedSkillPaths(params.projectRoot, name);
+  if (!resolved.ok || !existsSync(resolved.paths.skillPath)) return null;
+  try {
+    return readFileSync(resolved.paths.skillPath, 'utf-8');
+  } catch {
+    return null;
+  }
+}

--- a/packages/myco/src/skills/publication.ts
+++ b/packages/myco/src/skills/publication.ts
@@ -66,6 +66,13 @@ export function resolvePublishedSkillPaths(projectRoot: string, skillName: strin
   };
 }
 
+/**
+ * Materialization chokepoint: every published SKILL.md disk write flows
+ * through this function, and relocating the materialization step requires
+ * that to stay true. Content truth is `skill_lineage.content_snapshot`;
+ * the file written here is the delivery copy coding agents load. Delete
+ * side: `removePublishedSkillFileOrDirectory` below.
+ */
 export function writePublishedSkillFile(
   projectRoot: string,
   skillName: string,

--- a/packages/myco/ui/src/hooks/use-team.ts
+++ b/packages/myco/ui/src/hooks/use-team.ts
@@ -56,6 +56,8 @@ export interface TeamStatusResponse {
   daemon_protocol_version: number;
   worker_protocol_version: number | null;
   worker_min_client_version: number | null;
+  /** Tables reconcile is skipping because the deployed worker predates them. */
+  reconcile_gated_tables: string[];
 }
 
 export function teamSuffix(teamId?: string): string {

--- a/packages/myco/ui/src/pages/Team/index.tsx
+++ b/packages/myco/ui/src/pages/Team/index.tsx
@@ -59,6 +59,36 @@ function VersionBlockBanner({ status }: { status: TeamStatusResponse }) {
   );
 }
 
+/**
+ * Partial degradation companion to VersionBlockBanner: the worker accepts
+ * this daemon (sync is NOT paused) but its deployment predates some synced
+ * tables, so the reconcile pass skips them until the worker updates. Warns
+ * (ochre) rather than alerts, with the same actionable worker-update
+ * command. Renders nothing when the worker is current — and yields to the
+ * hard-block banner, which owns the page when sync is fully paused.
+ */
+function PartialSyncBanner({ status }: { status: TeamStatusResponse }) {
+  const gated = status.reconcile_gated_tables ?? [];
+  if (gated.length === 0) return null;
+  if (status.version_status === 'client_too_old' || status.version_status === 'worker_too_old') {
+    return null;
+  }
+  const command = `myco-team update --team-id ${status.team_id ?? '<team_id>'}`;
+  return (
+    <AccentSurface accent="ochre" padded className="mb-4 flex items-start gap-3" role="status">
+      <AlertTriangle className="size-5 shrink-0 text-ochre" aria-hidden />
+      <div className="flex flex-col gap-1">
+        <p className="m-0 text-sm font-medium text-on-surface">Partial sync — the team worker is behind this daemon</p>
+        <p className="m-0 text-sm text-on-surface-variant">
+          Not reconciling: <code className="text-ochre">{gated.join(', ')}</code> (worker protocol
+          v{status.worker_protocol_version ?? '?'}, daemon v{status.daemon_protocol_version}). Local
+          data is held safely; run <code className="text-ochre">{command}</code> to resume full sync.
+        </p>
+      </div>
+    </AccentSurface>
+  );
+}
+
 const TEAM_SELECTION_KEY = 'myco.team.selectedTeamId';
 
 export function TeamPage() {
@@ -145,6 +175,7 @@ export function TeamPage() {
         actions={teamScopeSelector}
       />
       <VersionBlockBanner status={status} />
+      <PartialSyncBanner status={status} />
       <TileTabs
         tabs={TABS}
         activeTab={tab}

--- a/tests/agent/instruction-builders.test.ts
+++ b/tests/agent/instruction-builders.test.ts
@@ -70,6 +70,7 @@ function createSkillWithWatermark(
   watermark: number,
   lastAssessedAt?: number,
   description?: string,
+  contentSnapshot?: string,
 ): string {
   const id = `skill-${name}`;
   const now = epochSeconds();
@@ -88,13 +89,16 @@ function createSkillWithWatermark(
       last_assessed_at: lastAssessedAt ?? 0,
     }),
   });
+  // Lineage-latest is the canonical content the builder reads — tests that
+  // care about structure/drift must put the real body here, not on disk.
   insertLineage({
     id: `lineage-${name}`,
     skill_id: id,
     generation: 1,
     action: 'created',
     rationale: 'test',
-    content_snapshot: `---\nname: myco:${name}\ndescription: Test\nmanaged_by: myco\nuser-invocable: true\nallowed-tools: Read, Grep\n---\n# ${name}`,
+    content_snapshot: contentSnapshot
+      ?? `---\nname: myco:${name}\ndescription: Test\nmanaged_by: myco\nuser-invocable: true\nallowed-tools: Read, Grep\n---\n# ${name}`,
     created_at: now,
   });
   return id;
@@ -435,13 +439,14 @@ describe('buildSkillEvolveInstruction', () => {
 
   it('returns undefined when all signals are zero with projectRoot', async () => {
     const now = epochSeconds();
-    createSkillWithWatermark('steady-skill', now + 1000, 0, 'Steady skill');
+    const steadyContent = '# Steady\n## Scope\nNo code refs.\n## Procedure\nNo changes.\n';
+    createSkillWithWatermark('steady-skill', now + 1000, 0, 'Steady skill', steadyContent);
 
     const root = mkdtempSync(join(tmpdir(), 'myco-evolve-'));
     mkdirSync(join(root, '.agents', 'skills', 'steady-skill'), { recursive: true });
     writeFileSync(
       join(root, '.agents', 'skills', 'steady-skill', 'SKILL.md'),
-      '# Steady\n## Scope\nNo code refs.\n## Procedure\nNo changes.\n',
+      steadyContent,
     );
 
     const result = await buildSkillEvolveInstruction({}, root, undefined, TEST_REQUEST_CONTEXT);

--- a/tests/agent/skill-validator.test.ts
+++ b/tests/agent/skill-validator.test.ts
@@ -16,7 +16,7 @@
 
 import { describe, expect, it } from 'bun:test';
 
-import { checkFrontmatterPreservation, MAX_SKILL_DESCRIPTION_CHARS } from '@myco/agent/tools/skill-validator.js';
+import { checkFrontmatterPreservation, extractFrontmatterFields, MAX_SKILL_DESCRIPTION_CHARS } from '@myco/agent/tools/skill-validator.js';
 import { descriptionHardContaminationLength } from '@myco/agent/tools/skill-contamination.js';
 
 /** Build valid SKILL.md content with the given description and optional body. */
@@ -149,5 +149,32 @@ describe('descriptionHardContaminationLength', () => {
     );
 
     expect(descriptionHardContaminationLength(content)).toBe(0);
+  });
+});
+
+describe('extractFrontmatterFields', () => {
+  it('parses block-list and quoted-colon values the way the write gates do', () => {
+    const content = [
+      '---',
+      'name: myco:block-list-skill',
+      'description: "Covers: block lists"',
+      'allowed-tools:',
+      '  - Read',
+      '  - Grep',
+      'user-invocable: true',
+      '---',
+      '',
+      '# Body',
+    ].join('\n');
+
+    const fields = extractFrontmatterFields(content);
+    expect(fields.name).toBe('myco:block-list-skill');
+    expect(fields.description).toBe('Covers: block lists');
+    expect(fields['allowed-tools']).toBe('Read, Grep');
+    expect(fields['user-invocable']).toBe('true');
+  });
+
+  it('returns an empty map for content without frontmatter', () => {
+    expect(extractFrontmatterFields('# Just a body\n')).toEqual({});
   });
 });

--- a/tests/agent/tools-skills.test.ts
+++ b/tests/agent/tools-skills.test.ts
@@ -4393,4 +4393,124 @@ describe('vault skill tools', () => {
       expect((await runEdit('run-brk', 'edit-brk', bad)).deferred).toBe(true); // 4
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // DB-resident content: skill_lineage.content_snapshot is the canonical
+  // published content; the on-disk SKILL.md is a materialization of it.
+  // ---------------------------------------------------------------------------
+
+  describe('DB-resident content (lineage-latest canonical)', () => {
+    /** Create a skill through the real tool so lineage rows exist. */
+    async function createSkill(name: string, body: string): Promise<string> {
+      const t = findTool(tools, 'vault_write_skill');
+      const res = parseResult(await t.handler(
+        {
+          name,
+          display_name: name,
+          description: `DB residency test skill ${name}`,
+          content: validSkillContent(name, body),
+        },
+        undefined,
+      )) as { id?: string; error?: string };
+      expect(res.error).toBeUndefined();
+      return res.id as string;
+    }
+
+    function skillFilePath(name: string): string {
+      return path.join(tmpDir, '.agents', 'skills', name, 'SKILL.md');
+    }
+
+    it('get returns lineage content when the published file is missing', async () => {
+      await createSkill('db-res-get', '# DB Res Get\n\nBody from lineage.');
+      fs.rmSync(skillFilePath('db-res-get'));
+
+      const t = findTool(tools, 'vault_skill_records');
+      const rec = parseResult(await t.handler({ action: 'get', id: 'db-res-get' }, undefined)) as { content?: string };
+      expect(rec.content).toContain('Body from lineage.');
+    });
+
+    it('get returns lineage content, not a hand-edited file (managed skills are DB-owned)', async () => {
+      await createSkill('db-res-owned', '# Owned\n\nCanonical body.');
+      fs.writeFileSync(
+        skillFilePath('db-res-owned'),
+        validSkillContent('db-res-owned', '# Owned\n\nHand edit.'),
+        'utf-8',
+      );
+
+      const t = findTool(tools, 'vault_skill_records');
+      const rec = parseResult(await t.handler({ action: 'get', id: 'db-res-owned' }, undefined)) as { content?: string };
+      expect(rec.content).toContain('Canonical body.');
+      expect(rec.content).not.toContain('Hand edit.');
+    });
+
+    it('evolve succeeds and re-materializes the file when it is missing locally', async () => {
+      await createSkill('db-res-evolve', '# Evolve\n\nGen one body.');
+      fs.rmSync(skillFilePath('db-res-evolve'));
+
+      const t = findTool(tools, 'vault_write_skill');
+      const res = parseResult(await t.handler(
+        {
+          name: 'db-res-evolve',
+          display_name: 'db-res-evolve',
+          description: 'DB residency test skill db-res-evolve',
+          content: validSkillContent('db-res-evolve', '# Evolve\n\nGen two body.'),
+        },
+        undefined,
+      )) as { generation?: number; error?: string };
+      expect(res.error).toBeUndefined();
+      expect(res.generation).toBe(2);
+      expect(fs.readFileSync(skillFilePath('db-res-evolve'), 'utf-8')).toContain('Gen two body.');
+    });
+
+    it('edit succeeds when the published file is missing locally', async () => {
+      await createSkill('db-res-edit', '# Edit\n\neditable line.');
+      fs.rmSync(skillFilePath('db-res-edit'));
+
+      const t = findTool(tools, 'vault_edit_skill');
+      const res = parseResult(await t.handler(
+        { name: 'db-res-edit', edits: [{ old_string: 'editable line.', new_string: 'edited line.' }] },
+        undefined,
+      )) as { generation?: number; error?: string };
+      expect(res.error).toBeUndefined();
+      expect(res.generation).toBe(2);
+      expect(fs.readFileSync(skillFilePath('db-res-edit'), 'utf-8')).toContain('edited line.');
+    });
+
+    it('failed evolve rolls the file back to lineage-latest, not a hand edit', async () => {
+      const id = await createSkill('db-res-rollback', '# Rollback\n\nCanonical body.');
+      // Manual edits to managed skills are unsupported: the rollback baseline
+      // is the DB snapshot, so the hand edit must NOT survive a failed evolve.
+      fs.writeFileSync(
+        skillFilePath('db-res-rollback'),
+        validSkillContent('db-res-rollback', '# Rollback\n\nHand edit.'),
+        'utf-8',
+      );
+
+      const db = getDatabase();
+      db.exec(
+        `CREATE TRIGGER fail_lineage BEFORE INSERT ON skill_lineage
+         WHEN NEW.skill_id = '${id}'
+         BEGIN SELECT RAISE(ABORT, 'forced failure'); END`,
+      );
+      try {
+        const t = findTool(tools, 'vault_write_skill');
+        const res = parseResult(await t.handler(
+          {
+            name: 'db-res-rollback',
+            display_name: 'db-res-rollback',
+            description: 'DB residency test skill db-res-rollback',
+            content: validSkillContent('db-res-rollback', '# Rollback\n\nGen two body.'),
+          },
+          undefined,
+        )) as { error?: string };
+        expect(res.error).toContain('rolled back');
+      } finally {
+        db.exec('DROP TRIGGER IF EXISTS fail_lineage');
+      }
+
+      const after = fs.readFileSync(skillFilePath('db-res-rollback'), 'utf-8');
+      expect(after).toContain('Canonical body.');
+      expect(after).not.toContain('Hand edit.');
+    });
+  });
 });

--- a/tests/daemon/api/team-connect-status.test.ts
+++ b/tests/daemon/api/team-connect-status.test.ts
@@ -299,12 +299,91 @@ describe('createTeamHandlers.handleStatus', () => {
       daemon_protocol_version: number;
       worker_protocol_version: number | null;
       worker_min_client_version: number | null;
+      reconcile_gated_tables: string[];
     };
 
     expect(body.version_status).toBe('client_too_old');
     expect(body.worker_protocol_version).toBe(3);
     expect(body.worker_min_client_version).toBe(2);
     expect(body.daemon_protocol_version).toBeGreaterThan(0);
+    // Worker at protocol 3 serves every synced table — nothing gated.
+    expect(body.reconcile_gated_tables).toEqual([]);
+  });
+
+  it('surfaces reconcile_gated_tables when the worker predates newer synced tables', async () => {
+    const { createTeamHandlers } = await import('../../../packages/myco/src/daemon/api/team-connect.js');
+    const { createGrove } = await import('../../../packages/myco/src/grove/registry.js');
+    const { teamRegistry } = await import('../../../packages/myco/src/team/registry.js');
+    const { createTeamId, createProjectId } = await import('../../../packages/myco/src/grove/ids.js');
+    const { resolveGroveDir } = await import('../../../packages/myco/src/grove/paths.js');
+
+    const mycoHome = process.env.MYCO_HOME!;
+    const grove = createGrove('Partial Skew Grove', mycoHome);
+    const projectId = createProjectId();
+    const teamId = createTeamId();
+    teamRegistry.save({
+      team_id: teamId,
+      name: 'Partial Skew Team',
+      worker_url: 'https://myco-team-test.example.workers.dev',
+      domain: null,
+      mcp_endpoint: null,
+      created_at: new Date().toISOString(),
+      projects: [{ grove_id: grove.id, project_id: projectId }],
+    });
+    const groveDir = resolveGroveDir(grove.id, mycoHome);
+    fs.mkdirSync(groveDir, { recursive: true });
+    teamRegistry.writeSecret(teamId, 'MYCO_TEAM_API_KEY', 'test-api-key');
+
+    // The partial-degradation middle state: the worker ACCEPTS this client
+    // (sync not paused) but its deployment predates the protocol-3 tables,
+    // so reconcile skips them. The status payload must disclose exactly
+    // which tables — from the same helper the reconcile gate uses.
+    const handlers = createTeamHandlers({
+      vaultDir,
+      machineId: 'machine-test',
+      globalPrefix: null,
+      logger: { debug: () => undefined, info: () => undefined, warn: () => undefined, error: () => undefined },
+      getTeamClient: () => ({
+        health: async () => ({
+          status: 'ok',
+          node_count: 1,
+          sync_protocol_version: 2,
+          min_compat_client_version: 1,
+        }),
+        getCollectiveStatus: async () => ({
+          connected: false, collective_url: null, project_id: null,
+          last_settings_sync: null, last_heartbeat: null, capabilities: [], settings: {},
+        }),
+        getConfig: async () => ({ config: {}, sync_protocol_version: 2 }),
+        getVersionCompat: () => 'ok',
+        getWorkerProtocolVersion: () => 2,
+        getWorkerMinClientVersion: () => 1,
+        getMcpToken: () => null,
+        getMcpEndpoint: () => null,
+      }) as never,
+    });
+
+    const response = await handlers.handleStatus({
+      requestContext: {
+        projectRoot: path.join(tempDir, 'project'),
+        projectVaultDir: vaultDir,
+        projectId,
+        groveId: grove.id,
+        machineId: 'machine-test',
+        sessionId: null,
+        databasePath: path.join(mycoHome, 'groves', grove.id, 'myco.db'),
+        source: 'headers',
+      },
+    } as never);
+    const body = response.body as {
+      version_status: string;
+      reconcile_gated_tables: string[];
+    };
+
+    expect(body.version_status).toBe('ok');
+    expect(new Set(body.reconcile_gated_tables)).toEqual(
+      new Set(['skill_lineage', 'okf_generations', 'okf_pages', 'okf_page_revisions']),
+    );
   });
 
   it('reports enabled=false when the Grove participates in no team (registry gate)', async () => {

--- a/tests/daemon/team-reconcile-triggers.test.ts
+++ b/tests/daemon/team-reconcile-triggers.test.ts
@@ -6,8 +6,10 @@ import { vi } from '../helpers/vi-shim.js';
 import { initTeamSync } from '@myco/daemon/team-sync-init.js';
 
 // Reconcile-eligible table allow-list the trigger pass iterates. Mocked to a
-// small set so call counts stay legible (real list is 13 project-scoped tables).
-const MOCK_RECONCILE_TABLES = ['sessions', 'spores'];
+// small set so call counts stay legible (real list is 13+ project-scoped
+// tables). skill_lineage is included as a protocol-3 table so the
+// worker-version gate has something to skip when the worker is older.
+const MOCK_RECONCILE_TABLES = ['sessions', 'spores', 'skill_lineage'];
 
 /**
  * Drain the microtask + timer queues so a FIRE-AND-FORGET reconcile pass
@@ -20,6 +22,7 @@ async function flushAsync(times = 3): Promise<void> {
 }
 
 const {
+  getWorkerProtocolVersionMock,
   enqueueBatchMock,
   listPendingMock,
   backfillUnsyncedMock,
@@ -47,6 +50,7 @@ const {
   enqueueOutboxMock: vi.fn(),
   enqueueProjectRemovalTombstonesMock: vi.fn(() => ({ enqueued: 0, reset: 0 })),
   forEachGroveMock: vi.fn(),
+  getWorkerProtocolVersionMock: vi.fn((): number | undefined => 3),
 }));
 
 mock.module('@myco/db/queries/team-outbox.js', () => ({
@@ -92,7 +96,7 @@ mock.module('@myco/daemon/team-sync.js', () => ({
     enqueueBatch = enqueueBatchMock;
     health = vi.fn();
     getVersionCompat = vi.fn(() => 'unknown');
-    getWorkerProtocolVersion = vi.fn(() => 3);
+    getWorkerProtocolVersion = getWorkerProtocolVersionMock;
     supportsManifest = vi.fn(() => true);
     getManifest = vi.fn();
   },
@@ -140,6 +144,8 @@ describe('team-sync reconcile triggers', () => {
     // clearAllMocks resets call history but NOT implementations, so restore the
     // default no-op pass here (the throwing-reconcile test overrides it).
     reconcilePartitionSpy.mockImplementation(async () => {});
+    // Same restore for the worker protocol probe (version-gate tests override).
+    getWorkerProtocolVersionMock.mockImplementation(() => 3);
     // Default fan-out: replay whatever scopes the test registered.
     forEachGroveMock.mockImplementation(
       async (
@@ -240,8 +246,8 @@ describe('team-sync reconcile triggers', () => {
     // settle before counting partition reconciles.
     await flushAsync();
 
-    // 2 projects × 2 eligible tables = 4 partition reconciles.
-    expect(reconcilePartitionSpy).toHaveBeenCalledTimes(4);
+    // 2 projects × 3 eligible tables = 6 partition reconciles.
+    expect(reconcilePartitionSpy).toHaveBeenCalledTimes(6);
     const args = reconcileArgs();
     expect(new Set(args.map((a) => a.projectId))).toEqual(new Set(['p-a', 'p-b']));
     expect(new Set(args.map((a) => a.table))).toEqual(new Set(MOCK_RECONCILE_TABLES));
@@ -267,8 +273,8 @@ describe('team-sync reconcile triggers', () => {
 
     await reconcileJob!.fn({ sliceBudget: { maxItems: 0, softDeadlineMs: 0 } });
 
-    // 2 groves × 1 project × 2 tables = 4 partition reconciles.
-    expect(reconcilePartitionSpy).toHaveBeenCalledTimes(4);
+    // 2 groves × 1 project × 3 tables = 6 partition reconciles.
+    expect(reconcilePartitionSpy).toHaveBeenCalledTimes(6);
     const args = reconcileArgs();
     expect(new Set(args.map((a2) => a2.projectId))).toEqual(new Set(['p-a', 'p-b']));
     // The backstop always forces a full diff to catch equal-count / different-set
@@ -327,15 +333,15 @@ describe('team-sync reconcile triggers', () => {
     await teamSync.reconcileClient(requestContext(grove.id, 'p-a'));
     await flushAsync();
 
-    // Exactly ONE poll-path pass ran (count-first; 2 projects × 2 tables = 4), not two.
+    // Exactly ONE poll-path pass ran (count-first; 2 projects × 3 tables = 6), not two.
     const pollPath = reconcileArgs().filter((a) => a.forceFullDiff === false);
-    expect(pollPath.length).toBe(4);
+    expect(pollPath.length).toBe(6);
 
     // The on-demand path bypasses the throttle entirely: it runs immediately even
     // though a poll-path pass just executed for the same grove. It full-diffs.
     await teamSync.reconcileAllGroves({} as never);
     const onDemand = reconcileArgs().filter((a) => a.forceFullDiff === true);
-    expect(onDemand.length).toBe(4);
+    expect(onDemand.length).toBe(6);
   });
 
   it('a throwing reconcile pass does not propagate out of reconcileClient and does not break the flush', async () => {
@@ -386,5 +392,39 @@ describe('team-sync reconcile triggers', () => {
     const args = reconcileArgs();
     expect(args.length).toBeGreaterThan(0);
     expect(args.every((a2) => a2.forceFullDiff === false)).toBe(true);
+  });
+
+  it('skips tables newer than the worker protocol and warns once per team', async () => {
+    // Worker advertises protocol 2 — skill_lineage (protocol 3) must be
+    // skipped instead of hammering the worker with 400s every cycle.
+    getWorkerProtocolVersionMock.mockImplementation(() => 2);
+    const { grove } = await registerGroveWithProjects('old-worker-grove', ['p-ow']);
+    const teamSync = makeTeamSync();
+
+    await teamSync.reconcileClient(requestContext(grove.id, 'p-ow'));
+    await flushAsync();
+
+    const tables = reconcileArgs().map((a) => a.table);
+    expect(new Set(tables)).toEqual(new Set(['sessions', 'spores']));
+    expect(tables).not.toContain('skill_lineage');
+    const warn = logger.warn.mock.calls.find(
+      (c) => String((c as unknown[])[1]).includes('newer than the worker protocol'),
+    );
+    expect(warn).toBeDefined();
+    expect(((warn as unknown[])[2] as { skipped_tables: string[] }).skipped_tables).toEqual(['skill_lineage']);
+  });
+
+  it('reconciles every table when the worker protocol is unprobed', async () => {
+    // An unreachable/unprobed worker leaves the version undefined — the gate
+    // stays open and the normal per-partition error handling applies.
+    getWorkerProtocolVersionMock.mockImplementation(() => undefined);
+    const { grove } = await registerGroveWithProjects('unprobed-grove', ['p-up']);
+    const teamSync = makeTeamSync();
+
+    await teamSync.reconcileClient(requestContext(grove.id, 'p-up'));
+    await flushAsync();
+
+    const tables = reconcileArgs().map((a) => a.table);
+    expect(new Set(tables)).toEqual(new Set(MOCK_RECONCILE_TABLES));
   });
 });

--- a/tests/db/synced-table-parity.test.ts
+++ b/tests/db/synced-table-parity.test.ts
@@ -35,7 +35,7 @@ import {
   TEAM_SYNC_BACKFILL_TABLES,
   REBUILD_TABLES,
 } from '@myco/db/queries/team-outbox.js';
-import { TEAM_DELETE_TRIGGER_TABLES } from '@myco/db/schema-ddl.js';
+import { TEAM_DELETE_TRIGGER_TABLES, TABLE_MIN_SYNC_PROTOCOL, tablesGatedByWorkerProtocol } from '@myco/db/schema-ddl.js';
 // Relative import (not a tsconfig path alias) so the bun runner resolves the
 // real worker module. We import from the dependency-free `synced-tables`
 // module, NOT `index.ts`: index.ts transitively imports `agents/mcp` →
@@ -246,5 +246,21 @@ describe('synced-table scope: derivation is wired to SYNCED_TABLE_SCOPE', () => 
       (t) => SYNCED_TABLE_SCOPE[t] === 'machine',
     );
     expect([...MACHINE_SCOPED_TABLES].sort()).toEqual([...machineFromScope].sort());
+  });
+});
+
+describe('per-table sync-protocol floors (TABLE_MIN_SYNC_PROTOCOL)', () => {
+  it('every table with a protocol floor is a real synced table (no typos)', () => {
+    for (const table of Object.keys(TABLE_MIN_SYNC_PROTOCOL)) {
+      expect(worker.has(table)).toBe(true);
+    }
+  });
+
+  it('tablesGatedByWorkerProtocol gates protocol-3 tables against an older worker and nothing against a current or unprobed one', () => {
+    const tables = ['sessions', 'spores', 'skill_lineage', 'okf_pages'];
+    expect(tablesGatedByWorkerProtocol(tables, 2)).toEqual(['skill_lineage', 'okf_pages']);
+    expect(tablesGatedByWorkerProtocol(tables, 3)).toEqual([]);
+    expect(tablesGatedByWorkerProtocol(tables, undefined)).toEqual([]);
+    expect(tablesGatedByWorkerProtocol(tables, null)).toEqual([]);
   });
 });


### PR DESCRIPTION
## What

Skill content now resolves from `skill_lineage.content_snapshot` (the team-synced source of truth) instead of the on-disk SKILL.md. The published file remains the fallback for hand-authored skills (no `skill_records` row) and legacy records without lineage. Implements Phases 1–2 of Myco plan `1b20afee0e3bbad2` (Skills full DB-residency), post 3-persona plan review.

## How

- **`resolveSkillContent()`** (`packages/myco/src/skills/content.ts`) — the single resolution rule: lineage-latest when a record exists, else the name-derived published file. Serves `vault_skill_records` get, the contamination full gate, `vault_write_skill`, `vault_edit_skill`, and the skill-evolve instruction builder.
- **`getPublishedSkillContent()`** (db/queries/skill-lineage.ts) — latest snapshot by `skill_id`, deliberately unscoped: the record is already tenancy-checked by the caller, and lineage `project_id` is denormalized metadata legacy backfills can leave NULL. Empty snapshots normalize to null. Lineage ordering gains `created_at, id` tiebreakers so same-generation rows from team sync resolve deterministically.
- **`detectDrift`** takes content in (`SkillDriftInput.content`), retaining `projectRoot` for codebase symbol verification; the evolve builder feeds both structural analysis and drift from one cached content map.
- **Daemon skill detail** parses frontmatter with the same YAML parse the write gates use (`extractFrontmatterFields`), replacing a colon-split loop that mis-read block lists and quoted colons.
- **`writePublishedSkillFile`** documented as the single materialization chokepoint (claim-system seam).

## Behavior changes

- File-less records (synced from another machine, or locally deleted files) are now readable, evolvable, and editable — the cross-machine case this work exists for.
- Managed skills are DB-owned (decision spore `3602040a`): a hand-edited published SKILL.md is no longer the gate/rollback baseline and is overwritten by the next evolution. Hand-authored skills (no record) are untouched and still disk-read.
- Failed evolve rolls the file back to lineage-latest.

## Testing

- 7 new tests: file-less get/evolve/edit, hand-edit non-authority, forced-tx-failure rollback baseline, block-list frontmatter parse.
- `make build` green (lint + tsc + fast tests + bundle); all touched suites pass (agent tools-skills 123, instruction-builders 51, drift/daemon/db/integration/smoke).
- Orphan inventory over all real Grove vaults: 52 skill records, zero without scope-matching lineage.
- NOT yet live-smoked against a running daemon (plan's dogfood gate) — recommend the dogfood pass from the root tree after merge, per the safe-dogfood sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)