### PR TITLE
feat(claims): publication-validity coupling — Publish reappears for missing published skills

### DIFF
--- a/packages/myco/src/constants/log-kinds.ts
+++ b/packages/myco/src/constants/log-kinds.ts
@@ -140,6 +140,8 @@ export const LOG_KINDS = {
   CONTENT_CLAIM_MATERIALIZE: 'content_claim.materialize',
   // Content claim system (Team Host WS2) — terminal-row retention prune
   CONTENT_CLAIM_PRUNE: 'content_claim.prune',
+  // Content claim system (Team Host PR-1) — member disk-truth file-status route
+  CONTENT_CLAIM_FILE_STATUS: 'content_claim.file_status',
 
   // Backup
   BACKUP_START: 'backup.start',

--- a/packages/myco/src/daemon/api/content-claims-file-status.ts
+++ b/packages/myco/src/daemon/api/content-claims-file-status.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 Goondocks.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Content claim system — member disk truth (design §2(b)).
+ *
+ *   POST /api/content-claims/file-status   { project_root, artifacts: [{ artifact_kind, artifact_id, name }] }
+ *
+ * Reports, per requested artifact, whether its expected file is present in
+ * the CALLING member's own working tree. Read-only sibling of the
+ * materialize route (`content-claims-materialize.ts`): same
+ * `resolveMemberProjectContext` prelude, same `localhost-only` posture (a
+ * disk-presence check is scoped to the member's own checkout, never proxied
+ * to the host), but this route never writes. `host/routing.ts` stamps it
+ * alongside materialize, sharing its capability so the two travel together.
+ *
+ * The UI merges this "disk truth" with the inventory route's (`content-claims.ts`
+ * `published` array) "DB truth" to re-offer Publish for a published skill whose
+ * file was deleted from the working tree (e.g. by `git rm` or a branch switch).
+ */
+import fs from 'node:fs';
+
+import { resolvePublishedSkillPaths } from '@myco/skills/publication.js';
+
+import type { ProxyLogger } from '../host-proxy.js';
+import type { RouteHandler, RouteRegistrar, RouteResponse } from '../router.js';
+import { errorBody } from './error-envelope.js';
+import { resolveMemberProjectContext } from './member-project-context.js';
+
+/** Requests larger than this are rejected outright (413) before any
+ *  per-artifact work — a batch this size is never a legitimate UI call. */
+const MAX_ARTIFACTS = 1000;
+
+interface FileStatusArtifactInput {
+  artifact_kind?: unknown;
+  artifact_id?: unknown;
+  name?: unknown;
+}
+
+interface FileStatusResult {
+  artifact_kind: unknown;
+  artifact_id: unknown;
+  file_present: boolean | null;
+}
+
+function asRecord(body: unknown): Record<string, unknown> {
+  return body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+}
+
+function asArtifactsArray(body: Record<string, unknown>): FileStatusArtifactInput[] {
+  const raw = body.artifacts;
+  return Array.isArray(raw) ? (raw as FileStatusArtifactInput[]) : [];
+}
+
+/**
+ * Disk-presence check for one requested artifact. Never throws: an unknown
+ * kind degrades to `null` silently (a routine, expected shape — e.g. an
+ * `okf_page` entry sent through the same batch, which this route does not
+ * yet cover); a resolver refusal (traversal/absolute/empty name) or any
+ * other per-artifact failure degrades to `null` with exactly one `warn` log.
+ * Either way a bad entry never fails the batch.
+ */
+function fileStatusForArtifact(
+  currentRoot: string,
+  artifact: FileStatusArtifactInput,
+  logger: ProxyLogger,
+): boolean | null {
+  if (artifact.artifact_kind !== 'skill') return null;
+
+  try {
+    if (typeof artifact.name !== 'string' || artifact.name.length === 0) {
+      logger.warn('file-status: refused a skill artifact with a non-string or empty name', {
+        artifact_id: artifact.artifact_id,
+      });
+      return null;
+    }
+
+    const resolved = resolvePublishedSkillPaths(currentRoot, artifact.name);
+    if (!resolved.ok) {
+      logger.warn('file-status: resolver refused a published skill path', {
+        artifact_id: artifact.artifact_id,
+        reason: resolved.reason,
+      });
+      return null;
+    }
+
+    return fs.existsSync(resolved.paths.skillPath);
+  } catch (err) {
+    logger.warn('file-status: unexpected failure checking a published skill path', {
+      artifact_id: artifact.artifact_id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+export interface ContentClaimFileStatusDeps {
+  logger: ProxyLogger;
+  mycoHome?: string;
+}
+
+export function createContentClaimFileStatusHandler(deps: ContentClaimFileStatusDeps): RouteHandler {
+  return async (req): Promise<RouteResponse> => {
+    const body = asRecord(req.body);
+
+    const context = await resolveMemberProjectContext(req, body, deps.mycoHome);
+    if ('status' in context) {
+      return context;
+    }
+
+    const artifacts = asArtifactsArray(body);
+    if (artifacts.length > MAX_ARTIFACTS) {
+      return {
+        status: 413,
+        body: errorBody('too_many_artifacts', `At most ${MAX_ARTIFACTS} artifacts may be checked per request.`),
+      };
+    }
+
+    const statuses: FileStatusResult[] = artifacts.map((artifact) => ({
+      artifact_kind: artifact.artifact_kind,
+      artifact_id: artifact.artifact_id,
+      file_present: fileStatusForArtifact(context.currentRoot, artifact, deps.logger),
+    }));
+
+    return { status: 200, body: { statuses } };
+  };
+}
+
+/** Register the file-status route on the daemon server. */
+export function registerContentClaimFileStatusRoute(
+  server: RouteRegistrar,
+  deps: ContentClaimFileStatusDeps,
+): void {
+  server.registerRoute('POST', '/api/content-claims/file-status', createContentClaimFileStatusHandler(deps));
+}

--- a/packages/myco/src/daemon/api/content-claims-file-status.ts
+++ b/packages/myco/src/daemon/api/content-claims-file-status.ts
@@ -60,9 +60,16 @@ function asRecord(body: unknown): Record<string, unknown> {
   return body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
 }
 
-function asArtifactsArray(body: Record<string, unknown>): FileStatusArtifactInput[] {
+function asArtifactsArray(body: Record<string, unknown>): unknown[] {
   const raw = body.artifacts;
-  return Array.isArray(raw) ? (raw as FileStatusArtifactInput[]) : [];
+  return Array.isArray(raw) ? raw : [];
+}
+
+/** A batch entry that isn't a plain object (null, string, number, boolean,
+ *  array) carries no artifact identity at all — distinct from a well-formed
+ *  entry with a bad field, which still echoes its own kind/id. */
+function isArtifactObject(entry: unknown): entry is FileStatusArtifactInput {
+  return !!entry && typeof entry === 'object' && !Array.isArray(entry);
 }
 
 /**
@@ -78,9 +85,9 @@ function fileStatusForArtifact(
   artifact: FileStatusArtifactInput,
   logger: ProxyLogger,
 ): boolean | null {
-  if (artifact.artifact_kind !== 'skill') return null;
-
   try {
+    if (artifact.artifact_kind !== 'skill') return null;
+
     if (typeof artifact.name !== 'string' || artifact.name.length === 0) {
       logger.warn('file-status: refused a skill artifact with a non-string or empty name', {
         artifact_id: artifact.artifact_id,
@@ -107,6 +114,26 @@ function fileStatusForArtifact(
   }
 }
 
+/**
+ * One response entry per request entry, index-aligned. A non-object entry
+ * (e.g. a literal `null` in the artifacts array) has no identity to echo —
+ * it degrades to `{artifact_kind: null, artifact_id: null, file_present: null}`
+ * with one `warn` log, keeping the batch alive and the alignment intact.
+ */
+function statusForEntry(currentRoot: string, entry: unknown, logger: ProxyLogger): FileStatusResult {
+  if (!isArtifactObject(entry)) {
+    logger.warn('file-status: refused a non-object artifact entry', {
+      entry_type: entry === null ? 'null' : Array.isArray(entry) ? 'array' : typeof entry,
+    });
+    return { artifact_kind: null, artifact_id: null, file_present: null };
+  }
+  return {
+    artifact_kind: entry.artifact_kind ?? null,
+    artifact_id: entry.artifact_id ?? null,
+    file_present: fileStatusForArtifact(currentRoot, entry, logger),
+  };
+}
+
 export interface ContentClaimFileStatusDeps {
   logger: ProxyLogger;
   mycoHome?: string;
@@ -129,11 +156,8 @@ export function createContentClaimFileStatusHandler(deps: ContentClaimFileStatus
       };
     }
 
-    const statuses: FileStatusResult[] = artifacts.map((artifact) => ({
-      artifact_kind: artifact.artifact_kind,
-      artifact_id: artifact.artifact_id,
-      file_present: fileStatusForArtifact(context.currentRoot, artifact, deps.logger),
-    }));
+    const statuses: FileStatusResult[] = artifacts.map((entry) =>
+      statusForEntry(context.currentRoot, entry, deps.logger));
 
     return { status: 200, body: { statuses } };
   };

--- a/packages/myco/src/daemon/api/content-claims-materialize.ts
+++ b/packages/myco/src/daemon/api/content-claims-materialize.ts
@@ -38,8 +38,18 @@
  * (mirroring `attached-config.ts`'s `fetchHostGroveConfig`) rather than
  * proxying the whole request — the member needs the claim state and content
  * snapshot as data to decide whether to write, not a relayed response body.
- * One `dialHostJson` transport backs every remote read below (skill content,
- * OKF content) — a second one must never be added.
+ * One `dialHostJson` transport backs every remote call below (skill content,
+ * OKF content, and the republish auto-close's mark-published POST) — a
+ * second one must never be added.
+ *
+ * Republish auto-close (spec §2(c)): after a successful write, if the
+ * claim's own generation equals the artifact's already-recorded
+ * `published_generation`, the write IS a republish of already-published
+ * content (e.g. the published file was deleted from disk/git and the user
+ * re-claimed at the same, unchanged generation) — the claim closes in the
+ * same request rather than dangling as an invisible lock. A first-time
+ * publish or a materialize at a newer generation leaves the claim `active`
+ * for the existing manual Mark-published flow.
  *
  * Two artifact kinds write through the SAME orchestration (spec §0: "one
  * mechanism, unified across skills + OKF + kin"): `skill` runs the two
@@ -59,10 +69,15 @@ import {
   HOST_PROXY_CONNECT_TIMEOUT_MS,
   HOST_PROXY_HEADERS_TIMEOUT_MS,
   HOST_PROXY_MAX_BUFFERED_BODY_BYTES,
+  epochSeconds,
 } from '@myco/constants.js';
 import { loadMergedConfig, loadAttachedMergedConfig } from '@myco/config/loader.js';
 import { withDatabase, type Database } from '@myco/db/client.js';
-import { getContentClaimById } from '@myco/db/queries/content-claims.js';
+import {
+  getContentClaimById,
+  getContentPublication,
+  markContentClaimPublished,
+} from '@myco/db/queries/content-claims.js';
 import { getSkillContentAtGeneration } from '@myco/db/queries/skill-lineage.js';
 import { getSkillRecord } from '@myco/db/queries/skill-records.js';
 import { getOkfPageById, getOkfPageRevisionAtGeneration } from '@myco/db/queries/okf.js';
@@ -114,9 +129,26 @@ export interface ClaimSource {
   getActiveClaim(claimId: string): Promise<ResolvedClaim | null>;
   getSkillContent(artifactId: string, generation: number): Promise<SkillContent | null>;
   getOkfPageContent(artifactId: string, generation: number): Promise<OkfPageContent | null>;
+  /** The durable `published_generation` already on record for this artifact,
+   *  or null if it has never been published. Read AFTER a successful write to
+   *  decide republish auto-close (spec §2(c)): never throws — a resolution
+   *  failure degrades to null (no auto-close) rather than failing the write
+   *  that already landed. */
+  getPublishedGeneration(artifactKind: string, artifactId: string): Promise<number | null>;
+  /** Marks the claim published through the branch's pinned close path
+   *  (local: `markContentClaimPublished`; attached: the host's `POST
+   *  /api/content-claims/:id/published`). Returns true on success, false on
+   *  any failure — never throws, so a bookkeeping failure after a successful
+   *  disk write never turns into a failed materialize response. */
+  markPublished(claimId: string): Promise<boolean>;
 }
 
-function localClaimSource(db: Database, scope: ProjectScope): ClaimSource {
+function localClaimSource(
+  db: Database,
+  scope: ProjectScope,
+  machineId: string,
+  logger: ProxyLogger,
+): ClaimSource {
   return {
     async getActiveClaim(claimId) {
       return withDatabase(db, () => {
@@ -146,6 +178,36 @@ function localClaimSource(db: Database, scope: ProjectScope): ClaimSource {
         return revision ? { path: page.path, frontmatter: revision.frontmatter, body: revision.body } : null;
       });
     },
+    async getPublishedGeneration(artifactKind, artifactId) {
+      try {
+        return withDatabase(db, () => getContentPublication(artifactKind, artifactId)?.published_generation ?? null);
+      } catch (err) {
+        logger.warn('materialize: local publication-row read failed during auto-close check', {
+          artifact_kind: artifactKind,
+          artifact_id: artifactId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return null;
+      }
+    },
+    async markPublished(claimId) {
+      try {
+        return withDatabase(db, () => {
+          const result = markContentClaimPublished(claimId, {
+            publishedAt: epochSeconds(),
+            publishedBy: machineId,
+            machineId,
+          });
+          return result !== null;
+        });
+      } catch (err) {
+        logger.warn('materialize: local mark-published call failed during auto-close', {
+          claim_id: claimId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return false;
+      }
+    },
   };
 }
 
@@ -156,6 +218,15 @@ interface ContentClaimsListBody {
     artifact_id: string;
     generation: number;
     state: string;
+  }>;
+  /** The inventory's already-published-at-latest artifacts (Task 1.2). Reused
+   *  here, from the SAME dial `getActiveClaim` already makes, as the attached
+   *  branch's publication read for the republish auto-close check — no second
+   *  host surface. */
+  published?: Array<{
+    artifact_kind: string;
+    artifact_id: string;
+    published_generation: number;
   }>;
 }
 
@@ -170,17 +241,25 @@ interface OkfPageRevisionsBody {
 }
 
 /**
- * One-shot GET against the host over the overlay, returning the parsed JSON
- * body alongside the status code — or null on any transport failure
+ * One-shot request against the host over the overlay, returning the parsed
+ * JSON body alongside the status code — or null on any transport failure
  * (unreachable, timeout, oversized, unparseable). Deliberately does not
  * special-case non-2xx: callers need to see a 404 body (e.g. a deleted skill
  * record) to render the right materialize failure, not have it degrade
  * silently the way a config read (which always has a sane default) does.
+ *
+ * Defaults to GET with no body; a caller doing the republish auto-close's
+ * mark-published call passes `method: 'POST'` and, when the target route
+ * needs one, `body` (JSON-serialized and given a `content-length`/
+ * `content-type` so the host's mutating-body CSRF gate accepts it) and
+ * `machineId` (stamped as `REQUEST_CONTEXT_HEADERS.machineId` so the host
+ * attributes the write to the calling member, not itself).
  */
 function dialHostJson<T>(
   target: RemoteTarget,
   pathname: string,
   dial: Dialer,
+  options: { method?: string; body?: unknown; machineId?: string } = {},
 ): Promise<{ status: number; body: T } | null> {
   return new Promise((resolve) => {
     let settled = false;
@@ -190,17 +269,24 @@ function dialHostJson<T>(
       resolve(value);
     };
 
+    const method = options.method ?? 'GET';
+    const bodyBytes = options.body !== undefined ? Buffer.from(JSON.stringify(options.body), 'utf-8') : null;
+
     let dialed: http.ClientRequest | Promise<http.ClientRequest>;
     try {
       dialed = dial(target, {
-        method: 'GET',
+        method,
         path: pathname,
         headers: {
           authorization: `Bearer ${target.bearer}`,
           [HOST_PROTOCOL_HEADER]: String(HOST_PROTOCOL_VERSION),
           [REQUEST_CONTEXT_HEADERS.groveId]: target.groveId,
           [REQUEST_CONTEXT_HEADERS.projectId]: target.projectId,
+          ...(options.machineId ? { [REQUEST_CONTEXT_HEADERS.machineId]: options.machineId } : {}),
           accept: 'application/json',
+          ...(bodyBytes
+            ? { 'content-type': 'application/json', 'content-length': String(bodyBytes.length) }
+            : {}),
         },
       });
     } catch {
@@ -237,12 +323,21 @@ function dialHostJson<T>(
           }
         });
       });
+      if (bodyBytes) proxyReq.write(bodyBytes);
       proxyReq.end();
     }).catch(() => done(null));
   });
 }
 
-function remoteClaimSource(target: RemoteTarget, dial: Dialer, logger: ProxyLogger): ClaimSource {
+function remoteClaimSource(target: RemoteTarget, dial: Dialer, logger: ProxyLogger, machineId: string): ClaimSource {
+  // Populated by every `getActiveClaim` dial from that SAME response's
+  // `published[]` array — the republish auto-close check below reads this
+  // cache instead of issuing a second `/api/content-claims` dial ("one dial
+  // covers claim state and publication row"). `getActiveClaim` runs at least
+  // once, and immediately before the write (spec §4 step 3), before the
+  // auto-close check ever runs, so the cache is always fresh by then.
+  let lastPublicationByKey: Map<string, number> | null = null;
+
   return {
     async getActiveClaim(claimId) {
       const result = await dialHostJson<ContentClaimsListBody>(target, '/api/content-claims', dial);
@@ -251,9 +346,16 @@ function remoteClaimSource(target: RemoteTarget, dial: Dialer, logger: ProxyLogg
           host_id: target.host.host_id,
           claim_id: claimId,
         });
+        lastPublicationByKey = null;
         return null;
       }
-      if (result.status !== 200) return null;
+      if (result.status !== 200) {
+        lastPublicationByKey = null;
+        return null;
+      }
+      lastPublicationByKey = new Map(
+        (result.body.published ?? []).map((p) => [`${p.artifact_kind}:${p.artifact_id}`, p.published_generation]),
+      );
       const claim = result.body.active_claims?.find((c) => c.id === claimId);
       if (!claim || claim.state !== 'active') return null;
       return {
@@ -297,6 +399,26 @@ function remoteClaimSource(target: RemoteTarget, dial: Dialer, logger: ProxyLogg
       const revision = result.body.revisions?.find((r) => r.page_generation === generation);
       return revision ? { path: result.body.path, frontmatter: revision.frontmatter, body: revision.body } : null;
     },
+    async getPublishedGeneration(artifactKind, artifactId) {
+      return lastPublicationByKey?.get(`${artifactKind}:${artifactId}`) ?? null;
+    },
+    async markPublished(claimId) {
+      const result = await dialHostJson<{ ok: boolean }>(
+        target,
+        `/api/content-claims/${encodeURIComponent(claimId)}/published`,
+        dial,
+        { method: 'POST', machineId },
+      );
+      if (!result || result.status !== 200) {
+        logger.warn('materialize: host mark-published dial failed during auto-close', {
+          host_id: target.host.host_id,
+          claim_id: claimId,
+          status: result?.status ?? null,
+        });
+        return false;
+      }
+      return true;
+    },
   };
 }
 
@@ -315,10 +437,57 @@ type MaterializeFailureCode =
   | 'scan_blocked';
 
 export type MaterializeOutcome =
-  | { ok: true; artifactKind: 'skill'; path: string; skillName: string; generation: number }
-  | { ok: true; artifactKind: 'okf_page'; path: string; pagePath: string; generation: number }
+  | { ok: true; artifactKind: 'skill'; path: string; skillName: string; generation: number; autoPublished: boolean }
+  | { ok: true; artifactKind: 'okf_page'; path: string; pagePath: string; generation: number; autoPublished: boolean }
   | { ok: false; code: Exclude<MaterializeFailureCode, 'scan_blocked'> }
   | { ok: false; code: 'scan_blocked'; findings: PublishFinding[] };
+
+/**
+ * Republish auto-close (spec §2(c)): after a successful write, close the
+ * claim through the branch's pinned mark-published path when the claim's own
+ * generation matches the artifact's already-recorded `published_generation`
+ * — this write republished already-published content unchanged. Never
+ * throws and never turns a bookkeeping failure into a failed materialize
+ * response (Step 2's failure posture): any exception or a `markPublished`
+ * false is logged as a warn and degrades to `autoPublished: false`, leaving
+ * the claim `active` for the pre-existing manual Mark-published flow or TTL
+ * expiry to close it instead.
+ */
+async function attemptAutoClose(
+  source: ClaimSource,
+  logger: ProxyLogger,
+  claimId: string,
+  artifactKind: string,
+  artifactId: string,
+  generation: number,
+): Promise<boolean> {
+  try {
+    const publishedGeneration = await source.getPublishedGeneration(artifactKind, artifactId);
+    if (publishedGeneration !== generation) return false;
+    const closed = await source.markPublished(claimId);
+    if (!closed) {
+      logger.warn(
+        'materialize: same-generation republish wrote to disk but the auto-close mark-published call failed; '
+        + 'the claim stays active for the manual Mark-published flow or TTL expiry',
+        { claim_id: claimId, artifact_kind: artifactKind, artifact_id: artifactId, generation },
+      );
+    }
+    return closed;
+  } catch (err) {
+    logger.warn(
+      'materialize: same-generation republish wrote to disk but the auto-close check threw; '
+      + 'the claim stays active for the manual Mark-published flow or TTL expiry',
+      {
+        claim_id: claimId,
+        artifact_kind: artifactKind,
+        artifact_id: artifactId,
+        generation,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    );
+    return false;
+  }
+}
 
 /**
  * Resolve the member's published-wiki root for an OKF write:
@@ -366,6 +535,11 @@ async function resolveOkfPublishedRoot(
  * `resolveOkfPublishedRoot` is lazy (called only for an `okf_page` claim) so
  * a skill materialize never pays for a config read it doesn't need.
  *
+ * After a successful write, {@link attemptAutoClose} runs the republish
+ * auto-close check for both artifact kinds — the disk write is already
+ * committed by that point, so its result never changes whether this function
+ * returns `ok: true`, only the `autoPublished` flag carried on it.
+ *
  * Exported as a test seam alongside {@link ClaimSource}.
  */
 export async function materializeContentClaim(
@@ -373,6 +547,7 @@ export async function materializeContentClaim(
   currentRoot: string,
   source: ClaimSource,
   resolveOkfPublishedRootFn: () => Promise<string>,
+  logger: ProxyLogger,
 ): Promise<MaterializeOutcome> {
   const initial = await source.getActiveClaim(claimId);
   if (!initial) return { ok: false, code: 'claim_not_active' };
@@ -389,12 +564,21 @@ export async function materializeContentClaim(
       return { ok: false, code: written.reason === 'unsafe_name' ? 'unsafe_skill_name' : 'path_escape' };
     }
     syncPublishedSkillSymlinks(currentRoot, content.name);
+    const autoPublished = await attemptAutoClose(
+      source,
+      logger,
+      claimId,
+      initial.artifactKind,
+      initial.artifactId,
+      initial.generation,
+    );
     return {
       ok: true,
       artifactKind: 'skill',
       path: written.paths.skillPath,
       skillName: content.name,
       generation: initial.generation,
+      autoPublished,
     };
   }
 
@@ -412,12 +596,21 @@ export async function materializeContentClaim(
         ? { ok: false, code: 'scan_blocked', findings: written.findings }
         : { ok: false, code: written.reason };
     }
+    const autoPublished = await attemptAutoClose(
+      source,
+      logger,
+      claimId,
+      initial.artifactKind,
+      initial.artifactId,
+      initial.generation,
+    );
     return {
       ok: true,
       artifactKind: 'okf_page',
       path: written.absolutePath,
       pagePath: written.relativePath,
       generation: initial.generation,
+      autoPublished,
     };
   }
 
@@ -429,11 +622,23 @@ function responseForOutcome(outcome: MaterializeOutcome): RouteResponse {
     return outcome.artifactKind === 'skill'
       ? {
           status: 200,
-          body: { ok: true, path: outcome.path, skill_name: outcome.skillName, generation: outcome.generation },
+          body: {
+            ok: true,
+            path: outcome.path,
+            skill_name: outcome.skillName,
+            generation: outcome.generation,
+            auto_published: outcome.autoPublished,
+          },
         }
       : {
           status: 200,
-          body: { ok: true, path: outcome.path, page_path: outcome.pagePath, generation: outcome.generation },
+          body: {
+            ok: true,
+            path: outcome.path,
+            page_path: outcome.pagePath,
+            generation: outcome.generation,
+            auto_published: outcome.autoPublished,
+          },
         };
   }
   switch (outcome.code) {
@@ -494,6 +699,12 @@ export interface ContentClaimMaterializeDeps {
   cache: GroveRuntimeCache;
   dial: Dialer;
   logger: ProxyLogger;
+  /** This daemon's own machine id — the identity stamped on a local
+   *  mark-published call (`publishedBy`/`machineId`) and sent as
+   *  `REQUEST_CONTEXT_HEADERS.machineId` on the attached branch's
+   *  mark-published dial, so the host's holder gate attributes the
+   *  republish auto-close to the calling member, not itself. */
+  machineId: string;
   mycoHome?: string;
 }
 
@@ -520,17 +731,23 @@ export function createContentClaimMaterializeHandler(deps: ContentClaimMateriali
       } catch {
         return { status: 404, body: errorBody('project_not_registered', `Malformed project id ${projectId}`) };
       }
-      const source = remoteClaimSource(target, deps.dial, deps.logger);
-      const outcome = await materializeContentClaim(claimId, currentRoot, source, () =>
-        resolveOkfPublishedRoot(
-          currentRoot,
-          () =>
-            loadAttachedMergedConfig(resolveProjectVaultDir(currentRoot), {
-              mycoHome: deps.mycoHome,
-              fetchGroveDoc: async () => (await fetchHostGroveConfig(target, deps.dial, deps.logger)).doc,
-            }),
-          deps.logger,
-        ));
+      const source = remoteClaimSource(target, deps.dial, deps.logger, deps.machineId);
+      const outcome = await materializeContentClaim(
+        claimId,
+        currentRoot,
+        source,
+        () =>
+          resolveOkfPublishedRoot(
+            currentRoot,
+            () =>
+              loadAttachedMergedConfig(resolveProjectVaultDir(currentRoot), {
+                mycoHome: deps.mycoHome,
+                fetchGroveDoc: async () => (await fetchHostGroveConfig(target, deps.dial, deps.logger)).doc,
+              }),
+            deps.logger,
+          ),
+        deps.logger,
+      );
       return responseForOutcome(outcome);
     }
 
@@ -542,18 +759,24 @@ export function createContentClaimMaterializeHandler(deps: ContentClaimMateriali
     } catch {
       return { status: 404, body: errorBody('project_not_registered', `Malformed project id ${projectId}`) };
     }
-    const source = localClaimSource(db, scope);
-    const outcome = await materializeContentClaim(claimId, currentRoot, source, () =>
-      resolveOkfPublishedRoot(
-        currentRoot,
-        async () =>
-          loadMergedConfig(resolveProjectVaultDir(currentRoot), {
-            groveId: registered.grove.id,
-            mycoHome: deps.mycoHome,
-            projectTierOptional: true,
-          }),
-        deps.logger,
-      ));
+    const source = localClaimSource(db, scope, deps.machineId, deps.logger);
+    const outcome = await materializeContentClaim(
+      claimId,
+      currentRoot,
+      source,
+      () =>
+        resolveOkfPublishedRoot(
+          currentRoot,
+          async () =>
+            loadMergedConfig(resolveProjectVaultDir(currentRoot), {
+              groveId: registered.grove.id,
+              mycoHome: deps.mycoHome,
+              projectTierOptional: true,
+            }),
+          deps.logger,
+        ),
+      deps.logger,
+    );
     return responseForOutcome(outcome);
   };
 }

--- a/packages/myco/src/daemon/api/content-claims-materialize.ts
+++ b/packages/myco/src/daemon/api/content-claims-materialize.ts
@@ -139,7 +139,10 @@ export interface ClaimSource {
    *  (local: `markContentClaimPublished`; attached: the host's `POST
    *  /api/content-claims/:id/published`). Returns true on success, false on
    *  any failure — never throws, so a bookkeeping failure after a successful
-   *  disk write never turns into a failed materialize response. */
+   *  disk write never turns into a failed materialize response. Every false
+   *  return carries exactly ONE warn, logged by the source itself at the
+   *  point of detection (where the failure's specifics live); the
+   *  orchestration adds no second, generic warn on top. */
   markPublished(claimId: string): Promise<boolean>;
 }
 
@@ -198,10 +201,16 @@ function localClaimSource(
             publishedBy: machineId,
             machineId,
           });
-          return result !== null;
+          if (result === null) {
+            logger.warn('materialize: auto-close found the claim no longer active after the write; it closes via the manual Mark-published flow or TTL instead', {
+              claim_id: claimId,
+            });
+            return false;
+          }
+          return true;
         });
       } catch (err) {
-        logger.warn('materialize: local mark-published call failed during auto-close', {
+        logger.warn('materialize: local mark-published call failed after the write; the claim stays active for the manual Mark-published flow or TTL', {
           claim_id: claimId,
           error: err instanceof Error ? err.message : String(err),
         });
@@ -410,7 +419,7 @@ function remoteClaimSource(target: RemoteTarget, dial: Dialer, logger: ProxyLogg
         { method: 'POST', machineId },
       );
       if (!result || result.status !== 200) {
-        logger.warn('materialize: host mark-published dial failed during auto-close', {
+        logger.warn('materialize: host mark-published dial failed after the write; the claim stays active for the manual Mark-published flow or TTL', {
           host_id: target.host.host_id,
           claim_id: claimId,
           status: result?.status ?? null,
@@ -448,10 +457,17 @@ export type MaterializeOutcome =
  * generation matches the artifact's already-recorded `published_generation`
  * — this write republished already-published content unchanged. Never
  * throws and never turns a bookkeeping failure into a failed materialize
- * response (Step 2's failure posture): any exception or a `markPublished`
- * false is logged as a warn and degrades to `autoPublished: false`, leaving
- * the claim `active` for the pre-existing manual Mark-published flow or TTL
- * expiry to close it instead.
+ * response (Step 2's failure posture): a `markPublished` false degrades to
+ * `autoPublished: false`, leaving the claim `active` for the pre-existing
+ * manual Mark-published flow or TTL expiry to close it instead.
+ *
+ * Log discipline: one warn per failure, at the point of detection. The
+ * sources own the `markPublished`-false warn (they hold the failure's
+ * specifics — dial status, DB error); this helper adds nothing on top of a
+ * false return. Its own catch is its own detection point — the sources
+ * contractually never throw, so it only fires for a source that breaks
+ * that contract (e.g. a test seam), and warns because that path has no
+ * other logger.
  */
 async function attemptAutoClose(
   source: ClaimSource,
@@ -464,15 +480,7 @@ async function attemptAutoClose(
   try {
     const publishedGeneration = await source.getPublishedGeneration(artifactKind, artifactId);
     if (publishedGeneration !== generation) return false;
-    const closed = await source.markPublished(claimId);
-    if (!closed) {
-      logger.warn(
-        'materialize: same-generation republish wrote to disk but the auto-close mark-published call failed; '
-        + 'the claim stays active for the manual Mark-published flow or TTL expiry',
-        { claim_id: claimId, artifact_kind: artifactKind, artifact_id: artifactId, generation },
-      );
-    }
-    return closed;
+    return await source.markPublished(claimId);
   } catch (err) {
     logger.warn(
       'materialize: same-generation republish wrote to disk but the auto-close check threw; '

--- a/packages/myco/src/daemon/api/content-claims-materialize.ts
+++ b/packages/myco/src/daemon/api/content-claims-materialize.ts
@@ -16,9 +16,10 @@
  * request that reaches this handler — `requestContext.hostServed` is
  * structurally always false here (a genuine overlay-origin request is
  * refused earlier, at the transport boundary, by `overlayHostStampRefusal`).
- * The explicit `isHostServedRequest` check below repeats that guarantee
- * in-handler as defense in depth, matching the host's own independent
- * enforcement elsewhere — it must never rest on the stamp alone.
+ * The explicit `isHostServedRequest` check inside `resolveMemberProjectContext`
+ * repeats that guarantee in-handler as defense in depth, matching the host's
+ * own independent enforcement elsewhere — it must never rest on the stamp
+ * alone.
  *
  * Deliberately bypasses `req.requestContext` for project identity: that
  * context is resolved from `x-myco-*` tenancy headers against the LOCAL
@@ -26,10 +27,10 @@
  * throws for an attached project (its Grove has no local registry row — see
  * `grove/request-context.ts`'s `requestContextFromHttpHeaders` docstring).
  * The caller sends none of those headers for this route; instead the
- * member's CURRENT project root travels in the JSON body, and this handler
- * resolves identity from it directly (`resolveAttach`, `findRegisteredProject`
- * — both pure disk reads), the same pattern `attached-config.ts` uses for the
- * config carve.
+ * member's CURRENT project root travels in the JSON body, and identity is
+ * resolved from it directly by the shared `resolveMemberProjectContext`
+ * prelude (`resolveAttach`, `findRegisteredProject` — both pure disk reads),
+ * the same pattern `attached-config.ts` uses for the config carve.
  *
  * Two claim/content sources feed the same orchestration
  * (`materializeContentClaim`): a LOCAL source that queries the project's own
@@ -59,7 +60,6 @@ import {
   HOST_PROXY_HEADERS_TIMEOUT_MS,
   HOST_PROXY_MAX_BUFFERED_BODY_BYTES,
 } from '@myco/constants.js';
-import { loadProjectManifest } from '@myco/config/project-manifest.js';
 import { loadMergedConfig, loadAttachedMergedConfig } from '@myco/config/loader.js';
 import { withDatabase, type Database } from '@myco/db/client.js';
 import { getContentClaimById } from '@myco/db/queries/content-claims.js';
@@ -67,10 +67,8 @@ import { getSkillContentAtGeneration } from '@myco/db/queries/skill-lineage.js';
 import { getSkillRecord } from '@myco/db/queries/skill-records.js';
 import { getOkfPageById, getOkfPageRevisionAtGeneration } from '@myco/db/queries/okf.js';
 import { assertGroveProjectId, projectScope, type ProjectScope } from '@myco/grove/ids.js';
-import { pathsEquivalent, resolveGroveDbPath, resolveProjectVaultDir } from '@myco/grove/paths.js';
-import { isHostServedRequest, REQUEST_CONTEXT_HEADERS } from '@myco/grove/request-context.js';
-import { findRegisteredProject } from '@myco/grove/registry.js';
-import { resolveAttach } from '@myco/host/registry.js';
+import { resolveGroveDbPath, resolveProjectVaultDir } from '@myco/grove/paths.js';
+import { REQUEST_CONTEXT_HEADERS } from '@myco/grove/request-context.js';
 import { remoteTargetFor, type RemoteTarget } from '@myco/host/routing.js';
 import { writePublishedSkillFile, syncPublishedSkillSymlinks } from '@myco/skills/publication.js';
 import { materializeOkfPage, type OkfPageContent } from '@myco/okf/materialize.js';
@@ -80,6 +78,7 @@ import type { GroveRuntimeCache } from '../grove-runtime-cache.js';
 import type { Dialer, ProxyLogger } from '../host-proxy.js';
 import type { RouteHandler, RouteRegistrar, RouteResponse } from '../router.js';
 import { errorBody } from './error-envelope.js';
+import { resolveMemberProjectContext } from './member-project-context.js';
 
 /** OKF's project-tier default (`config/schema.ts`'s `OkfMaintainSchema.output_path`),
  *  repeated here only as the fallback when config cannot be resolved at all —
@@ -504,49 +503,17 @@ function asRecord(body: unknown): Record<string, unknown> {
 
 export function createContentClaimMaterializeHandler(deps: ContentClaimMaterializeDeps): RouteHandler {
   return async (req) => {
-    // Defense in depth: `localhost-only` (host/routing.ts) already refuses an
-    // overlay-origin request before this handler runs, and every loopback
-    // request stamps `hostServed: false` — this can never actually be true.
-    // Repeating the check here means the never-writes-a-member-tree
-    // invariant does not rest on the routing stamp alone (`skill-tools.ts`
-    // 166-182 documents the same layered posture for the agent tool surface).
-    if (isHostServedRequest(req.requestContext)) {
-      return { status: 404, body: errorBody('not_found', 'This route is served on localhost only.') };
-    }
-
     const claimId = req.params.id;
     const body = asRecord(req.body);
-    const projectRootInput = body.project_root;
-    if (typeof projectRootInput !== 'string' || projectRootInput.length === 0) {
-      return { status: 400, body: errorBody('invalid_request', 'project_root is required') };
+
+    const context = await resolveMemberProjectContext(req, body, deps.mycoHome);
+    if ('status' in context) {
+      return context;
     }
-    const currentRoot = path.resolve(projectRootInput);
+    const { currentRoot, projectId } = context;
 
-    const manifest = loadProjectManifest(resolveProjectVaultDir(currentRoot));
-    const projectId = manifest?.project?.id;
-    if (!projectId) {
-      return {
-        status: 404,
-        body: errorBody('project_not_registered', `No Grove project manifest at ${currentRoot}`),
-      };
-    }
-
-    const attach = resolveAttach(projectId);
-    if (attach) {
-      if (attach.ref.root && !pathsEquivalent(attach.ref.root, currentRoot)) {
-        return {
-          status: 409,
-          body: {
-            ...errorBody(
-              'root_mismatch',
-              'The attached checkout root does not match the current project root.',
-            ),
-            attached_root: attach.ref.root,
-            current_root: currentRoot,
-          },
-        };
-      }
-
+    if (context.source === 'attached') {
+      const { attach } = context;
       let target: RemoteTarget;
       try {
         target = remoteTargetFor(assertGroveProjectId(projectId), attach);
@@ -567,30 +534,7 @@ export function createContentClaimMaterializeHandler(deps: ContentClaimMateriali
       return responseForOutcome(outcome);
     }
 
-    const registered = findRegisteredProject({ projectId }, deps.mycoHome);
-    if (!registered) {
-      return {
-        status: 404,
-        body: errorBody(
-          'project_not_registered',
-          `Project ${projectId} is not registered locally and is not attached to a host`,
-        ),
-      };
-    }
-    if (!pathsEquivalent(registered.project.root, currentRoot)) {
-      return {
-        status: 409,
-        body: {
-          ...errorBody(
-            'root_mismatch',
-            'The registered project root does not match the current project root.',
-          ),
-          registered_root: registered.project.root,
-          current_root: currentRoot,
-        },
-      };
-    }
-
+    const { registered } = context;
     const db = deps.cache.getDatabase(resolveGroveDbPath(registered.grove.id, deps.mycoHome));
     let scope: ProjectScope;
     try {

--- a/packages/myco/src/daemon/api/content-claims.ts
+++ b/packages/myco/src/daemon/api/content-claims.ts
@@ -97,6 +97,19 @@ function claimView(row: ContentClaimRow, currentGeneration: number | null): Reco
   };
 }
 
+/** One artifact published at its current lineage-latest generation — the
+ *  additive companion to `claimable`. Skills-only: a published `okf_page`
+ *  emits no entry (spec §2(a)). */
+interface PublishedArtifactView {
+  artifact_kind: 'skill';
+  artifact_id: string;
+  name: string;
+  label: string;
+  published_generation: number;
+  lineage_generation: number;
+  active_claim: Record<string, unknown> | null;
+}
+
 // ---------------------------------------------------------------------------
 // GET /api/content-claims — claimable inventory + active claims
 // ---------------------------------------------------------------------------
@@ -116,11 +129,32 @@ export async function handleContentClaimsList(
   const activeClaimByKey = new Map(activeClaims.map((c) => [`${c.artifact_kind}:${c.artifact_id}`, c]));
 
   const claimable: Array<Record<string, unknown>> = [];
-  const addCandidate = (kind: ContentClaimArtifactKind, id: string, label: string, generation: number) => {
+  const published: PublishedArtifactView[] = [];
+  const addCandidate = (
+    kind: ContentClaimArtifactKind,
+    id: string,
+    name: string,
+    label: string,
+    generation: number,
+  ) => {
     const key = `${kind}:${id}`;
     const publishedGeneration = publicationByKey.get(key)?.published_generation ?? null;
-    if (publishedGeneration === generation) return; // already published at lineage-latest
     const activeClaim = activeClaimByKey.get(key) ?? null;
+    if (publishedGeneration === generation) {
+      // already published at lineage-latest — surfaced via `published`, not `claimable`.
+      if (kind === 'skill') {
+        published.push({
+          artifact_kind: 'skill',
+          artifact_id: id,
+          name,
+          label,
+          published_generation: publishedGeneration,
+          lineage_generation: generation,
+          active_claim: activeClaim ? claimView(activeClaim, generation) : null,
+        });
+      }
+      return;
+    }
     claimable.push({
       artifact_kind: kind,
       artifact_id: id,
@@ -132,10 +166,10 @@ export async function handleContentClaimsList(
   };
 
   for (const record of skills) {
-    addCandidate('skill', record.id, record.display_name || record.name, record.generation);
+    addCandidate('skill', record.id, record.name, record.display_name || record.name, record.generation);
   }
   for (const page of pages) {
-    addCandidate('okf_page', page.id, page.title || page.path, page.generation);
+    addCandidate('okf_page', page.id, page.path, page.title || page.path, page.generation);
   }
 
   return {
@@ -143,6 +177,7 @@ export async function handleContentClaimsList(
     body: {
       ok: true,
       claimable,
+      published,
       active_claims: activeClaims.map((claim) => {
         const artifact = resolveArtifact(claim.artifact_kind, claim.artifact_id, scope);
         return claimView(claim, artifact?.generation ?? null);

--- a/packages/myco/src/daemon/api/content-claims.ts
+++ b/packages/myco/src/daemon/api/content-claims.ts
@@ -3,7 +3,7 @@
  * surface over DB-resident skills and OKF pages (design:
  * docs/superpowers/specs/2026-07-09-content-claim-system-design.md §3).
  *
- *   GET  /api/content-claims                  claimable inventory + active claims
+ *   GET  /api/content-claims                  claimable inventory + active claims + published artifacts
  *   POST /api/content-claims                  constraint-based claim
  *   POST /api/content-claims/:id/refresh      holder-only generation bump
  *   POST /api/content-claims/:id/release      holder-only release
@@ -111,7 +111,7 @@ interface PublishedArtifactView {
 }
 
 // ---------------------------------------------------------------------------
-// GET /api/content-claims — claimable inventory + active claims
+// GET /api/content-claims — claimable inventory + active claims + published
 // ---------------------------------------------------------------------------
 
 export async function handleContentClaimsList(

--- a/packages/myco/src/daemon/api/member-project-context.ts
+++ b/packages/myco/src/daemon/api/member-project-context.ts
@@ -1,0 +1,129 @@
+/**
+ * Shared project-context resolution for member-side, `localhost-only`
+ * content-claim routes: host-served guard → `project_root` (request body)
+ * → Grove project manifest → `resolveAttach` → reconciling the resolved
+ * (attached or locally-registered) root against the current checkout.
+ *
+ * Used by the content-claim materialize handler
+ * (`content-claims-materialize.ts`) and the file-status route.
+ */
+import path from 'node:path';
+
+import { loadProjectManifest } from '@myco/config/project-manifest.js';
+import { pathsEquivalent, resolveProjectVaultDir } from '@myco/grove/paths.js';
+import { isHostServedRequest } from '@myco/grove/request-context.js';
+import { findRegisteredProject, type ResolvedRegisteredProject } from '@myco/grove/registry.js';
+import { resolveAttach } from '@myco/host/registry.js';
+
+import type { RouteRequest } from '../router.js';
+import { errorBody } from './error-envelope.js';
+
+/** Non-null shape of {@link resolveAttach}'s return value. */
+export type ResolveAttachResult = NonNullable<ReturnType<typeof resolveAttach>>;
+
+export interface AttachedMemberProjectContext {
+  source: 'attached';
+  currentRoot: string;
+  projectId: string;
+  attach: ResolveAttachResult;
+}
+
+export interface LocalMemberProjectContext {
+  source: 'local';
+  currentRoot: string;
+  projectId: string;
+  registered: ResolvedRegisteredProject;
+}
+
+export type MemberProjectContext = AttachedMemberProjectContext | LocalMemberProjectContext;
+
+/** A resolution failure — the exact `status`/`body` the caller must return as-is. */
+export interface MemberProjectContextError {
+  status: number;
+  body: unknown;
+}
+
+/**
+ * Resolves which Grove project a member-side request is for, its current
+ * checkout root, and whether that project is attached to a host or
+ * registered locally. Returns a `MemberProjectContextError` — to be
+ * returned verbatim by the caller — when: the request is host-served, the
+ * body is missing a non-empty `project_root`, no Grove project manifest
+ * exists at that root, the resolved (attached or registered) root doesn't
+ * match the current root, or the project is neither attached nor
+ * registered locally.
+ */
+export async function resolveMemberProjectContext(
+  req: RouteRequest,
+  body: Record<string, unknown>,
+  mycoHome?: string,
+): Promise<MemberProjectContext | MemberProjectContextError> {
+  // Defense in depth: `localhost-only` (host/routing.ts) already refuses an
+  // overlay-origin request before any localhost-only handler runs, and every
+  // loopback request stamps `hostServed: false` — this can never actually be
+  // true. Repeating the check here means the never-writes-a-member-tree
+  // invariant does not rest on the routing stamp alone (`skill-tools.ts`
+  // 166-182 documents the same layered posture for the agent tool surface).
+  if (isHostServedRequest(req.requestContext)) {
+    return { status: 404, body: errorBody('not_found', 'This route is served on localhost only.') };
+  }
+
+  const projectRootInput = body.project_root;
+  if (typeof projectRootInput !== 'string' || projectRootInput.length === 0) {
+    return { status: 400, body: errorBody('invalid_request', 'project_root is required') };
+  }
+  const currentRoot = path.resolve(projectRootInput);
+
+  const manifest = loadProjectManifest(resolveProjectVaultDir(currentRoot));
+  const projectId = manifest?.project?.id;
+  if (!projectId) {
+    return {
+      status: 404,
+      body: errorBody('project_not_registered', `No Grove project manifest at ${currentRoot}`),
+    };
+  }
+
+  const attach = resolveAttach(projectId);
+  if (attach) {
+    if (attach.ref.root && !pathsEquivalent(attach.ref.root, currentRoot)) {
+      return {
+        status: 409,
+        body: {
+          ...errorBody(
+            'root_mismatch',
+            'The attached checkout root does not match the current project root.',
+          ),
+          attached_root: attach.ref.root,
+          current_root: currentRoot,
+        },
+      };
+    }
+    return { source: 'attached', currentRoot, projectId, attach };
+  }
+
+  const registered = findRegisteredProject({ projectId }, mycoHome);
+  if (!registered) {
+    return {
+      status: 404,
+      body: errorBody(
+        'project_not_registered',
+        `Project ${projectId} is not registered locally and is not attached to a host`,
+      ),
+    };
+  }
+  if (!pathsEquivalent(registered.project.root, currentRoot)) {
+    return {
+      status: 409,
+      body: {
+        ...errorBody(
+          'root_mismatch',
+          'The registered project root does not match the current project root.',
+        ),
+        registered_root: registered.project.root,
+        current_root: currentRoot,
+      },
+    };
+  }
+
+  return { source: 'local', currentRoot, projectId, registered };
+}

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -108,6 +108,7 @@ import { createCortexHandlers } from './api/cortex.js';
 import { registerOkfRoutes } from './api/okf.js';
 import { registerContentClaimRoutes } from './api/content-claims.js';
 import { registerContentClaimMaterializeRoute } from './api/content-claims-materialize.js';
+import { registerContentClaimFileStatusRoute } from './api/content-claims-file-status.js';
 import { defaultDial, proxyLoggerFrom } from './host-proxy.js';
 import { tenantRoute } from './api/route-helpers.js';
 import { createCanopyInjectHandler } from './api/canopy-inject.js';
@@ -1523,6 +1524,10 @@ export async function main(): Promise<void> {
     cache: runtimeCache,
     dial: defaultDial,
     logger: proxyLoggerFrom(logger, LOG_KINDS.CONTENT_CLAIM_MATERIALIZE),
+    mycoHome,
+  });
+  registerContentClaimFileStatusRoute(server, {
+    logger: proxyLoggerFrom(logger, LOG_KINDS.CONTENT_CLAIM_FILE_STATUS),
     mycoHome,
   });
 

--- a/packages/myco/src/daemon/main.ts
+++ b/packages/myco/src/daemon/main.ts
@@ -1524,6 +1524,7 @@ export async function main(): Promise<void> {
     cache: runtimeCache,
     dial: defaultDial,
     logger: proxyLoggerFrom(logger, LOG_KINDS.CONTENT_CLAIM_MATERIALIZE),
+    machineId,
     mycoHome,
   });
   registerContentClaimFileStatusRoute(server, {

--- a/packages/myco/src/host/routing.ts
+++ b/packages/myco/src/host/routing.ts
@@ -380,6 +380,13 @@ const ROUTE_RULES: RouteRule[] = [
   //     `attached-config.ts`'s grove-tier fetch) for the claim/content state
   //     instead of proxying the request wholesale. ---
   { method: 'POST', pattern: '/api/content-claims/:id/materialize', stamp: 'localhost-only', capability: CONTENT_MATERIALIZE },
+
+  // --- localhost-only: content-claim FILE-STATUS, the member disk-truth read
+  //     (design: docs/superpowers/specs/2026-07-09-content-claim-system-design.md
+  //     §2(b)). Read-only sibling of materialize above, sharing its capability
+  //     stamp: it checks presence in the CALLING member's own working tree, so
+  //     proxying it to the host would answer with the wrong machine's disk. ---
+  { method: 'POST', pattern: '/api/content-claims/file-status', stamp: 'localhost-only', capability: CONTENT_MATERIALIZE },
 ];
 
 /**

--- a/packages/myco/src/host/routing.ts
+++ b/packages/myco/src/host/routing.ts
@@ -382,7 +382,7 @@ const ROUTE_RULES: RouteRule[] = [
   { method: 'POST', pattern: '/api/content-claims/:id/materialize', stamp: 'localhost-only', capability: CONTENT_MATERIALIZE },
 
   // --- localhost-only: content-claim FILE-STATUS, the member disk-truth read
-  //     (design: docs/superpowers/specs/2026-07-09-content-claim-system-design.md
+  //     (design: docs/superpowers/specs/2026-07-10-publication-coupling-okf-disposition-design.md
   //     §2(b)). Read-only sibling of materialize above, sharing its capability
   //     stamp: it checks presence in the CALLING member's own working tree, so
   //     proxying it to the host would answer with the wrong machine's disk. ---

--- a/packages/myco/ui/src/components/content-claims/ClaimControl.tsx
+++ b/packages/myco/ui/src/components/content-claims/ClaimControl.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import { Surface } from '../ui/surface';
@@ -5,11 +6,14 @@ import { formatEpochAgo } from '../../lib/format';
 import { useActiveProjectSelection } from '../../hooks/use-project-selection';
 import {
   useContentClaims,
+  useContentFileStatus,
+  useInvalidateContentClaims,
   useReleaseContentClaim,
   useMarkContentClaimPublished,
   useClaimAndMaterialize,
   useMyMachineId,
   findClaimableArtifact,
+  findPublishedArtifact,
   type ContentClaimArtifactKind,
 } from '../../hooks/use-content-claims';
 
@@ -20,8 +24,13 @@ import {
  * holder, "Mark published" once the holder has committed the materialized
  * file (spec §3/§4 step 6 — closes the publish loop by upserting
  * `content_publications` and retiring the claim), and a holder+age display
- * when someone else holds it. Renders nothing when the artifact is already
- * published at lineage-latest (not present in the claimable inventory).
+ * when someone else holds it. Also re-offers "Publish" for an artifact
+ * that's already published at lineage-latest but whose file is missing from
+ * this checkout (design §2(c) — e.g. `git rm`'d or an unpulled branch);
+ * that merged-state flow reuses the same claim/materialize plumbing, but a
+ * same-generation republish auto-closes server-side (Task 1.4), so no
+ * "Mark published" step is needed there. Renders nothing when the artifact
+ * is neither claimable nor published-but-missing.
  *
  * Copy doctrine: every rendered string uses outcome vocabulary ("Publish",
  * "Being published by…"), never mechanism vocabulary (claim, materialize,
@@ -38,14 +47,158 @@ export function ClaimControl({
 }) {
   const { data } = useContentClaims();
   const claimable = findClaimableArtifact(data, artifactKind, artifactId);
+  const publishedEntry = findPublishedArtifact(data, artifactKind, artifactId);
   const myMachineId = useMyMachineId();
   const selection = useActiveProjectSelection();
   const projectRoot = selection?.project.root;
   const release = useReleaseContentClaim();
   const markPublished = useMarkContentClaimPublished();
-  const { phase, run, retryMaterialize } = useClaimAndMaterialize();
+  const { phase, run, retryMaterialize, reset } = useClaimAndMaterialize();
+  const fileStatus = useContentFileStatus(projectRoot, data?.published ?? []);
+  const invalidateContentClaims = useInvalidateContentClaims();
 
-  if (!claimable) return null;
+  // Same-generation republish auto-closes server-side (Task 1.4): once that
+  // lands, this session's own repair is done — invalidate both queries so
+  // the entry drops the Publish affordance immediately, and reset the phase
+  // so a healthy re-render (no active claim, file present) can return null
+  // instead of leaving a stale "success" message pinned forever. A materialize
+  // originating from the CLAIMABLE branch below can never set `autoPublished`
+  // true (that branch only runs when published/lineage generations already
+  // differ, which structurally fails Task 1.4's same-generation check), so
+  // this effect only ever fires for the merged-state flow.
+  useEffect(() => {
+    if (phase.status === 'success' && phase.autoPublished) {
+      invalidateContentClaims();
+      reset();
+    }
+  }, [phase, invalidateContentClaims, reset]);
+
+  if (!claimable) {
+    if (!publishedEntry) return null;
+
+    const activeClaim = publishedEntry.active_claim;
+    const heldByMe = !!activeClaim && !!myMachineId && activeClaim.claimed_by === myMachineId;
+    const inFlight = phase.status === 'claiming' || phase.status === 'materializing';
+    const materializing = phase.status === 'materializing';
+    const materializeFailed = phase.status === 'materialize-failed';
+    const justPublished = phase.status === 'success';
+
+    // Degrade (design §2, pinned): a non-200 file-status response or a
+    // per-artifact `file_present: null` both mean "no affordance" — exactly
+    // today's behavior. `fileStatus.isError` covers the whole-batch failure;
+    // a missing per-artifact entry (route degrades a bad batch entry rather
+    // than dropping it, but match-by-identity still guards against drift)
+    // falls through the same `?? null`.
+    const fileStatusEntry = fileStatus.isError
+      ? undefined
+      : fileStatus.data?.statuses.find(
+          (s) => s.artifact_kind === publishedEntry.artifact_kind && s.artifact_id === publishedEntry.artifact_id,
+        );
+    const filePresent = fileStatusEntry?.file_present ?? null;
+
+    const nothingToRepair =
+      !activeClaim && !inFlight && !materializeFailed && !justPublished && filePresent !== false;
+    if (nothingToRepair) return null;
+
+    // The bottom Publish button stays visible+disabled through the entire
+    // in-flight window (claiming → materializing) regardless of whether
+    // `activeClaim` has caught up via refetch yet — keying visibility off
+    // the phase machine, not the merged flags, is what keeps the control
+    // from vanishing mid-flow (design §2(c)).
+    const showPublishButton = inFlight || (!activeClaim && !materializeFailed && !justPublished);
+
+    return (
+      <Surface
+        level="low"
+        className="flex flex-col gap-2 p-4"
+        data-testid={`claim-control-${artifactKind}-${artifactId}`}
+      >
+        {filePresent === false && (
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="warning">Missing</Badge>
+            <span className="font-mono text-[10px] text-on-surface-variant">
+              gen {publishedEntry.published_generation}
+            </span>
+          </div>
+        )}
+        {filePresent === false && (
+          <p className="font-sans text-xs text-on-surface-variant m-0">
+            Published file missing from your checkout
+          </p>
+        )}
+
+        {activeClaim && !inFlight && (
+          <div
+            className="flex flex-wrap items-center gap-2"
+            data-testid={heldByMe ? 'claim-held-by-me' : 'claim-held-by-other'}
+          >
+            <span className="font-sans text-xs text-on-surface-variant">
+              Being published by <span className="font-mono">{activeClaim.claimed_by}</span>
+              {' · '}
+              {formatEpochAgo(activeClaim.claimed_at)}
+            </span>
+            {heldByMe && <Badge variant="outline">this machine</Badge>}
+            {heldByMe && (
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={release.isPending}
+                onClick={() => release.mutate(activeClaim.id)}
+                data-testid="release-claim"
+              >
+                {release.isPending ? 'Releasing…' : 'Release'}
+              </Button>
+            )}
+          </div>
+        )}
+
+        {materializing && (
+          <p className="font-sans text-xs text-on-surface-variant" data-testid="materializing">
+            Publishing…
+          </p>
+        )}
+
+        {materializeFailed && (
+          <div className="flex flex-wrap items-center gap-2" data-testid="materialize-failed">
+            <p className="font-sans text-xs text-tertiary m-0">
+              Couldn't finish publishing — writing the file failed: {phase.message}
+            </p>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => projectRoot && retryMaterialize(phase.claimId, projectRoot)}
+            >
+              Retry publish
+            </Button>
+          </div>
+        )}
+
+        {justPublished && (
+          <p className="font-sans text-xs text-primary m-0" data-testid="materialize-success">
+            Published to {phase.path}
+          </p>
+        )}
+
+        {showPublishButton && (
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              size="sm"
+              disabled={inFlight || !projectRoot}
+              onClick={() => projectRoot && run({ artifactKind, artifactId, projectRoot })}
+              data-testid="claim-and-materialize"
+            >
+              {phase.status === 'claiming' ? 'Publishing…' : 'Publish'}
+            </Button>
+            {phase.status === 'claim-failed' && (
+              <span className="font-sans text-xs text-tertiary" data-testid="claim-failed">
+                {phase.message}
+              </span>
+            )}
+          </div>
+        )}
+      </Surface>
+    );
+  }
 
   const activeClaim = claimable.active_claim;
   const heldByMe = !!activeClaim && !!myMachineId && activeClaim.claimed_by === myMachineId;

--- a/packages/myco/ui/src/hooks/use-content-claims.ts
+++ b/packages/myco/ui/src/hooks/use-content-claims.ts
@@ -46,9 +46,28 @@ export interface ClaimableArtifact {
   active_claim: ContentClaimView | null;
 }
 
+/** One artifact published at its current lineage-latest generation — the
+ *  additive companion to `claimable` (design §2(a)). Skills-only: a
+ *  published `okf_page` never emits an entry here. `name` is the
+ *  path-derivation key (skills derive `.agents/skills/<name>/SKILL.md`);
+ *  `label` is display-only. */
+export interface PublishedArtifactView {
+  artifact_kind: 'skill';
+  artifact_id: string;
+  name: string;
+  label: string;
+  published_generation: number;
+  lineage_generation: number;
+  active_claim: ContentClaimView | null;
+}
+
 export interface ContentClaimsListResponse {
   ok: boolean;
   claimable: ClaimableArtifact[];
+  /** Absent from a response predating this field — every consumer
+   *  (`findPublishedArtifact`, the file-status batch below) treats a
+   *  missing `published` as `[]`, never as an error. */
+  published?: PublishedArtifactView[];
   active_claims: ContentClaimView[];
 }
 
@@ -79,8 +98,8 @@ export interface MarkContentClaimPublishedResponse {
 }
 
 export type MaterializeContentClaimResponse =
-  | { ok: true; path: string; skill_name: string; generation: number }
-  | { ok: true; path: string; page_path: string; generation: number };
+  | { ok: true; path: string; skill_name: string; generation: number; auto_published: boolean }
+  | { ok: true; path: string; page_path: string; generation: number; auto_published: boolean };
 
 const CONTENT_CLAIMS_BASE_KEY = ['content-claims'] as const;
 
@@ -103,6 +122,89 @@ export function findClaimableArtifact(
   artifactId: string,
 ): ClaimableArtifact | undefined {
   return (data?.claimable ?? []).find((c) => c.artifact_kind === artifactKind && c.artifact_id === artifactId);
+}
+
+/** Find one artifact's published-at-latest entry, or undefined when it's
+ *  unpublished/stale (in `claimable` instead) or the response predates the
+ *  `published` field. Mirrors `findClaimableArtifact`. */
+export function findPublishedArtifact(
+  data: ContentClaimsListResponse | undefined,
+  artifactKind: ContentClaimArtifactKind,
+  artifactId: string,
+): PublishedArtifactView | undefined {
+  return (data?.published ?? []).find((p) => p.artifact_kind === artifactKind && p.artifact_id === artifactId);
+}
+
+/* ---------- File-status (member disk truth, Task 1.3) ---------- */
+
+export interface ContentFileStatusRequestArtifact {
+  artifact_kind: ContentClaimArtifactKind;
+  artifact_id: string;
+  name: string;
+}
+
+/** One status entry, index-aligned to the request's `artifacts` — the route
+ *  echoes `artifact_kind`/`artifact_id` back unvalidated (a malformed batch
+ *  entry degrades rather than throwing), so callers match by the SAME
+ *  identity pair rather than trusting response order. */
+export interface ContentFileStatusEntry {
+  artifact_kind: ContentClaimArtifactKind | null;
+  artifact_id: string | null;
+  file_present: boolean | null;
+}
+
+export interface ContentFileStatusResponse {
+  statuses: ContentFileStatusEntry[];
+}
+
+const CONTENT_FILE_STATUS_BASE_KEY = [...CONTENT_CLAIMS_BASE_KEY, 'file-status'] as const;
+
+/** POST /api/content-claims/file-status — one batched disk-presence check
+ *  for every published-at-latest artifact, against the active project's own
+ *  working tree (design §2(b)). Skipped entirely (no request fires) when
+ *  there's nothing to check or no project root to check it against — the
+ *  route requires both. Rides the same 15s cadence as `useContentClaims`. */
+export function useContentFileStatus(
+  projectRoot: string | undefined,
+  published: PublishedArtifactView[],
+): UseQueryResult<ContentFileStatusResponse> {
+  const artifacts: ContentFileStatusRequestArtifact[] = published.map((p) => ({
+    artifact_kind: p.artifact_kind,
+    artifact_id: p.artifact_id,
+    name: p.name,
+  }));
+  return usePowerQuery<ContentFileStatusResponse>({
+    queryKey: [...CONTENT_FILE_STATUS_BASE_KEY, projectRoot, artifacts],
+    queryFn: ({ signal }) =>
+      fetchJson<ContentFileStatusResponse>('/content-claims/file-status', {
+        method: 'POST',
+        body: JSON.stringify({ project_root: projectRoot, artifacts }),
+        signal,
+      }),
+    enabled: artifacts.length > 0 && !!projectRoot,
+    refetchInterval: POLL_INTERVALS.CONTENT_CLAIMS,
+    pollCategory: 'standard',
+  });
+}
+
+/**
+ * Invalidate the inventory query AND the file-status query in one call. The
+ * two live under different query-key shapes (the inventory's scoped key has
+ * nothing after the project marker; file-status has request params after
+ * it), so the inventory mutations' own `onSettled` invalidation — which
+ * targets the inventory's exact scoped key — never reaches file-status.
+ * Used by `ClaimControl`'s merged-state Publish flow: when a same-generation
+ * republish auto-closes server-side (Task 1.4's `auto_published: true`), the
+ * repaired entry should drop its Publish affordance immediately rather than
+ * wait for the next poll.
+ */
+export function useInvalidateContentClaims(): () => void {
+  const qc = useQueryClient();
+  const inventoryKey = useProjectScopedQueryKey(CONTENT_CLAIMS_BASE_KEY);
+  return useCallback(() => {
+    void qc.invalidateQueries({ queryKey: inventoryKey });
+    void qc.invalidateQueries({ queryKey: CONTENT_FILE_STATUS_BASE_KEY });
+  }, [qc, inventoryKey]);
 }
 
 /** This daemon's own machine id — the identity a claim's `claimed_by` is compared against to
@@ -196,7 +298,7 @@ export type ClaimAndMaterializePhase =
   | { status: 'claim-failed'; message: string; holder: ContentClaimView | null }
   | { status: 'materializing'; claimId: string }
   | { status: 'materialize-failed'; claimId: string; message: string }
-  | { status: 'success'; claimId: string; path: string };
+  | { status: 'success'; claimId: string; path: string; autoPublished: boolean };
 
 function messageFor(err: unknown, fallback: string): string {
   return err instanceof Error ? err.message : fallback;
@@ -220,7 +322,7 @@ export function useClaimAndMaterialize() {
       setPhase({ status: 'materializing', claimId });
       try {
         const result = await materialize.mutateAsync({ claimId, projectRoot });
-        setPhase({ status: 'success', claimId, path: result.path });
+        setPhase({ status: 'success', claimId, path: result.path, autoPublished: result.auto_published });
       } catch (err) {
         setPhase({ status: 'materialize-failed', claimId, message: messageFor(err, 'Publishing failed') });
       }

--- a/tests/daemon/api/content-claims-file-status.test.ts
+++ b/tests/daemon/api/content-claims-file-status.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Content claim file-status — member disk truth (design §2(b)). Real
+ * project registration + real filesystem writes in a temp project root; no
+ * Grove DB is ever opened (the route never queries it).
+ */
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { RouteRequest } from '@myco/daemon/router.js';
+import { createContentClaimFileStatusHandler } from '@myco/daemon/api/content-claims-file-status.js';
+import { saveProjectManifest } from '@myco/config/project-manifest.js';
+import { createGrove, registerProjectInGrove, clearGroveRegistryCaches } from '@myco/grove/registry.js';
+import { assertGroveProjectId, createProjectId } from '@myco/grove/ids.js';
+import { resolveProjectVaultDir } from '@myco/grove/paths.js';
+import { CANONICAL_PROJECT_SKILLS_DIR } from '@myco/skills/publication.js';
+
+interface FileStatusEntry {
+  artifact_kind: unknown;
+  artifact_id: unknown;
+  file_present: boolean | null;
+}
+
+function req(projectRoot: string, artifacts: unknown[], extra: Partial<RouteRequest> = {}): RouteRequest {
+  return {
+    params: {},
+    query: {},
+    body: { project_root: projectRoot, artifacts },
+    pathname: '/api/content-claims/file-status',
+    ...extra,
+  };
+}
+
+function writeSkillFile(projectRoot: string, name: string, content = `# ${name}\n`): void {
+  const dir = path.join(projectRoot, CANONICAL_PROJECT_SKILLS_DIR, name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'SKILL.md'), content, 'utf-8');
+}
+
+/**
+ * `resolveMemberProjectContext`'s own prelude (manifest + registry reads)
+ * calls `existsSync` too, so a raw call count over the whole handler
+ * invocation would be noisy. Filtering to calls that check a `SKILL.md`
+ * path isolates the ones this route's per-artifact resolution makes.
+ */
+function skillPathCalls(spy: ReturnType<typeof spyOn>): string[] {
+  return spy.mock.calls
+    .map((call) => call[0] as string)
+    .filter((checkedPath) => checkedPath.endsWith('SKILL.md'));
+}
+
+describe('content claim file-status — local project', () => {
+  let tmp: string;
+  let mycoHome: string;
+  let projectRoot: string;
+  let projectId: string;
+  let groveId: string;
+  let savedHome: string | undefined;
+  let savedMycoHome: string | undefined;
+  let savedTeamHome: string | undefined;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-cclaim-status-'));
+    savedHome = process.env.HOME;
+    savedMycoHome = process.env.MYCO_HOME;
+    savedTeamHome = process.env.MYCO_TEAM_HOME;
+
+    const fakeHome = path.join(tmp, 'user-home');
+    fs.mkdirSync(fakeHome, { recursive: true });
+    process.env.HOME = fakeHome;
+
+    mycoHome = path.join(tmp, 'myco-home');
+    fs.mkdirSync(mycoHome, { recursive: true });
+    process.env.MYCO_HOME = mycoHome;
+    process.env.MYCO_TEAM_HOME = path.join(tmp, 'team-home'); // no host ever registered here
+    clearGroveRegistryCaches();
+
+    projectRoot = path.join(tmp, 'project');
+    fs.mkdirSync(projectRoot, { recursive: true });
+
+    const grove = createGrove('Work', mycoHome);
+    groveId = grove.id;
+
+    projectId = assertGroveProjectId(createProjectId());
+    registerProjectInGrove(groveId, { projectId, projectName: 'Work project', projectRoot }, mycoHome);
+    saveProjectManifest(resolveProjectVaultDir(projectRoot), { project: { id: projectId } });
+  });
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.HOME; else process.env.HOME = savedHome;
+    if (savedMycoHome === undefined) delete process.env.MYCO_HOME; else process.env.MYCO_HOME = savedMycoHome;
+    if (savedTeamHome === undefined) delete process.env.MYCO_TEAM_HOME; else process.env.MYCO_TEAM_HOME = savedTeamHome;
+    clearGroveRegistryCaches();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function handler() {
+    const warnObj = { warn(_message: string, _meta?: Record<string, unknown>): void {} };
+    const warnSpy = spyOn(warnObj, 'warn');
+    const h = createContentClaimFileStatusHandler({
+      logger: { warn: warnObj.warn.bind(warnObj), error: () => {} },
+      mycoHome,
+    });
+    return { h, warnSpy };
+  }
+
+  test('present/missing: an existing published file reports true, a missing one reports false', async () => {
+    writeSkillFile(projectRoot, 'present-skill');
+
+    const { h } = handler();
+    const res = await h(req(projectRoot, [
+      { artifact_kind: 'skill', artifact_id: 'sk-present', name: 'present-skill' },
+      { artifact_kind: 'skill', artifact_id: 'sk-missing', name: 'missing-skill' },
+    ]));
+
+    expect(res.status).toBe(200);
+    const statuses = (res.body as { statuses: FileStatusEntry[] }).statuses;
+    expect(statuses).toEqual([
+      { artifact_kind: 'skill', artifact_id: 'sk-present', file_present: true },
+      { artifact_kind: 'skill', artifact_id: 'sk-missing', file_present: false },
+    ]);
+  });
+
+  test('hostile names (traversal, absolute, empty) resolve to null and the resolver refusal never leaks an fs check outside the skills root', async () => {
+    writeSkillFile(projectRoot, 'good-skill');
+    const skillsRoot = path.resolve(projectRoot, CANONICAL_PROJECT_SKILLS_DIR);
+
+    const existsSpy = spyOn(fs, 'existsSync');
+    const { h, warnSpy } = handler();
+    try {
+      const res = await h(req(projectRoot, [
+        { artifact_kind: 'skill', artifact_id: 'sk-good', name: 'good-skill' },
+        { artifact_kind: 'skill', artifact_id: 'sk-traversal', name: '../evil' },
+        { artifact_kind: 'skill', artifact_id: 'sk-absolute', name: '/etc/passwd' },
+        { artifact_kind: 'skill', artifact_id: 'sk-empty', name: '' },
+      ]));
+
+      expect(res.status).toBe(200);
+      const statuses = (res.body as { statuses: FileStatusEntry[] }).statuses;
+      expect(statuses).toEqual([
+        { artifact_kind: 'skill', artifact_id: 'sk-good', file_present: true },
+        { artifact_kind: 'skill', artifact_id: 'sk-traversal', file_present: null },
+        { artifact_kind: 'skill', artifact_id: 'sk-absolute', file_present: null },
+        { artifact_kind: 'skill', artifact_id: 'sk-empty', file_present: null },
+      ]);
+
+      // The three hostile entries never reach existsSync: only the one
+      // legitimate lookup fires, and it stays under the skills root.
+      const skillChecks = skillPathCalls(existsSpy);
+      expect(skillChecks).toEqual([path.join(skillsRoot, 'good-skill', 'SKILL.md')]);
+      for (const checkedPath of skillChecks) {
+        expect(checkedPath.startsWith(skillsRoot)).toBe(true);
+      }
+
+      // One warn log per bad entry — not noisy, not silent.
+      expect(warnSpy).toHaveBeenCalledTimes(3);
+    } finally {
+      existsSpy.mockRestore();
+    }
+  });
+
+  test('an empty artifact name alone -> null, one warn, no fs check', async () => {
+    const existsSpy = spyOn(fs, 'existsSync');
+    const { h, warnSpy } = handler();
+    try {
+      const res = await h(req(projectRoot, [{ artifact_kind: 'skill', artifact_id: 'sk-empty', name: '' }]));
+      expect(res.status).toBe(200);
+      expect((res.body as { statuses: FileStatusEntry[] }).statuses).toEqual([
+        { artifact_kind: 'skill', artifact_id: 'sk-empty', file_present: null },
+      ]);
+      expect(skillPathCalls(existsSpy)).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      existsSpy.mockRestore();
+    }
+  });
+
+  test('unknown artifact kind -> null, no warn log (a routine, expected shape — not a bad entry)', async () => {
+    const { h, warnSpy } = handler();
+    const res = await h(req(projectRoot, [
+      { artifact_kind: 'okf_page', artifact_id: 'page-1', name: 'architecture/foo' },
+    ]));
+
+    expect(res.status).toBe(200);
+    expect((res.body as { statuses: FileStatusEntry[] }).statuses).toEqual([
+      { artifact_kind: 'okf_page', artifact_id: 'page-1', file_present: null },
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test('a host-served request context -> 404, never resolves paths', async () => {
+    const { h } = handler();
+    const res = await h(req(projectRoot, [{ artifact_kind: 'skill', artifact_id: 'sk-1', name: 'x' }], {
+      requestContext: { hostServed: true } as never,
+    }));
+    expect(res.status).toBe(404);
+  });
+
+  test('current project root does not match the registered root -> 409 root_mismatch with both paths', async () => {
+    const movedRoot = path.join(tmp, 'moved-checkout');
+    fs.mkdirSync(movedRoot, { recursive: true });
+    saveProjectManifest(resolveProjectVaultDir(movedRoot), { project: { id: projectId } });
+
+    const { h } = handler();
+    const res = await h(req(movedRoot, [{ artifact_kind: 'skill', artifact_id: 'sk-1', name: 'x' }]));
+
+    expect(res.status).toBe(409);
+    const body = res.body as { error: { code: string }; registered_root: string; current_root: string };
+    expect(body.error.code).toBe('root_mismatch');
+    expect(body.registered_root).toBe(projectRoot);
+    expect(body.current_root).toBe(path.resolve(movedRoot));
+  });
+
+  test('more than 1000 artifacts -> 413, per-artifact work never runs', async () => {
+    const existsSpy = spyOn(fs, 'existsSync');
+    const { h } = handler();
+    try {
+      const artifacts = Array.from({ length: 1001 }, (_, i) => ({
+        artifact_kind: 'skill',
+        artifact_id: `sk-${i}`,
+        name: `skill-${i}`,
+      }));
+      const res = await h(req(projectRoot, artifacts));
+      expect(res.status).toBe(413);
+      expect((res.body as { error: { code: string } }).error.code).toBe('too_many_artifacts');
+      expect(skillPathCalls(existsSpy)).toEqual([]);
+    } finally {
+      existsSpy.mockRestore();
+    }
+  });
+
+  test('exactly 1000 artifacts stays under the cap (not 413)', async () => {
+    const { h } = handler();
+    const artifacts = Array.from({ length: 1000 }, (_, i) => ({
+      artifact_kind: 'skill',
+      artifact_id: `sk-${i}`,
+      name: `skill-${i}`,
+    }));
+    const res = await h(req(projectRoot, artifacts));
+    expect(res.status).toBe(200);
+    expect((res.body as { statuses: FileStatusEntry[] }).statuses.length).toBe(1000);
+  });
+
+  test('an empty artifacts list -> {statuses: []}', async () => {
+    const { h } = handler();
+    const res = await h(req(projectRoot, []));
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ statuses: [] });
+  });
+});

--- a/tests/daemon/api/content-claims-file-status.test.ts
+++ b/tests/daemon/api/content-claims-file-status.test.ts
@@ -176,6 +176,28 @@ describe('content claim file-status — local project', () => {
     }
   });
 
+  test('malformed entries (null, non-object) never fail the batch — index-aligned nulls with one warn each', async () => {
+    writeSkillFile(projectRoot, 'good-skill');
+
+    const { h, warnSpy } = handler();
+    const res = await h(req(projectRoot, [
+      { artifact_kind: 'skill', artifact_id: 'sk-good', name: 'good-skill' },
+      null,
+      'not-an-object',
+    ]));
+
+    expect(res.status).toBe(200);
+    const statuses = (res.body as { statuses: FileStatusEntry[] }).statuses;
+    // One response entry per request entry, in request order — a bad entry
+    // degrades in place instead of failing the batch or shifting alignment.
+    expect(statuses).toEqual([
+      { artifact_kind: 'skill', artifact_id: 'sk-good', file_present: true },
+      { artifact_kind: null, artifact_id: null, file_present: null },
+      { artifact_kind: null, artifact_id: null, file_present: null },
+    ]);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
   test('unknown artifact kind -> null, no warn log (a routine, expected shape — not a bad entry)', async () => {
     const { h, warnSpy } = handler();
     const res = await h(req(projectRoot, [

--- a/tests/daemon/api/content-claims-materialize.test.ts
+++ b/tests/daemon/api/content-claims-materialize.test.ts
@@ -387,6 +387,35 @@ describe('content claim materialize — local project', () => {
     expect(fs.readFileSync(writtenPath, 'utf-8')).toBe(expected.content);
   });
 
+  test('a same-generation okf_page republish auto-closes the claim — the local publication read is kind-agnostic', async () => {
+    const { pageId, claimId, docPath } = seedOkfPage({ body: 'Body for the okf republish.' });
+    const db = cache.getDatabase(resolveGroveDbPath(groveId, mycoHome));
+    const priorPublishedAt = epochNow() - 3600;
+    withDatabase(db, () => {
+      upsertContentPublication({
+        artifact_kind: 'okf_page',
+        artifact_id: pageId,
+        published_generation: 1, // matches the claim's generation — a republish
+        published_at: priorPublishedAt,
+        published_by: 'machine-a',
+        machine_id: 'machine-a',
+      });
+    });
+
+    const res = await handler()(req(claimId, projectRoot));
+    expect(res.status).toBe(200);
+    const body = res.body as { ok: boolean; page_path: string; generation: number; auto_published: boolean };
+    expect(body).toMatchObject({ ok: true, page_path: docPath, generation: 1, auto_published: true });
+    expect(fs.existsSync(path.join(projectRoot, 'okf', docPath))).toBe(true);
+
+    const claimRow = withDatabase(db, () => getContentClaimById(claimId, projectScope(projectId as GroveProjectId)));
+    expect(claimRow?.state).toBe('published');
+
+    const publication = withDatabase(db, () => getContentPublication('okf_page', pageId));
+    expect(publication?.published_generation).toBe(1);
+    expect(publication?.published_at).toBeGreaterThan(priorPublishedAt);
+  });
+
   test('a non-default config.okf.maintain.output_path resolves the published root — proves the config read, not the fallback', async () => {
     // `output_path` is project-tier (config/scope.ts homes okf.* at 'project'),
     // read from the project's own myco.yaml. A value the hard-coded fallback
@@ -568,7 +597,12 @@ describe('materializeContentClaim orchestration — the re-assert race', () => {
     expect(fs.existsSync(path.join(tmp, 'race.md'))).toBe(false);
   });
 
-  test('a same-generation republish whose mark-published call fails still returns the write outcome with autoPublished:false, and logs a warn', async () => {
+  test('a same-generation republish whose mark-published call fails still returns the write outcome with autoPublished:false — and the orchestration adds no warn of its own', async () => {
+    // Log discipline: the SOURCE owns the markPublished-false warn at its
+    // point of detection (proven against the real remote source by the
+    // overlay suite's failing-mark test). This seam-level test pins the
+    // complementary half — `attemptAutoClose` adds no second, generic warn
+    // on top of a false return, so a real failure logs exactly once.
     const warnings: Array<{ message: string; meta?: Record<string, unknown> }> = [];
     const spyLogger: ProxyLogger = {
       warn: (message, meta) => warnings.push({ message, meta }),
@@ -583,7 +617,7 @@ describe('materializeContentClaim orchestration — the re-assert race', () => {
       },
       getOkfPageContent: unusedOkfPageContent,
       async getPublishedGeneration() { return 1; }, // matches claim.generation -> a same-generation republish
-      async markPublished() { return false; }, // simulated failure AFTER the disk write already landed
+      async markPublished() { return false; }, // failure AFTER the disk write landed; a real source logs this itself
     };
 
     const outcome = await materializeContentClaim('cclaim_fail_mark', tmp, source, unusedOkfPublishedRoot, spyLogger);
@@ -594,7 +628,6 @@ describe('materializeContentClaim orchestration — the re-assert race', () => {
     // The write is the user-visible outcome — it lands regardless of the
     // bookkeeping failure (spec's binding failure posture).
     expect(fs.existsSync(path.join(tmp, CANONICAL_PROJECT_SKILLS_DIR, 'fail-mark-skill', 'SKILL.md'))).toBe(true);
-    expect(warnings.length).toBe(1);
-    expect(warnings[0].message).toContain('auto-close');
+    expect(warnings.length).toBe(0);
   });
 });

--- a/tests/daemon/api/content-claims-materialize.test.ts
+++ b/tests/daemon/api/content-claims-materialize.test.ts
@@ -17,11 +17,18 @@ import {
   materializeContentClaim,
   type ClaimSource,
 } from '@myco/daemon/api/content-claims-materialize.js';
+import type { ProxyLogger } from '@myco/daemon/host-proxy.js';
 import { withDatabase } from '@myco/db/client.js';
 import { registerAgent } from '@myco/db/queries/agents.js';
 import { insertSkillRecord } from '@myco/db/queries/skill-records.js';
 import { insertLineage } from '@myco/db/queries/skill-lineage.js';
-import { insertContentClaim, releaseContentClaim } from '@myco/db/queries/content-claims.js';
+import {
+  insertContentClaim,
+  releaseContentClaim,
+  getContentClaimById,
+  getContentPublication,
+  upsertContentPublication,
+} from '@myco/db/queries/content-claims.js';
 import { getOkfPageRevisionAtGeneration } from '@myco/db/queries/okf.js';
 import { saveProjectManifest } from '@myco/config/project-manifest.js';
 import { MycoConfigSchema } from '@myco/config/schema.js';
@@ -106,6 +113,7 @@ describe('content claim materialize — local project', () => {
       cache,
       dial: (() => { throw new Error('dial must not be called for a local (non-attached) project'); }) as never,
       logger: noopProxyLogger,
+      machineId: 'daemon-machine',
       mycoHome,
     });
   }
@@ -154,7 +162,7 @@ describe('content claim materialize — local project', () => {
       if (!result.ok) throw new Error('test setup: unexpected already_claimed conflict');
       claimId = result.row.id;
     });
-    return { skillId, claimId, name, content };
+    return { skillId, claimId, name, content, generation };
   }
 
   function okfPlan(pagePath: string): WikiPlan {
@@ -240,14 +248,81 @@ describe('content claim materialize — local project', () => {
 
     const res = await handler()(req(claimId, projectRoot));
     expect(res.status).toBe(200);
-    const body = res.body as { ok: boolean; path: string; skill_name: string; generation: number };
-    expect(body).toMatchObject({ ok: true, skill_name: name, generation: 1 });
+    const body = res.body as { ok: boolean; path: string; skill_name: string; generation: number; auto_published: boolean };
+    expect(body).toMatchObject({ ok: true, skill_name: name, generation: 1, auto_published: false });
 
     const writtenPath = path.join(projectRoot, CANONICAL_PROJECT_SKILLS_DIR, name, 'SKILL.md');
     expect(fs.readFileSync(writtenPath, 'utf-8')).toBe(content);
 
     const linkPath = path.join(projectRoot, '.claude', 'skills', name);
     expect(fs.lstatSync(linkPath).isSymbolicLink()).toBe(true);
+
+    // First-time publish (no prior content_publications row): the manual
+    // Mark-published flow owns this, not the republish auto-close — the
+    // claim stays active.
+    const claimRow = withDatabase(cache.getDatabase(resolveGroveDbPath(groveId, mycoHome)), () =>
+      getContentClaimById(claimId, projectScope(projectId as GroveProjectId)));
+    expect(claimRow?.state).toBe('active');
+  });
+
+  test('a same-generation republish (claim generation matches the recorded publication) auto-closes the claim', async () => {
+    const { claimId, skillId, name, content } = seed({ generation: 1, claimedBy: 'machine-a' });
+    const db = cache.getDatabase(resolveGroveDbPath(groveId, mycoHome));
+    const priorPublishedAt = epochNow() - 3600;
+    withDatabase(db, () => {
+      upsertContentPublication({
+        artifact_kind: 'skill',
+        artifact_id: skillId,
+        published_generation: 1,
+        published_at: priorPublishedAt,
+        published_by: 'machine-a',
+        machine_id: 'machine-a',
+      });
+    });
+
+    const res = await handler()(req(claimId, projectRoot));
+    expect(res.status).toBe(200);
+    const body = res.body as { ok: boolean; skill_name: string; generation: number; auto_published: boolean };
+    expect(body).toMatchObject({ ok: true, skill_name: name, generation: 1, auto_published: true });
+
+    // The republished content still lands on disk exactly as a normal
+    // materialize would — auto-close never substitutes for the write.
+    const writtenPath = path.join(projectRoot, CANONICAL_PROJECT_SKILLS_DIR, name, 'SKILL.md');
+    expect(fs.readFileSync(writtenPath, 'utf-8')).toBe(content);
+
+    const claimRow = withDatabase(db, () => getContentClaimById(claimId, projectScope(projectId as GroveProjectId)));
+    expect(claimRow?.state).toBe('published');
+
+    const publication = withDatabase(db, () => getContentPublication('skill', skillId));
+    expect(publication?.published_generation).toBe(1);
+    expect(publication?.published_at).toBeGreaterThan(priorPublishedAt);
+  });
+
+  test('a different-generation materialize (content evolved since the last publish) leaves the claim active, auto_published false', async () => {
+    const { claimId, skillId, generation: claimGeneration } = seed({ generation: 2 });
+    expect(claimGeneration).toBe(2);
+    const db = cache.getDatabase(resolveGroveDbPath(groveId, mycoHome));
+    withDatabase(db, () => {
+      upsertContentPublication({
+        artifact_kind: 'skill',
+        artifact_id: skillId,
+        published_generation: 1, // an OLDER generation than the claim being materialized now
+        published_at: epochNow() - 3600,
+        published_by: 'machine-a',
+        machine_id: 'machine-a',
+      });
+    });
+
+    const res = await handler()(req(claimId, projectRoot));
+    expect(res.status).toBe(200);
+    const body = res.body as { ok: boolean; generation: number; auto_published: boolean };
+    expect(body).toMatchObject({ ok: true, generation: 2, auto_published: false });
+
+    const claimRow = withDatabase(db, () => getContentClaimById(claimId, projectScope(projectId as GroveProjectId)));
+    expect(claimRow?.state).toBe('active');
+
+    const publication = withDatabase(db, () => getContentPublication('skill', skillId));
+    expect(publication?.published_generation).toBe(1); // unchanged — the manual flow owns this generation
   });
 
   test('a released (no longer active) claim -> 409 claim_not_active, nothing written', async () => {
@@ -407,6 +482,16 @@ async function unusedOkfPublishedRoot(): Promise<never> {
   throw new Error('resolveOkfPublishedRootFn must not be called for a skill claim');
 }
 
+/** The re-assert race tests below never reach a successful write, so the
+ *  post-write auto-close check never runs — these stubs prove it by throwing
+ *  if the orchestration ever calls them in those tests. */
+async function unusedGetPublishedGeneration(): Promise<never> {
+  throw new Error('getPublishedGeneration must not be called when the write never lands');
+}
+async function unusedMarkPublished(): Promise<never> {
+  throw new Error('markPublished must not be called when the write never lands');
+}
+
 describe('materializeContentClaim orchestration — the re-assert race', () => {
   let tmp: string;
 
@@ -433,9 +518,11 @@ describe('materializeContentClaim orchestration — the re-assert race', () => {
         return { name: 'race-skill', content: '# race\n' };
       },
       getOkfPageContent: unusedOkfPageContent,
+      getPublishedGeneration: unusedGetPublishedGeneration,
+      markPublished: unusedMarkPublished,
     };
 
-    const outcome = await materializeContentClaim('cclaim_race', tmp, source, unusedOkfPublishedRoot);
+    const outcome = await materializeContentClaim('cclaim_race', tmp, source, unusedOkfPublishedRoot, noopProxyLogger);
     expect(outcome).toEqual({ ok: false, code: 'claim_no_longer_active' });
     expect(calls).toBe(2);
     expect(fs.existsSync(path.join(tmp, CANONICAL_PROJECT_SKILLS_DIR, 'race-skill'))).toBe(false);
@@ -447,9 +534,11 @@ describe('materializeContentClaim orchestration — the re-assert race', () => {
       async getActiveClaim() { return null; },
       async getSkillContent() { contentFetched = true; return { name: 'x', content: 'x' }; },
       getOkfPageContent: unusedOkfPageContent,
+      getPublishedGeneration: unusedGetPublishedGeneration,
+      markPublished: unusedMarkPublished,
     };
 
-    const outcome = await materializeContentClaim('cclaim_stale', tmp, source, unusedOkfPublishedRoot);
+    const outcome = await materializeContentClaim('cclaim_stale', tmp, source, unusedOkfPublishedRoot, noopProxyLogger);
     expect(outcome).toEqual({ ok: false, code: 'claim_not_active' });
     expect(contentFetched).toBe(false);
   });
@@ -468,12 +557,44 @@ describe('materializeContentClaim orchestration — the re-assert race', () => {
         contentFetched = true;
         return { path: 'race.md', frontmatter: JSON.stringify({ type: 'note', title: 't', description: 'd', timestamp: '2026-01-01T00:00:00Z' }), body: 'race body' };
       },
+      getPublishedGeneration: unusedGetPublishedGeneration,
+      markPublished: unusedMarkPublished,
     };
 
-    const outcome = await materializeContentClaim('cclaim_okf_race', tmp, source, async () => tmp);
+    const outcome = await materializeContentClaim('cclaim_okf_race', tmp, source, async () => tmp, noopProxyLogger);
     expect(outcome).toEqual({ ok: false, code: 'claim_no_longer_active' });
     expect(calls).toBe(2);
     expect(contentFetched).toBe(true); // content WAS fetched — the re-assert runs after, per spec §4 step 3
     expect(fs.existsSync(path.join(tmp, 'race.md'))).toBe(false);
+  });
+
+  test('a same-generation republish whose mark-published call fails still returns the write outcome with autoPublished:false, and logs a warn', async () => {
+    const warnings: Array<{ message: string; meta?: Record<string, unknown> }> = [];
+    const spyLogger: ProxyLogger = {
+      warn: (message, meta) => warnings.push({ message, meta }),
+      error() { /* unused */ },
+    };
+    const source: ClaimSource = {
+      async getActiveClaim(id) {
+        return { id, artifactKind: 'skill', artifactId: 'skill-fail-mark', generation: 1 };
+      },
+      async getSkillContent() {
+        return { name: 'fail-mark-skill', content: '# fail\n' };
+      },
+      getOkfPageContent: unusedOkfPageContent,
+      async getPublishedGeneration() { return 1; }, // matches claim.generation -> a same-generation republish
+      async markPublished() { return false; }, // simulated failure AFTER the disk write already landed
+    };
+
+    const outcome = await materializeContentClaim('cclaim_fail_mark', tmp, source, unusedOkfPublishedRoot, spyLogger);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok && outcome.artifactKind === 'skill') {
+      expect(outcome.autoPublished).toBe(false);
+    }
+    // The write is the user-visible outcome — it lands regardless of the
+    // bookkeeping failure (spec's binding failure posture).
+    expect(fs.existsSync(path.join(tmp, CANONICAL_PROJECT_SKILLS_DIR, 'fail-mark-skill', 'SKILL.md'))).toBe(true);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0].message).toContain('auto-close');
   });
 });

--- a/tests/daemon/api/content-claims.test.ts
+++ b/tests/daemon/api/content-claims.test.ts
@@ -7,7 +7,7 @@
 import { describe, expect, it, beforeAll, afterAll, beforeEach } from 'bun:test';
 import { setupTestDb, cleanTestDb, teardownTestDb } from '../../helpers/db';
 import { registerAgent } from '@myco/db/queries/agents.js';
-import { insertSkillRecord, updateSkillRecord } from '@myco/db/queries/skill-records.js';
+import { insertSkillRecord, updateSkillRecord, deleteSkillRecordCascade } from '@myco/db/queries/skill-records.js';
 import { insertOkfPage } from '@myco/db/queries/okf.js';
 import { getContentPublication, upsertContentPublication } from '@myco/db/queries/content-claims.js';
 import { projectScope, type GroveProjectId } from '@myco/grove/ids.js';
@@ -168,6 +168,104 @@ describe('content claim daemon API', () => {
       expect(body.claimable[0].active_claim).toMatchObject({ claimed_by: 'machine-a', generation: 1, stale: true });
       expect(body.active_claims).toHaveLength(1);
       expect(body.active_claims[0]).toMatchObject({ claimed_by: 'machine-a', stale: true });
+    });
+
+    it('surfaces a published-at-latest artifact in `published` with active_claim populated, and excludes it from `claimable`', async () => {
+      seedSkill('skill-1');
+      const created = await handleContentClaimCreate(
+        req({ body: { artifact_kind: 'skill', artifact_id: 'skill-1' } }),
+        principal('machine-a'),
+      );
+      const claimId = (created.body as { claim: { id: string } }).claim.id;
+      await handleContentClaimPublished(req({ params: { id: claimId } }), principal('machine-a'));
+
+      // The first claim is now `published`, not `active` — a second claim on
+      // the still-published artifact (same generation) is free to succeed.
+      await handleContentClaimCreate(
+        req({ body: { artifact_kind: 'skill', artifact_id: 'skill-1' } }),
+        principal('machine-b'),
+      );
+
+      const res = await handleContentClaimsList(req(), principal());
+      const body = res.body as {
+        ok: boolean;
+        claimable: unknown[];
+        published: Array<Record<string, unknown>>;
+        active_claims: unknown[];
+      };
+      expect(Object.keys(body).sort()).toEqual(['active_claims', 'claimable', 'ok', 'published']);
+      expect(body.claimable).toHaveLength(0);
+      expect(body.published).toHaveLength(1);
+      expect(body.published[0]).toMatchObject({
+        artifact_kind: 'skill',
+        artifact_id: 'skill-1',
+        name: 'skill-1',
+        label: 'skill-1',
+        published_generation: 1,
+        lineage_generation: 1,
+      });
+      expect(body.published[0].active_claim).toMatchObject({ claimed_by: 'machine-b', state: 'active', stale: false });
+    });
+
+    it('a stale-published artifact appears in `claimable` only, with the pre-existing claimable shape unchanged', async () => {
+      seedSkill('skill-1');
+      const created = await handleContentClaimCreate(
+        req({ body: { artifact_kind: 'skill', artifact_id: 'skill-1' } }),
+        principal('machine-a'),
+      );
+      const claimId = (created.body as { claim: { id: string } }).claim.id;
+      await handleContentClaimPublished(req({ params: { id: claimId } }), principal('machine-a'));
+      updateSkillRecord('skill-1', { generation: 2 }, projectScope(PROJECT_ID as GroveProjectId));
+
+      const res = await handleContentClaimsList(req(), principal());
+      const body = res.body as { claimable: Array<Record<string, unknown>>; published: unknown[] };
+      expect(body.published).toHaveLength(0);
+      expect(body.claimable).toHaveLength(1);
+      expect(body.claimable[0]).toEqual({
+        artifact_kind: 'skill',
+        artifact_id: 'skill-1',
+        label: 'skill-1',
+        lineage_generation: 2,
+        published_generation: 1,
+        active_claim: null,
+      });
+    });
+
+    it('a published-at-latest okf_page emits no `published` entry (skills-only)', async () => {
+      seedOkfPage('page-1');
+      upsertContentPublication({
+        artifact_kind: 'okf_page',
+        artifact_id: 'page-1',
+        published_generation: 1,
+        published_at: epochNow(),
+        published_by: 'machine-a',
+        machine_id: 'machine-a',
+      });
+
+      const res = await handleContentClaimsList(req(), principal());
+      const body = res.body as { claimable: unknown[]; published: unknown[] };
+      expect(body.published).toHaveLength(0);
+      expect(body.claimable).toHaveLength(0);
+    });
+
+    it('a publication row whose skill record was deleted emits no `published` entry (orphan)', async () => {
+      seedSkill('skill-1');
+      const created = await handleContentClaimCreate(
+        req({ body: { artifact_kind: 'skill', artifact_id: 'skill-1' } }),
+        principal('machine-a'),
+      );
+      const claimId = (created.body as { claim: { id: string } }).claim.id;
+      await handleContentClaimPublished(req({ params: { id: claimId } }), principal('machine-a'));
+
+      deleteSkillRecordCascade('skill-1', projectScope(PROJECT_ID as GroveProjectId));
+
+      const res = await handleContentClaimsList(req(), principal());
+      const body = res.body as { claimable: unknown[]; published: unknown[] };
+      expect(body.published).toHaveLength(0);
+      expect(body.claimable).toHaveLength(0);
+      // The durable publication marker survives the delete — proves the join
+      // iterates scoped skill records, not `listContentPublications()`.
+      expect(getContentPublication('skill', 'skill-1')).not.toBeNull();
     });
   });
 

--- a/tests/daemon/content-claims-materialize-overlay.test.ts
+++ b/tests/daemon/content-claims-materialize-overlay.test.ts
@@ -38,7 +38,7 @@ import { defaultDial } from '@myco/daemon/host-proxy.js';
 import { registerAgent } from '@myco/db/queries/agents.js';
 import { insertSkillRecord } from '@myco/db/queries/skill-records.js';
 import { insertLineage } from '@myco/db/queries/skill-lineage.js';
-import { insertContentClaim } from '@myco/db/queries/content-claims.js';
+import { insertContentClaim, upsertContentPublication } from '@myco/db/queries/content-claims.js';
 import { getOkfPageRevisionAtGeneration } from '@myco/db/queries/okf.js';
 import { getDatabase, initDatabase, closeDatabase } from '@myco/db/client.js';
 import { createGrove, registerProjectInGrove, clearGroveRegistryCaches } from '@myco/grove/registry.js';
@@ -208,6 +208,7 @@ describe('content claim materialize over the Team Host overlay', () => {
       cache: hostCache,
       dial: defaultDial,
       logger: noopProxyLogger,
+      machineId: 'host-machine',
       mycoHome,
     });
     await hostServer.start(0);
@@ -246,6 +247,12 @@ describe('content claim materialize over the Team Host overlay', () => {
       cache: memberCache,
       dial: defaultDial,
       logger: noopProxyLogger,
+      // Matches `claimedBy` on both fixture claims above: the auto-close
+      // mark-published dial stamps this as the member's own machine id
+      // (`REQUEST_CONTEXT_HEADERS.machineId`), and the host's holder gate
+      // (`content-claims.ts`'s `loadActiveHeldClaim`) requires it to equal
+      // `claim.claimed_by`.
+      machineId: 'attached-member-machine',
       mycoHome,
     });
     await memberServer.start(0);
@@ -276,8 +283,8 @@ describe('content claim materialize over the Team Host overlay', () => {
       body: JSON.stringify({ project_root: memberProjectRoot }),
     });
     expect(res.status).toBe(200);
-    const body = await res.json() as { ok: boolean; skill_name: string; generation: number };
-    expect(body).toMatchObject({ ok: true, skill_name: 'skill-1', generation: 1 });
+    const body = await res.json() as { ok: boolean; skill_name: string; generation: number; auto_published: boolean };
+    expect(body).toMatchObject({ ok: true, skill_name: 'skill-1', generation: 1, auto_published: false });
 
     const written = fs.readFileSync(
       path.join(memberProjectRoot, CANONICAL_PROJECT_SKILLS_DIR, 'skill-1', 'SKILL.md'),
@@ -289,13 +296,57 @@ describe('content claim materialize over the Team Host overlay', () => {
     // Grove DB, not the member's working tree (B1).
     expect(fs.existsSync(path.join(hostProjectRoot, CANONICAL_PROJECT_SKILLS_DIR))).toBe(false);
 
-    // The claim on the host's Grove DB is still `active` — materialize does
-    // not itself transition the claim; the holder marks it published after
-    // committing (a separate, later step, out of this task's scope).
+    // No prior publication row exists for this artifact, so this is a
+    // first-time publish, not a republish — the claim on the host's Grove DB
+    // stays `active` for the manual Mark-published flow (Task 1.4's
+    // republish auto-close is covered by the test below).
     const row = getDatabase().prepare(
       `SELECT state FROM content_claims WHERE id = ?`,
     ).get(claimId) as { state: string } | undefined;
     expect(row?.state).toBe('active');
+  });
+
+  test('member republishes a same-generation claim — auto-closes through the proxied mark-published call', async () => {
+    const priorPublishedAt = Math.floor(Date.now() / 1000) - 3600;
+    upsertContentPublication({
+      artifact_kind: 'skill',
+      artifact_id: 'skill-1',
+      published_generation: 1, // matches the fixture claim's own generation — a republish
+      published_at: priorPublishedAt,
+      published_by: 'attached-member-machine',
+      machine_id: 'attached-member-machine',
+    });
+
+    const res = await fetch(`${memberBase}/api/content-claims/${claimId}/materialize`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ project_root: memberProjectRoot }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean; skill_name: string; generation: number; auto_published: boolean };
+    expect(body).toMatchObject({ ok: true, skill_name: 'skill-1', generation: 1, auto_published: true });
+
+    // The republished content still lands on the member's tree exactly as a
+    // normal materialize would.
+    const written = fs.readFileSync(
+      path.join(memberProjectRoot, CANONICAL_PROJECT_SKILLS_DIR, 'skill-1', 'SKILL.md'),
+      'utf-8',
+    );
+    expect(written).toBe(CONTENT);
+
+    // The member dialed the host's OWN `POST /api/content-claims/:id/published`
+    // through the real overlay — the close landed on the host's Grove DB.
+    const claimRow = getDatabase().prepare(
+      `SELECT state, published_at FROM content_claims WHERE id = ?`,
+    ).get(claimId) as { state: string; published_at: number } | undefined;
+    expect(claimRow?.state).toBe('published');
+    expect(claimRow?.published_at).toBeGreaterThan(priorPublishedAt);
+
+    const pubRow = getDatabase().prepare(
+      `SELECT published_generation, published_at FROM content_publications WHERE artifact_kind = 'skill' AND artifact_id = 'skill-1'`,
+    ).get() as { published_generation: number; published_at: number } | undefined;
+    expect(pubRow?.published_generation).toBe(1);
+    expect(pubRow?.published_at).toBeGreaterThan(priorPublishedAt);
   });
 
   test('member materializes an attached okf_page claim by dialing the host directly — byte-faithful, lands on the MEMBER tree only', async () => {

--- a/tests/daemon/content-claims-materialize-overlay.test.ts
+++ b/tests/daemon/content-claims-materialize-overlay.test.ts
@@ -30,6 +30,7 @@ import { DaemonLogger } from '@myco/daemon/logger.js';
 import type { DaemonStateAuthority } from '@myco/daemon/daemon-state-authority.js';
 import { registerContentClaimRoutes } from '@myco/daemon/api/content-claims.js';
 import { registerContentClaimMaterializeRoute } from '@myco/daemon/api/content-claims-materialize.js';
+import { registerContentClaimFileStatusRoute } from '@myco/daemon/api/content-claims-file-status.js';
 import { handleGetSkillRecord } from '@myco/daemon/api/skills.js';
 import { handleOkfPageRevisionsById } from '@myco/daemon/api/okf.js';
 import { tenantRoute } from '@myco/daemon/api/route-helpers.js';
@@ -193,6 +194,12 @@ describe('content claim materialize over the Team Host overlay', () => {
       hostServe: { overlayAddress: '127.0.0.1', overlayPort: 0, bearer: HOST_BEARER },
     });
     registerContentClaimRoutes(hostServer, { machineId: 'host-machine', logger: hostLogger });
+    // Registered so the host's own overlay-stamp backstop (`overlayHostStampRefusal`
+    // in `daemon/server.ts`) has a matched route to classify — an overlay hit on
+    // this `localhost-only`-stamped path must be refused BEFORE the handler below
+    // ever resolves a member's disk (see the transport-boundary test at the bottom
+    // of this file).
+    registerContentClaimFileStatusRoute(hostServer, { logger: noopProxyLogger, mycoHome });
     hostServer.registerRoute(
       'GET',
       '/api/skill-records/:id',
@@ -243,6 +250,13 @@ describe('content claim materialize over the Team Host overlay', () => {
       daemonStateAuthority: stubAuthority,
     });
     memberCache = new GroveRuntimeCache();
+    // Registered locally (mirroring production `daemon/main.ts`, which wires every
+    // content-claim route on every daemon unconditionally) so the router match
+    // succeeds and the daemon's attach-classification chokepoint (`server.ts`
+    // `handleRequest`) runs at all — for an attached project this `serve`-stamped
+    // GET is then proxied to the host rather than invoking this local handler
+    // (see the inventory-through-the-proxy test at the bottom of this file).
+    registerContentClaimRoutes(memberServer, { machineId: 'attached-member-machine', logger: memberLogger });
     registerContentClaimMaterializeRoute(memberServer, {
       cache: memberCache,
       dial: defaultDial,
@@ -566,5 +580,91 @@ describe('content claim materialize over the Team Host overlay', () => {
     // Nothing landed anywhere a materialize write could plausibly have gone.
     expect(fs.existsSync(path.join(hostProjectRoot, CANONICAL_PROJECT_SKILLS_DIR))).toBe(false);
     expect(fs.existsSync(path.join(memberProjectRoot, CANONICAL_PROJECT_SKILLS_DIR))).toBe(false);
+  });
+
+  test('an attached member GET /api/content-claims proxies to the host and carries the published[] entry, with active_claim', async () => {
+    // skill-1 published at its own lineage-latest generation (1) — the
+    // inventory route's `addCandidate` (content-claims.ts) routes this to
+    // `published`, not `claimable`, and still attaches the live claim fixture
+    // set up above (also generation 1, still `active`) as `active_claim`.
+    const publishedAt = Math.floor(Date.now() / 1000) - 60;
+    upsertContentPublication({
+      artifact_kind: 'skill',
+      artifact_id: 'skill-1',
+      published_generation: 1,
+      published_at: publishedAt,
+      published_by: 'attached-member-machine',
+      machine_id: 'attached-member-machine',
+    });
+
+    // No `x-myco-machine-id` — this is the member DAEMON's own attach-classification
+    // dispatch, the same header shape the dashboard's inventory fetch uses. The
+    // member has no local Grove DB for this project at all (B1's whole premise):
+    // this can ONLY resolve by the member proxying to the host over the real
+    // overlay dial, never a local answer.
+    //
+    // `x-myco-project-id` is a context-switching header (grove/request-context.ts),
+    // so the member daemon's own auth-token gate requires its bearer here — the
+    // same token a spawned child (hook/MCP) inherits via `MYCO_REQUEST_CONTEXT_AUTH`.
+    const res = await fetch(`${memberBase}/api/content-claims`, {
+      headers: { 'x-myco-project-id': projectId, 'x-myco-auth': memberServer.getAuthToken() },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      ok: boolean;
+      published: Array<{
+        artifact_kind: string;
+        artifact_id: string;
+        name: string;
+        label: string;
+        published_generation: number;
+        lineage_generation: number;
+        active_claim: { id: string; state: string; generation: number; claimed_by: string } | null;
+      }>;
+    };
+    expect(body.ok).toBe(true);
+    const entry = body.published.find((p) => p.artifact_id === 'skill-1');
+    expect(entry).toMatchObject({
+      artifact_kind: 'skill',
+      artifact_id: 'skill-1',
+      name: 'skill-1',
+      label: 'Skill One',
+      published_generation: 1,
+      lineage_generation: 1,
+    });
+    expect(entry?.active_claim).toMatchObject({
+      id: claimId,
+      state: 'active',
+      generation: 1,
+      claimed_by: 'attached-member-machine',
+    });
+  });
+
+  test('a file-status POST arriving over the overlay is refused at the transport boundary — never resolves a member disk', async () => {
+    // The member-disk-truth sibling of the materialize refusal above: the
+    // `localhost-only` stamp (host/routing.ts) and the host's independent
+    // overlay backstop (`overlayHostStampRefusal`, server.ts) hold for
+    // `/api/content-claims/file-status` exactly as they do for materialize —
+    // the specific `message`/`retryable` fields (not just a bare 404) prove the
+    // STAMP-based refusal fired, not merely "no such route registered here".
+    const res = await fetch(`http://127.0.0.1:${hostServer.overlayPort}/api/content-claims/file-status`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${HOST_BEARER}`,
+        'x-myco-host-protocol': String(HOST_PROTOCOL_VERSION),
+        'x-myco-grove-id': groveId,
+        'x-myco-project-id': projectId,
+      },
+      body: JSON.stringify({
+        project_root: hostProjectRoot,
+        artifacts: [{ artifact_kind: 'skill', artifact_id: 'skill-1', name: 'skill-1' }],
+      }),
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json() as { error: string; message: string; retryable: boolean };
+    expect(body.error).toBe('not_found');
+    expect(body.message).toBe('This route is served on localhost only, not over the overlay.');
+    expect(body.retryable).toBe(false);
   });
 });

--- a/tests/daemon/content-claims-materialize-overlay.test.ts
+++ b/tests/daemon/content-claims-materialize-overlay.test.ts
@@ -349,15 +349,103 @@ describe('content claim materialize over the Team Host overlay', () => {
     expect(pubRow?.published_at).toBeGreaterThan(priorPublishedAt);
   });
 
+  test('a same-generation republish whose proxied mark-published call fails (real 403 not_holder) still returns the write with auto_published:false and exactly ONE warn', async () => {
+    // Drives the REAL remote source's mark-failure path end-to-end: this
+    // member daemon's machineId does not match the claim's `claimed_by`, so
+    // every read dial succeeds and the write lands, but the host's holder
+    // gate 403s the mark-published POST. The failure posture (200 +
+    // auto_published:false) and the single-warn discipline (the remote
+    // source's one detection warn, nothing added by the orchestration) are
+    // both asserted against real code, not a hand-rolled ClaimSource.
+    upsertContentPublication({
+      artifact_kind: 'skill',
+      artifact_id: 'skill-1',
+      published_generation: 1, // same generation as the claim — the auto-close check fires
+      published_at: Math.floor(Date.now() / 1000) - 3600,
+      published_by: 'attached-member-machine',
+      machine_id: 'attached-member-machine',
+    });
+
+    const warnings: Array<{ message: string; meta?: Record<string, unknown> }> = [];
+    const spyLogger = {
+      warn(message: string, meta?: Record<string, unknown>): void { warnings.push({ message, meta }); },
+      error(): void { /* unused */ },
+    };
+    const nonHolderLogger = new DaemonLogger(path.join(tmp, 'non-holder-logs'));
+    const nonHolderServer = new DaemonServer({
+      vaultDir: path.join(tmp, 'non-holder-anchor', '.myco'),
+      logger: nonHolderLogger,
+      daemonStateAuthority: stubAuthority,
+    });
+    const nonHolderCache = new GroveRuntimeCache();
+    registerContentClaimMaterializeRoute(nonHolderServer, {
+      cache: nonHolderCache,
+      dial: defaultDial,
+      logger: spyLogger,
+      machineId: 'not-the-claim-holder', // != claimed_by -> the host's holder gate 403s the mark dial
+      mycoHome,
+    });
+    await nonHolderServer.start(0);
+
+    try {
+      const res = await fetch(`http://127.0.0.1:${nonHolderServer.port}/api/content-claims/${claimId}/materialize`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ project_root: memberProjectRoot }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json() as { ok: boolean; skill_name: string; generation: number; auto_published: boolean };
+      expect(body).toMatchObject({ ok: true, skill_name: 'skill-1', generation: 1, auto_published: false });
+
+      // The write is the user-visible outcome — it landed on the member tree
+      // despite the failed bookkeeping.
+      const written = fs.readFileSync(
+        path.join(memberProjectRoot, CANONICAL_PROJECT_SKILLS_DIR, 'skill-1', 'SKILL.md'),
+        'utf-8',
+      );
+      expect(written).toBe(CONTENT);
+
+      // The host refused the close: the claim stays active for the holder's
+      // own manual Mark-published flow or TTL expiry.
+      const claimRow = getDatabase().prepare(
+        `SELECT state FROM content_claims WHERE id = ?`,
+      ).get(claimId) as { state: string } | undefined;
+      expect(claimRow?.state).toBe('active');
+
+      // Exactly one warn: the remote source's detection log (carrying the
+      // dial's real 403), with no second generic warn from the orchestration.
+      expect(warnings.length).toBe(1);
+      expect(warnings[0].message).toContain('mark-published');
+      expect(warnings[0].meta?.status).toBe(403);
+    } finally {
+      try { await nonHolderServer.stop(); } catch { /* not started */ }
+      try { nonHolderCache.closeAll(); } catch { /* not created */ }
+    }
+  });
+
   test('member materializes an attached okf_page claim by dialing the host directly — byte-faithful, lands on the MEMBER tree only', async () => {
+    // Pin the okf_page half of the auto-close asymmetry: even with a
+    // same-generation publication row on record, an attached okf_page never
+    // auto-closes — the inventory's `published[]` array (the attached
+    // branch's only publication read) is skills-only by design (spec §2(a)),
+    // so the remote source resolves no published generation for the page.
+    upsertContentPublication({
+      artifact_kind: 'okf_page',
+      artifact_id: okfPageId,
+      published_generation: 1, // matches the claim's generation — would auto-close on the LOCAL branch
+      published_at: Math.floor(Date.now() / 1000) - 3600,
+      published_by: 'attached-member-machine',
+      machine_id: 'attached-member-machine',
+    });
+
     const res = await fetch(`${memberBase}/api/content-claims/${okfClaimId}/materialize`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ project_root: memberProjectRoot }),
     });
     expect(res.status).toBe(200);
-    const body = await res.json() as { ok: boolean; path: string; page_path: string; generation: number };
-    expect(body).toMatchObject({ ok: true, page_path: okfDocPath, generation: 1 });
+    const body = await res.json() as { ok: boolean; path: string; page_path: string; generation: number; auto_published: boolean };
+    expect(body).toMatchObject({ ok: true, page_path: okfDocPath, generation: 1, auto_published: false });
 
     const revision = getOkfPageRevisionAtGeneration(okfPageId, 1)!;
     const expected = renderOkfDocument({
@@ -374,6 +462,13 @@ describe('content claim materialize over the Team Host overlay', () => {
 
     // The host's own project tree was never touched (B1).
     expect(fs.existsSync(path.join(hostProjectRoot, 'okf'))).toBe(false);
+
+    // No auto-close fired: the claim on the host's Grove DB stays active for
+    // the manual Mark-published flow.
+    const claimRow = getDatabase().prepare(
+      `SELECT state FROM content_claims WHERE id = ?`,
+    ).get(okfClaimId) as { state: string } | undefined;
+    expect(claimRow?.state).toBe('active');
   });
 
   test('attached member with a non-default output_path in its own myco.yaml materializes there — proves the attached config resolution, not the fallback', async () => {

--- a/tests/ui/content-claim-control.test.tsx
+++ b/tests/ui/content-claim-control.test.tsx
@@ -17,8 +17,8 @@
  * claim just created, or leave a published artifact still in the inventory.
  */
 
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { render, screen, waitFor, fireEvent, act, cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import { vi } from '../helpers/vi-shim.js';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { PowerProvider } from '../../packages/myco/ui/src/providers/power';
@@ -169,6 +169,21 @@ beforeEach(() => {
   });
 });
 
+// Without this, an earlier test's ClaimControl instance stays mounted (and
+// its QueryClient's background refetches keep running) while a later test
+// executes — a stray invalidation from that leftover instance updates state
+// outside any `act()` the later test controls, and React warns about it
+// attributed to a generically-named component with no test context. Flush
+// one macrotask under `act()` BEFORE unmounting so an in-flight mock fetch
+// (the mocks don't honor AbortSignal) settles and its state update lands
+// while the tree is still mounted and act-tracked, not after.
+afterEach(async () => {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  cleanup();
+});
+
 /* ---------- Tests ---------- */
 
 describe('ClaimControl — already published', () => {
@@ -285,6 +300,268 @@ describe('ClaimControl — mark published', () => {
 describe('ClaimControl — release', () => {
   it('clicking Release posts to /content-claims/:id/release and returns to the unclaimed state', async () => {
     seedActiveClaim('machine-a');
+    renderControl();
+    await waitFor(() => expect(screen.getByTestId('release-claim')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('release-claim'));
+
+    await waitFor(() => {
+      expect(postJsonMock).toHaveBeenCalledWith('/content-claims/cclaim_aaaa/release', {});
+    });
+    await waitFor(() => expect(screen.getByTestId('claim-and-materialize')).toBeInTheDocument());
+  });
+});
+
+/* ---------- Merged state: published-at-latest but missing from disk ---------- */
+
+/**
+ * A second fake-server model, independent of the `claimable` one above: one
+ * skill already published at its lineage-latest generation (so it's ONLY in
+ * `published`, never `claimable`), plus a controllable file-status batch
+ * response. Exercises the real `useContentFileStatus`/`findPublishedArtifact`
+ * wiring against a mocked `lib/api`, matching this file's existing "exercise
+ * the real hooks" convention.
+ */
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('ClaimControl — published but missing from the working tree (merged state)', () => {
+  let mergedActiveClaim: ContentClaimView | null;
+  let filePresent: boolean | null;
+  let fileStatusOk: boolean;
+  let autoPublishOnMaterialize: boolean;
+
+  function mergedListResponse(): ContentClaimsListResponse {
+    return {
+      ok: true,
+      claimable: [],
+      published: [
+        {
+          artifact_kind: 'skill',
+          artifact_id: 'skill-1',
+          name: 'my-skill',
+          label: 'My Skill',
+          published_generation: 3,
+          lineage_generation: 3,
+          active_claim: mergedActiveClaim,
+        },
+      ],
+      active_claims: mergedActiveClaim ? [mergedActiveClaim] : [],
+    };
+  }
+
+  function seedMergedActiveClaim(claimedBy: string): void {
+    mergedActiveClaim = {
+      id: 'cclaim_aaaa',
+      artifact_kind: 'skill',
+      artifact_id: 'skill-1',
+      generation: 3,
+      claimed_by: claimedBy,
+      claimed_at: Math.floor(Date.now() / 1000) - 120,
+      expires_at: Math.floor(Date.now() / 1000) + 86_400,
+      state: 'active',
+      released_at: null,
+      published_at: null,
+      stale: false,
+    };
+  }
+
+  beforeEach(() => {
+    mergedActiveClaim = null;
+    filePresent = false;
+    fileStatusOk = true;
+    autoPublishOnMaterialize = true;
+
+    fetchJsonMock.mockImplementation(async (path: string) => {
+      if (path === '/content-claims') return mergedListResponse();
+      if (path === '/content-claims/file-status') {
+        if (!fileStatusOk) {
+          throw new (class ApiError extends Error {
+            status = 409;
+            body = { error: { code: 'root_mismatch' } };
+          })('root mismatch');
+        }
+        return { statuses: [{ artifact_kind: 'skill', artifact_id: 'skill-1', file_present: filePresent }] };
+      }
+      return {};
+    });
+
+    postJsonMock.mockImplementation(async (path: string) => {
+      if (path === '/content-claims') {
+        if (mergedActiveClaim) {
+          throw new (class ApiError extends Error {
+            status = 409;
+            body = { error: { code: 'already_claimed' }, holder: mergedActiveClaim };
+          })('already claimed');
+        }
+        seedMergedActiveClaim('machine-a');
+        return { ok: true, claim: mergedActiveClaim, content: {} };
+      }
+      if (path === '/content-claims/cclaim_aaaa/materialize') {
+        filePresent = true;
+        if (autoPublishOnMaterialize) mergedActiveClaim = null;
+        return {
+          ok: true,
+          path: '.claude/skills/my-skill/SKILL.md',
+          skill_name: 'my-skill',
+          generation: 3,
+          auto_published: autoPublishOnMaterialize,
+        };
+      }
+      if (path === '/content-claims/cclaim_aaaa/release') {
+        const released = { ...(mergedActiveClaim as ContentClaimView), state: 'released' as const };
+        mergedActiveClaim = null;
+        return { ok: true, claim: released };
+      }
+      throw new Error(`unexpected POST ${path}`);
+    });
+  });
+
+  it('renders nothing for a healthy published artifact (file present, no claim) — same as today', async () => {
+    filePresent = true;
+    const { container } = renderControl();
+
+    await waitFor(() => expect(fetchJsonMock).toHaveBeenCalledWith('/content-claims', expect.anything()));
+    await waitFor(() => expect(container.textContent).toBe(''));
+  });
+
+  it('renders Publish when published-at-latest, the file is missing, and there is no active claim', async () => {
+    renderControl();
+
+    await waitFor(() => expect(screen.getByTestId('claim-and-materialize')).toBeInTheDocument());
+    expect(screen.getByTestId('claim-and-materialize')).toHaveTextContent('Publish');
+    expect(screen.getByText(/Published file missing from your checkout/)).toBeInTheDocument();
+    expect(screen.queryByText('Unpublished')).toBeNull();
+  });
+
+  it('renders nothing when file_present is null (degraded) — no affordance', async () => {
+    filePresent = null;
+    const { container } = renderControl();
+
+    await waitFor(() => expect(fetchJsonMock).toHaveBeenCalledWith('/content-claims/file-status', expect.anything()));
+    await waitFor(() => expect(container.textContent).toBe(''));
+  });
+
+  it('renders nothing when the file-status batch fails (non-200) — no affordance', async () => {
+    fileStatusOk = false;
+    const { container } = renderControl();
+
+    await waitFor(() => expect(fetchJsonMock).toHaveBeenCalledWith('/content-claims/file-status', expect.anything()));
+    await waitFor(() => expect(container.textContent).toBe(''));
+  });
+
+  it('renders nothing when `published` is missing entirely from the response', async () => {
+    fetchJsonMock.mockImplementation(async (path: string) =>
+      path === '/content-claims' ? { ok: true, claimable: [], active_claims: [] } : {},
+    );
+    const { container } = renderControl();
+
+    await waitFor(() => expect(fetchJsonMock).toHaveBeenCalled());
+    expect(container.textContent).toBe('');
+  });
+
+  it('keeps Publish visible and disabled through claiming and materializing — never vanishes mid-flow', async () => {
+    const claimGate = deferred<void>();
+    const materializeGate = deferred<void>();
+    postJsonMock.mockImplementation(async (path: string) => {
+      if (path === '/content-claims') {
+        await claimGate.promise;
+        seedMergedActiveClaim('machine-a');
+        return { ok: true, claim: mergedActiveClaim, content: {} };
+      }
+      if (path === '/content-claims/cclaim_aaaa/materialize') {
+        await materializeGate.promise;
+        filePresent = true;
+        mergedActiveClaim = null;
+        return {
+          ok: true,
+          path: '.claude/skills/my-skill/SKILL.md',
+          skill_name: 'my-skill',
+          generation: 3,
+          auto_published: true,
+        };
+      }
+      throw new Error(`unexpected POST ${path}`);
+    });
+
+    renderControl();
+    await waitFor(() => expect(screen.getByTestId('claim-and-materialize')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('claim-and-materialize'));
+
+    // Claiming: the button stays in the DOM, disabled, labeled as in-flight.
+    await waitFor(() => expect(screen.getByTestId('claim-and-materialize')).toBeDisabled());
+    expect(screen.getByTestId('claim-and-materialize')).toHaveTextContent('Publishing…');
+
+    await act(async () => {
+      claimGate.resolve();
+      await Promise.resolve();
+    });
+
+    // Materializing: still the SAME button, still visible and disabled — not
+    // swapped out for a holder/Release display, even though the server now
+    // has an active claim held by this machine.
+    await waitFor(() => expect(screen.getByTestId('materializing')).toBeInTheDocument());
+    expect(screen.getByTestId('claim-and-materialize')).toBeInTheDocument();
+    expect(screen.getByTestId('claim-and-materialize')).toBeDisabled();
+    expect(screen.queryByTestId('claim-held-by-me')).toBeNull();
+
+    await act(async () => {
+      materializeGate.resolve();
+      await Promise.resolve();
+    });
+
+    // Same-generation republish auto-closes; the repair is complete and the
+    // control returns to rendering nothing, with no Mark-published step ever
+    // shown for this flow.
+    await waitFor(() => expect(screen.queryByTestId('claim-control-skill-skill-1')).toBeNull());
+    expect(screen.queryByTestId('mark-published')).toBeNull();
+  });
+
+  it('a stale active claim held by this machine shows Release, not Mark published', async () => {
+    seedMergedActiveClaim('machine-a');
+    renderControl();
+
+    await waitFor(() => expect(screen.getByTestId('claim-held-by-me')).toBeInTheDocument());
+    expect(screen.getByTestId('release-claim')).toBeInTheDocument();
+    expect(screen.queryByTestId('mark-published')).toBeNull();
+    expect(screen.queryByTestId('claim-and-materialize')).toBeNull();
+  });
+
+  it('a stale active claim held by another machine shows the holder and age, no actions', async () => {
+    seedMergedActiveClaim('machine-b');
+    renderControl();
+
+    await waitFor(() => expect(screen.getByTestId('claim-held-by-other')).toBeInTheDocument());
+    expect(screen.getByTestId('claim-held-by-other')).toHaveTextContent('machine-b');
+    expect(screen.queryByTestId('release-claim')).toBeNull();
+    expect(screen.queryByTestId('claim-and-materialize')).toBeNull();
+  });
+
+  it('clicking Publish auto-closes on a same-generation republish — invalidates and clears the affordance', async () => {
+    renderControl();
+    await waitFor(() => expect(screen.getByTestId('claim-and-materialize')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('claim-and-materialize'));
+
+    await waitFor(() => {
+      expect(postJsonMock).toHaveBeenCalledWith('/content-claims/cclaim_aaaa/materialize', { project_root: '/repo' });
+    });
+    // auto_published: true closed the claim server-side (simulated by the fake
+    // server clearing `mergedActiveClaim`) — no Mark-published affordance
+    // ever appears, and the repaired entry drops out once the invalidated
+    // queries refetch.
+    await waitFor(() => expect(screen.queryByTestId('claim-control-skill-skill-1')).toBeNull());
+    expect(screen.queryByTestId('mark-published')).toBeNull();
+  });
+
+  it('Release still works from the merged state and returns to Publish', async () => {
+    seedMergedActiveClaim('machine-a');
     renderControl();
     await waitFor(() => expect(screen.getByTestId('release-claim')).toBeInTheDocument());
 

--- a/tests/ui/okf-page.test.tsx
+++ b/tests/ui/okf-page.test.tsx
@@ -121,6 +121,9 @@ const PAGES: OkfPageSummary[] = [
 mock.module('../../packages/myco/ui/src/hooks/use-content-claims', () => ({
   useContentClaims: () => ({ data: undefined, isLoading: false }),
   findClaimableArtifact: () => undefined,
+  findPublishedArtifact: () => undefined,
+  useContentFileStatus: () => ({ data: undefined, isLoading: false, isError: false }),
+  useInvalidateContentClaims: () => () => {},
   useMyMachineId: () => undefined,
   useReleaseContentClaim: () => ({ mutate: () => {}, isPending: false }),
   useMarkContentClaimPublished: () => ({ mutate: () => {}, isPending: false }),

--- a/tests/ui/skills-tabs.test.tsx
+++ b/tests/ui/skills-tabs.test.tsx
@@ -88,12 +88,25 @@ mock.module('../../packages/myco/ui/src/hooks/use-debounce', () => ({
   useDebounce: (v: string) => v,
 }));
 
-// SkillList renders the content-claims "Unpublished" badge per row (B6) —
-// stub the hook so this unrelated test doesn't need a PowerProvider or a
-// mocked lib/api just to satisfy usePowerQuery's context requirement.
+// SkillList renders the content-claims "Unpublished" badge per row, and
+// SkillDetail renders the full ClaimControl (B6) — stub every hook
+// ClaimControl imports so this unrelated test doesn't need a PowerProvider
+// or a mocked lib/api just to satisfy usePowerQuery's context requirement.
 mock.module('../../packages/myco/ui/src/hooks/use-content-claims', () => ({
   useContentClaims: () => ({ data: undefined, isLoading: false }),
   findClaimableArtifact: () => undefined,
+  findPublishedArtifact: () => undefined,
+  useContentFileStatus: () => ({ data: undefined, isLoading: false, isError: false }),
+  useInvalidateContentClaims: () => () => {},
+  useMyMachineId: () => undefined,
+  useReleaseContentClaim: () => ({ mutate: () => {}, isPending: false }),
+  useMarkContentClaimPublished: () => ({ mutate: () => {}, isPending: false }),
+  useClaimAndMaterialize: () => ({
+    phase: { status: 'idle' },
+    run: () => {},
+    retryMaterialize: () => {},
+    reset: () => {},
+  }),
 }));
 
 import Skills from '../../packages/myco/ui/src/pages/Skills';

--- a/tests/ui/use-content-claims.test.tsx
+++ b/tests/ui/use-content-claims.test.tsx
@@ -16,7 +16,11 @@ import { vi } from '../helpers/vi-shim.js';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import { POLL_INTERVALS } from '../../packages/myco/ui/src/lib/constants';
-import type { ContentClaimView, ContentClaimsListResponse } from '../../packages/myco/ui/src/hooks/use-content-claims';
+import type {
+  ContentClaimView,
+  ContentClaimsListResponse,
+  PublishedArtifactView,
+} from '../../packages/myco/ui/src/hooks/use-content-claims';
 
 /* ---------- Mocks ---------- */
 
@@ -30,13 +34,14 @@ mock.module('../../packages/myco/ui/src/hooks/use-project-selection', () => ({
 }));
 
 const postJsonMock = vi.fn();
+const fetchJsonMock = vi.fn();
 class MockApiError extends Error {
   constructor(public status: number, public body: unknown) {
     super(`API error ${status}`);
   }
 }
 mock.module('../../packages/myco/ui/src/lib/api', () => ({
-  fetchJson: vi.fn(),
+  fetchJson: (...args: unknown[]) => fetchJsonMock(...args),
   postJson: (...args: unknown[]) => postJsonMock(...args),
   putJson: async () => ({}),
   patchJson: async () => ({}),
@@ -58,6 +63,8 @@ import {
   useClaimAndMaterialize,
   useMyMachineId,
   findClaimableArtifact,
+  findPublishedArtifact,
+  useContentFileStatus,
 } from '../../packages/myco/ui/src/hooks/use-content-claims';
 
 /* ---------- Fixtures ---------- */
@@ -131,6 +138,108 @@ describe('findClaimableArtifact', () => {
   });
 });
 
+function publishedFixture(overrides: Partial<PublishedArtifactView> = {}): PublishedArtifactView {
+  return {
+    artifact_kind: 'skill',
+    artifact_id: 'skill-1',
+    name: 'my-skill',
+    label: 'My Skill',
+    published_generation: 3,
+    lineage_generation: 3,
+    active_claim: null,
+    ...overrides,
+  };
+}
+
+describe('findPublishedArtifact', () => {
+  it('finds the matching published-at-latest artifact by kind + id', () => {
+    const data: ContentClaimsListResponse = {
+      ok: true,
+      claimable: [],
+      published: [publishedFixture(), publishedFixture({ artifact_id: 'skill-2', label: 'Other' })],
+      active_claims: [],
+    };
+    expect(findPublishedArtifact(data, 'skill', 'skill-1')?.label).toBe('My Skill');
+    expect(findPublishedArtifact(data, 'skill', 'skill-2')?.label).toBe('Other');
+    expect(findPublishedArtifact(data, 'skill', 'missing')).toBeUndefined();
+  });
+
+  it('treats a missing `published` field as [] — a response from a daemon build that predates the field', () => {
+    expect(findPublishedArtifact(undefined, 'skill', 'skill-1')).toBeUndefined();
+    const withoutPublished: ContentClaimsListResponse = { ok: true, claimable: [], active_claims: [] };
+    expect(findPublishedArtifact(withoutPublished, 'skill', 'skill-1')).toBeUndefined();
+  });
+});
+
+describe('useContentFileStatus', () => {
+  beforeEach(() => {
+    usePowerQueryMock.mockReset();
+    fetchJsonMock.mockReset();
+  });
+
+  it('polls /content-claims/file-status at the CONTENT_CLAIMS interval, keyed on root + the derived batch', () => {
+    usePowerQueryMock.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+
+    renderHook(() => useContentFileStatus('/proj', [publishedFixture()]));
+
+    expect(usePowerQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: [
+          'content-claims',
+          'file-status',
+          '/proj',
+          [{ artifact_kind: 'skill', artifact_id: 'skill-1', name: 'my-skill' }],
+        ],
+        enabled: true,
+        refetchInterval: POLL_INTERVALS.CONTENT_CLAIMS,
+        pollCategory: 'standard',
+      }),
+    );
+  });
+
+  it('is disabled (no request fires) when the published list is empty', () => {
+    usePowerQueryMock.mockReturnValue({ data: undefined, isLoading: false, isError: false });
+
+    renderHook(() => useContentFileStatus('/proj', []));
+
+    expect(usePowerQueryMock).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
+  });
+
+  it('is disabled (no request fires) when there is no project root, even with published artifacts', () => {
+    usePowerQueryMock.mockReturnValue({ data: undefined, isLoading: false, isError: false });
+
+    renderHook(() => useContentFileStatus(undefined, [publishedFixture()]));
+
+    expect(usePowerQueryMock).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
+  });
+
+  it('the query function POSTs {project_root, artifacts} derived from the published entries', async () => {
+    usePowerQueryMock.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    fetchJsonMock.mockResolvedValue({ statuses: [] });
+
+    renderHook(() =>
+      useContentFileStatus('/proj', [publishedFixture(), publishedFixture({ artifact_id: 'skill-2', name: 'other-skill' })]),
+    );
+
+    const call = usePowerQueryMock.mock.calls.at(-1)?.[0] as { queryFn: (ctx: { signal?: AbortSignal }) => unknown };
+    await call.queryFn({});
+
+    expect(fetchJsonMock).toHaveBeenCalledWith(
+      '/content-claims/file-status',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          project_root: '/proj',
+          artifacts: [
+            { artifact_kind: 'skill', artifact_id: 'skill-1', name: 'my-skill' },
+            { artifact_kind: 'skill', artifact_id: 'skill-2', name: 'other-skill' },
+          ],
+        }),
+      }),
+    );
+  });
+});
+
 describe('useMyMachineId', () => {
   it("reads this daemon's own machine id off /stats", () => {
     useDaemonMock.mockReturnValue({
@@ -173,7 +282,13 @@ describe('mutations', () => {
   });
 
   it('useMaterializeContentClaim posts {project_root} to /content-claims/:id/materialize', async () => {
-    postJsonMock.mockResolvedValue({ ok: true, path: '/proj/.claude/skills/foo/SKILL.md', skill_name: 'foo', generation: 2 });
+    postJsonMock.mockResolvedValue({
+      ok: true,
+      path: '/proj/.claude/skills/foo/SKILL.md',
+      skill_name: 'foo',
+      generation: 2,
+      auto_published: false,
+    });
     const { result } = renderHook(() => useMaterializeContentClaim(), { wrapper });
 
     result.current.mutate({ claimId: 'cclaim_aaaa', projectRoot: '/proj' });
@@ -213,7 +328,13 @@ describe('useClaimAndMaterialize', () => {
     postJsonMock.mockImplementation(async (path: string) => {
       if (path === '/content-claims') return { ok: true, claim: claimFixture(), content: {} };
       if (path === '/content-claims/cclaim_aaaa/materialize') {
-        return { ok: true, path: '/proj/.claude/skills/foo/SKILL.md', skill_name: 'foo', generation: 2 };
+        return {
+          ok: true,
+          path: '/proj/.claude/skills/foo/SKILL.md',
+          skill_name: 'foo',
+          generation: 2,
+          auto_published: false,
+        };
       }
       throw new Error(`unexpected path ${path}`);
     });
@@ -228,6 +349,7 @@ describe('useClaimAndMaterialize', () => {
       status: 'success',
       claimId: 'cclaim_aaaa',
       path: '/proj/.claude/skills/foo/SKILL.md',
+      autoPublished: false,
     });
     expect(postJsonMock).toHaveBeenCalledWith('/content-claims', { artifact_kind: 'skill', artifact_id: 'skill-1' });
     expect(postJsonMock).toHaveBeenCalledWith('/content-claims/cclaim_aaaa/materialize', { project_root: '/proj' });
@@ -277,7 +399,13 @@ describe('useClaimAndMaterialize', () => {
     // Retrying materialize (without re-claiming) succeeds against the same held claim.
     postJsonMock.mockImplementation(async (path: string) => {
       if (path === '/content-claims/cclaim_aaaa/materialize') {
-        return { ok: true, path: '/proj/.claude/skills/foo/SKILL.md', skill_name: 'foo', generation: 2 };
+        return {
+          ok: true,
+          path: '/proj/.claude/skills/foo/SKILL.md',
+          skill_name: 'foo',
+          generation: 2,
+          auto_published: false,
+        };
       }
       throw new Error(`unexpected path ${path}`);
     });
@@ -290,6 +418,36 @@ describe('useClaimAndMaterialize', () => {
       status: 'success',
       claimId: 'cclaim_aaaa',
       path: '/proj/.claude/skills/foo/SKILL.md',
+      autoPublished: false,
+    });
+  });
+
+  it('carries `auto_published: true` on the success phase for a same-generation republish', async () => {
+    postJsonMock.mockImplementation(async (path: string) => {
+      if (path === '/content-claims') return { ok: true, claim: claimFixture(), content: {} };
+      if (path === '/content-claims/cclaim_aaaa/materialize') {
+        return {
+          ok: true,
+          path: '/proj/.claude/skills/foo/SKILL.md',
+          skill_name: 'foo',
+          generation: 2,
+          auto_published: true,
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    const { result } = renderHook(() => useClaimAndMaterialize(), { wrapper });
+
+    await act(async () => {
+      await result.current.run({ artifactKind: 'skill', artifactId: 'skill-1', projectRoot: '/proj' });
+    });
+
+    expect(result.current.phase).toEqual({
+      status: 'success',
+      claimId: 'cclaim_aaaa',
+      path: '/proj/.claude/skills/foo/SKILL.md',
+      autoPublished: true,
     });
   });
 });


### PR DESCRIPTION
## What this fixes

A git-deleted published skill was permanently unpublishable from the UI. The claims API observed zero disk state — "published" was a pure DB generation-equality check, so once a SKILL.md left the working tree, the artifact vanished from the claimable inventory, `ClaimControl` rendered nothing, and no republish path existed.

## Design (spec: `docs/superpowers/specs/2026-07-10-publication-coupling-okf-disposition-design.md`, v2.1)

Publication validity is recomputed at read time from two orthogonal truths, merged in the UI — no new tables, no jobs, no drift states, no reconciler:

- **Host DB truth:** the inventory GET gains an additive `published[]` array (published-at-latest skills; carries `name` as the path-derivation key and the artifact's `active_claim`). Skills-only; derived from scoped records so orphaned publication rows never emit entries. Existing response fields byte-identical (snapshot-asserted).
- **Member disk truth:** new `localhost-only` `POST /api/content-claims/file-status` — reuses the materialize handler's project-context prelude (extracted to a shared helper, behavior byte-identical) and the existing pure escape-guarded path resolver + `existsSync`. Per-artifact `null` degrade (a bad batch entry never fails the batch), 1000-entry cap, explicit ROUTE_RULES stamp.
- **UI merge:** `ClaimControl` renders **Publish** for published-at-latest + file-missing + unclaimed; visibility keys off the phase machine (never vanishes mid-flow); every degrade path (non-200, `null`, missing `published` field) collapses to today's behavior.
- **Republish auto-closes:** a same-generation republish marks published server-side in the materialize flow (idempotent transaction; dialed with the member's machine id for the host's holder gate when attached). Without this, the repair claim dangled as an invisible 24h lock and blocked repeat repair — all three independent spec reviewers converged on this.

## Verification

- Per-task independent reviews (two loops caught and fixed real defects pre-merge: a batch-crash on malformed entries; missing okf-path coverage + a double-warn discipline violation).
- Final whole-branch review: ready-to-merge; fix wave applied.
- Full `npm test` + `make build` green; overlay fixture tests drive the real two-daemon proxy path.
- **Live rig smoke (ship gate) passed** on the standing Team Host rig with real overlay traffic and real dashboard clicks: delete → Publish appears within one poll → click → file returns byte-identical and the claim ends `published` on the host under the member's machine id → delete again → repeat repair succeeds in the same sitting; zero dangling active claims; zero tenancy failures in member logs across the flow.

## Notes

- PR-2 (OKF retirement + shipped `myco-okf` skill) follows separately per the plan's two-PR order; it narrows the claim system to skills-only in the same files this PR touches.
- Follow-ups from review triage are recorded on the implementation plan (`docs/superpowers/plans/2026-07-10-publication-coupling-okf-retirement.md`), most riding PR-2's claim-narrowing task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
