### PR TITLE
docs(skills): codify capture classification and sub-agent thread patterns

### DIFF
--- a/.agents/skills/add-symbiont/SKILL.md
+++ b/.agents/skills/add-symbiont/SKILL.md
@@ -129,6 +129,47 @@ hookFields:
 
 `normalizeHookInput()` reads the active manifest at hook runtime and applies the mapping before any processing logic runs. Each hook invocation is a fresh process, so per-invocation manifest detection is correct.
 
+### 5a. Declare Capture Classification Rules
+
+A new agent emits more than human prompts: slash-command dispatch envelopes, runtime/system continuations, agent-to-agent notifications, and (for some agents) wrapped human input. Declare `capture.rules` in the manifest so these are filtered or classified instead of leaking as human prompts. Rules are `{ event, scope, when, action }` records evaluated first-match-wins by `evaluateUserPromptRules` — a YAML-only surface; no evaluator code changes.
+
+**The `when` predicates** (a rule fires only when every condition matches):
+
+- `prompt_starts_with` / `prompt_contains` — literal text guards.
+- `transcript_path_missing` — structural: fires when the hook carried no transcript path (an ephemeral phantom sub-invocation).
+- `transcript_meta_field_exists` / `transcript_meta_field_equals` — dot-path checks into the transcript's first JSON line (`session_meta`).
+- `prompt_envelope_tag_in: [tags]` — **structural, attribute-robust**: matches when the prompt begins with `<tag` for any listed tag name, ignoring attributes, so `<agent-message from="…">` still matches `agent-message`. Prefer this over `prompt_starts_with: "<tag"` for XML envelopes.
+- `prompt_is_enclosing_envelope: true` — **structural whole-message fail-safe**: fires when the ENTIRE trimmed prompt is one balanced/self-closing XML envelope.
+
+**The three action lanes:**
+
+- `drop` — remove the event. Only for *proven-valueless* content (duplicate dispatch envelopes, no-transcript phantoms, non-interactive `exec`). Never drop anything that might carry user intent.
+- `classify` + `set_origin` — capture but tag the batch `system` or `agent_dispatch` (hidden behind the dashboard's system/sub-agent filter). Origins: `human` (default), `system` (runtime/synthesized continuations), `agent_dispatch` (sub-agent → parent), `hook_injected` (reserved).
+- `rewrite_prompt` — unwrap a human wrapper: `strip_envelope: {open, close}` removes a tag pair; `extract_after: "<marker>"` keeps the text after a preamble. The stored prompt then holds only the user's text.
+
+**Session-level classification.** `event: session_start` rules run at SessionStart *and* at Stop-driven registration (via `evaluateSessionCaptureRules`), so a phantom or sub-agent session is refused at every materialization boundary, not just the first. `session_start` rules can only `drop` — there is no prompt text to rewrite yet.
+
+**Fail-safe ordering invariant.** The `prompt_is_enclosing_envelope: true` rule classifies every unknown whole-message envelope as `system` (preserved, hidden), so new runtime envelopes never leak as human. It MUST be the **last** `user_prompt` rule (first-match-wins), placed after every `drop` and every human-wrapper `rewrite_prompt`.
+
+**When NOT to add the fail-safe.** Only agents whose human input arrives *unwrapped* may carry it. Agents that wrap the user's own message in an envelope — Cursor `<user_query>…</user_query>`, Cline `<user_input>…</user_input>` — must instead **strip that wrapper first** with a `rewrite_prompt` + `strip_envelope` rule and carry NO fail-safe: otherwise the fail-safe hides every real human prompt as `system`.
+
+### 5b. Declare Sub-Agent Thread Paths (only if the agent isolates sub-agents)
+
+Declare these three `capture:` dot-paths ONLY for agents that write sub-agent work into *separate* transcripts (Codex `thread_spawn`). They let the miner attribute a sub-agent's turns to the PARENT session as `agent_dispatch` batches carrying a `thread_id`/`thread_label` — one session, many threads, no child session row. Omit all three for agents with no sub-agent concept or whose sub-agent turns already land inline on the parent transcript.
+
+```yaml
+capture:
+  subagentParentPath: source.subagent.thread_spawn.parent_thread_id  # → parent session id
+  subagentThreadIdPath: id                                           # → the thread's own stable id
+  subagentLabelPath: source.subagent.thread_spawn                    # → object with the label fields
+```
+
+- `subagentParentPath` — the parent session/thread id the batches attach to. Its absence means "not a sub-agent thread."
+- `subagentThreadIdPath` — the thread's OWN id (distinct from the daemon session id); folded into `content_hash` so sibling threads with identical text don't dedupe into each other.
+- `subagentLabelPath` — points at the OBJECT carrying the friendly label. The derivation (`agent_nickname` when non-empty, else the last `/`-segment of `agent_path`) lives in `resolveSubagentThread` in code, because a single dot-path can't express that fallback — the manifest stays a pure location declaration.
+
+Verify each path against a real child transcript's first JSON line before shipping; a wrong `subagentThreadIdPath` makes the miner drop the sub-agent instead of reattributing it (it logs a WARN naming the field).
+
 ### 6. Wire Instruction File (If Needed)
 
 If the new agent does **not** read `AGENTS.md` natively, declare `instructionsFile` in the manifest:

--- a/.agents/skills/debug-capture/SKILL.md
+++ b/.agents/skills/debug-capture/SKILL.md
@@ -123,6 +123,37 @@ If the session row exists but batches don't (or vice versa) — that's a FK or t
 
 If the rows exist but you can't see them via a scoped query (e.g., from the UI for project A) — that's the multi-tenancy shape. The row's `project_id` must match the request context's project scope.
 
+### Step 4b — Is the prompt captured but hidden? (classification)
+
+A prompt the agent "sent" can be in the DB yet absent from the default UI because it was *classified* rather than dropped. Check the origin before concluding anything was lost:
+
+```bash
+sqlite3 "$GROVE_DB" "SELECT id, origin, thread_id, substr(user_prompt,1,60) FROM prompt_batches WHERE session_id = '<sid>' ORDER BY id"
+```
+
+`origin` records WHO issued the prompt. A non-`human` origin (`system`, `agent_dispatch`) is captured but hidden behind the dashboard's "Show system & sub-agent prompts" filter — the data is present, just filtered out of the default view.
+
+The capture rules act in three lanes; know which one handled the prompt:
+
+- **`drop`** — the event is removed entirely. Reserved for *proven-valueless* content only: duplicate slash-command dispatch envelopes (`<command-message>` / `<command-name>` / `<local-command-stdout>`), ephemeral phantoms with no transcript, non-interactive `exec` transcripts. If a real prompt was dropped, a `drop` rule matched too broadly.
+- **`classify` + `set_origin`** — preserve-and-hide: the prompt is stored but tagged `system` or `agent_dispatch`. This is the origin you see in Step 4b.
+- **`rewrite_prompt`** (`strip_envelope` / `extract_after`) — unwrap a human wrapper so the stored prompt holds only the user's text (e.g. Codex's `## My request for Codex:` preamble).
+
+To find which rule fired, grep the daemon log for the rule's `reason` audit string:
+
+```bash
+grep '"session_id":"<sid>"' ~/.myco/service*/logs/daemon.log | grep -E 'reason|envelope|dispatch' | tail
+```
+
+Two structural predicates drive classification (both prefer message *shape* over brittle text):
+
+- **`prompt_envelope_tag_in: [tags]`** — matches when the prompt begins with `<tag` for any listed tag name, ignoring attributes, so `<agent-message from="…">` still matches `agent-message`. Maps known runtime/agent envelopes to an origin.
+- **`prompt_is_enclosing_envelope: true`** — the whole-message fail-safe: fires when the ENTIRE trimmed prompt is one balanced (or self-closing) XML envelope, and classifies it `system` (preserved, hidden). It MUST be the last `user_prompt` rule (first-match-wins) and belongs only on agents whose human input does NOT arrive wrapped.
+
+**Common misclassifications:**
+- A real human prompt tagged `system` with `reason` ending `-unknown-envelope` — the fail-safe caught it. Either the agent's `prompt_envelope_tag_in` map is missing that tag (add it with the right origin), or the agent wraps its human input in an envelope and should NOT carry the fail-safe at all (strip the wrapper first instead — see `add-symbiont`).
+- A prompt hidden as `agent_dispatch` that was genuinely user-typed — an envelope-tag rule listed a tag that also appears in human prompts.
+
 ### Step 5 — Did transcript-mining add the post-stop turns?
 
 ```bash
@@ -141,6 +172,32 @@ wc -l <transcript_path>
 If `/events/stop` arrived but the post-stop turns aren't in the DB, the transcript miner either didn't recognize the file format, or it deduped against an in-flight live capture (correctly or incorrectly). Compare batch counts before and after the stop window.
 
 If `/events/stop` never arrived — the agent crashed or was killed without firing it. The reconciler at next daemon startup should pick this up via the buffer replay; check `lifecycle.reconcile` entries in the log.
+
+### Step 5b — Is a sub-agent's transcript "missing"?
+
+An agent that isolates sub-agent work into separate transcripts (Codex `thread_spawn`) does not get its own session row. Its turns are mined into the PARENT session as batches carrying `origin='agent_dispatch'` and a non-null `thread_id` (+ `thread_label`) — one session, many threads. So a sub-agent whose work appears "missing" is usually on the parent under a thread id, not lost.
+
+Query thread rows explicitly — they are scoped away from the main thread:
+
+```bash
+# Sub-agent thread batches live on the PARENT session id under a thread_id.
+sqlite3 "$GROVE_DB" "SELECT id, origin, thread_id, thread_label, substr(user_prompt,1,50) FROM prompt_batches WHERE session_id = '<parent_sid>' AND thread_id IS NOT NULL ORDER BY thread_id, id"
+```
+
+Attribution runs through `resolveSubagentThread`, which reads three manifest-declared dot-paths from the transcript's `session_meta`:
+
+- **`subagentParentPath`** → the parent session/thread id the batches attach to.
+- **`subagentThreadIdPath`** → the thread's OWN stable id (folded into `content_hash` so sibling threads with identical text don't dedupe into each other).
+- **`subagentLabelPath`** → the object carrying the friendly label (`thread_label`, derived as `agent_nickname` else the last segment of `agent_path`).
+
+If a manifest omits `subagentParentPath`, the agent has no sub-agent thread concept and its transcripts are top-level sessions — this step doesn't apply.
+
+**Two distinct WARN logs pinpoint the break** (grep `processor.transcript`):
+
+- *"Sub-agent transcript has a resolvable parent but no thread id — dropping instead of reattributing (check `subagentThreadIdPath`)"* — the parent resolved but the thread id didn't, so the miner drops rather than mine an un-thread-scoped row. Fix the agent's `subagentThreadIdPath`.
+- *"Sub-agent reattribution active but no maskable drop rule found"* — reattribution fired but the agent's capture rules lack the `source.subagent` drop the reattributing mine masks, so records may all drop. Add the structural sub-agent drop rule to the manifest.
+
+If neither parent nor thread id resolves, the transcript follows the ordinary drop path (unresolvable-parent sub-agent stops are dropped by design), and any leaked child session row is cleaned up.
 
 ### Step 6 — Did MCP tool calls log?
 
@@ -170,5 +227,6 @@ If you fixed a regression while debugging, the right follow-up is:
 
 - `references/capture-lifecycle.md` — the layered tenet
 - `references/symbiont-capture-contract.md` — per-agent capture differences
+- `packages/myco/src/hooks/capture-rules.ts` — the rule evaluator, structural predicates, and `resolveSubagentThread`
 - `packages/myco/src/daemon/session-lifecycle.ts` — the `ensureSession*` contract (in code)
 - `.agents/skills/debug-daemon-errors/SKILL.md` — broader daemon debugging

--- a/.agents/skills/debug-capture/references/symbiont-capture-contract.md
+++ b/.agents/skills/debug-capture/references/symbiont-capture-contract.md
@@ -33,6 +33,21 @@ The values below are derived from the symbiont manifests in `packages/myco/src/s
 - **Project root resolution** — how the daemon knows which project's vault to route the event to. Claude Code uses an env var the agent injects; everyone else carries `cwd` in the hook payload.
 - **Manifest rules** — declarative filters that drop or rewrite specific event shapes before they hit the dispatcher. These are how we handle agent-specific quirks (slash command dispatch envelopes, ephemeral sub-invocations, etc.) without hardcoding agent names in the dispatcher.
 
+## Prompt classification (origin) and sub-agent threads
+
+Beyond drop/keep, each agent's `capture.rules` classify prompts by *origin* — WHO issued them — so non-human prompts are preserved but hidden by default. Three action lanes:
+
+- **`drop`** — proven-valueless only (duplicate dispatch envelopes, no-transcript phantoms, non-interactive `exec`).
+- **`classify` + `set_origin`** — capture but tag `system` or `agent_dispatch` (hidden behind the "Show system & sub-agent prompts" filter). Origin values: `human` (default), `system` (runtime/synthesized continuations), `agent_dispatch` (sub-agent → parent), `hook_injected` (reserved).
+- **`rewrite_prompt`** — unwrap a human wrapper (`strip_envelope` for a tag pair, `extract_after` for a marker preamble) so the stored prompt is only the user's text.
+
+Two structural predicates decide classification without brittle text matching:
+
+- `prompt_envelope_tag_in: [tags]` — attribute-robust open-tag-name match (`<agent-message from="…">` matches `agent-message`); maps known envelopes to an origin.
+- `prompt_is_enclosing_envelope: true` — whole-message fail-safe → `system`. MUST be the last `user_prompt` rule, and only for agents whose human input is NOT itself wrapped. Agents that wrap human input (e.g. Cursor `<user_query>`, Cline `<user_input>`) strip the wrapper first and carry no fail-safe, otherwise every human prompt hides as `system`.
+
+Sub-agent threads (agents that isolate sub-agent work into separate transcripts, e.g. Codex `thread_spawn`): the sub-agent's turns are mined into the PARENT session as `agent_dispatch` batches with a non-null `thread_id`/`thread_label` — one session, many threads, no child session row. Three manifest dot-paths drive it: `subagentParentPath`, `subagentThreadIdPath`, `subagentLabelPath` (all in `capture:`). Agents without `subagentParentPath` have no thread concept.
+
 ## Where to look when this doc is wrong
 
 The source of truth for everything in the matrix lives under `packages/myco/src/symbionts/`:

--- a/.agents/skills/vault-schema-migration/SKILL.md
+++ b/.agents/skills/vault-schema-migration/SKILL.md
@@ -140,6 +140,28 @@ grep -r "D1\|BACKFILL_TABLES" packages/myco/src --include="*.ts"
 
 Common D1 tables include: `team_outbox`, `notifications`, `agent_runs`, and `sessions` (if team sync is enabled).
 
+The authoritative synced-table set lives in `packages/myco-team/worker/src/synced-tables.ts` (`SYNCED_TABLES`). If your changed table is in that set, the parity rule below is mandatory.
+
+#### 6a-parity. The synced-column parity rule — every local column must reach the D1 mirror
+
+**Any column added to a synced table MUST also be added to the D1 worker mirror.** The worker's insert path (`buildInsertParts` in `packages/myco-team/worker/src/index.ts`) builds its column list from the row payload, not from an allowlist — `sanitizeSyncPayload` only strips `LOCAL_ONLY_SYNC_COLUMNS`. So any new local column rides straight into the worker's `INSERT OR REPLACE INTO ${table} (...)`, and if D1 has no matching column, D1 throws `no such column` for **every** unsynced row of that table — a total sync stall for the table, with no local error.
+
+Mirror the column with the **3-part idempotent pattern** in `packages/myco-team/worker/src/schema.ts`, all inside `initD1Schema` (which is idempotent and runs on every request):
+
+1. **DDL** — add the column to the table's `CREATE TABLE` constant (e.g. `PROMPT_BATCHES_TABLE`), so fresh D1 databases get it at creation.
+2. **Idempotent ALTER** — add `ALTER TABLE <table> ADD COLUMN <col> <type>` to the `migrations` array; it runs inside a try/catch that swallows the "column already exists" error, so existing D1 databases pick it up on the next request.
+3. **`verifyColumnsAddressable`** — add the column to that table's entry in the `verifyColumnsAddressable(db, [...])` list, so a lazy/partial schema-cache refresh that hasn't propagated the ALTER fails fast and is retried on the next request instead of silently dropping writes.
+
+If the new column is intentionally local-only (never synced), add it to `LOCAL_ONLY_SYNC_COLUMNS[table]` in `packages/myco/src/db/queries/team-outbox.ts` instead — then it's stripped before the payload reaches the worker.
+
+**The column-parity test enforces this.** `tests/db/synced-table-parity.test.ts` extracts column names from both the local and worker `CREATE TABLE` DDL strings and asserts every synced local column (minus `LOCAL_ONLY_SYNC_COLUMNS` and globally-stripped columns) exists on the worker DDL. Adding a synced column without its worker counterpart turns this test red and names the offending column — run it after any synced-table change:
+
+```bash
+npm test -- tests/db/synced-table-parity.test.ts
+```
+
+**Older binary on a newer schema is safe for additive-nullable columns.** The local `createSchema` migration loop no-ops when the vault's `user_version` is already ahead of the running binary's `SCHEMA_VERSION` (the `if (currentVersion < N)` blocks are all skipped), and every query names its columns explicitly rather than `SELECT *`. So a machine still on an older binary reading a vault another machine migrated forward keeps working, as long as the new columns are **additive and nullable** (no NOT-NULL-without-default, no dropped/renamed columns an old query still references). This is the guarantee that lets a mixed-version team share one synced schema.
+
 #### 6b. Generate D1 migration SQL
 
 Extract the SQL statements from your migration block that affect D1 tables:
@@ -214,6 +236,34 @@ ls docs/ | grep schema
 grep -r "schema v" memory/ --include="*.md"
 ```
 
+### 9. Migrate a real existing vault offline (with backup)
+
+When you need to apply a new binary's migration to a live vault that already holds real data (e.g. before shipping, or to recover a stuck vault), do it offline with a backup so a bad migration is fully reversible:
+
+```bash
+# 1. Stop the daemon so nothing writes mid-migration.
+myco daemon stop      # or the service stop for your install
+
+# 2. Back up the DB and its write-ahead log together — the WAL holds
+#    committed pages not yet checkpointed into the main file; copying the
+#    .db without the .wal can restore a torn state.
+GROVE_DB=~/.myco/groves/<grove-id>/myco.db
+cp "$GROVE_DB"      "$GROVE_DB.bak"
+cp "$GROVE_DB-wal"  "$GROVE_DB-wal.bak" 2>/dev/null || true
+
+# 3. Open the vault once with the new binary so createSchema runs the
+#    migration chain to the new SCHEMA_VERSION.
+myco daemon start
+#    (or any command that opens the vault, e.g. `myco doctor`)
+
+# 4. Verify: version advanced and the new column/table is present and intact.
+sqlite3 "$GROVE_DB" "PRAGMA user_version;"
+sqlite3 "$GROVE_DB" ".schema <changed_table>"
+sqlite3 "$GROVE_DB" "PRAGMA integrity_check;"   # must print 'ok'
+```
+
+If `integrity_check` reports anything but `ok`, or the migration errored, restore from the backup (`mv "$GROVE_DB.bak" "$GROVE_DB"` and the WAL) and fix the migration before retrying. Never leave the daemon running against a half-migrated vault.
+
 ## Common Pitfalls
 
 **Never edit an existing migration block.** Once a version block ships, real vaults have already applied it. Changing it means the migration won't re-run for existing users. If you need to fix a past migration, add a new version that corrects it.
@@ -234,3 +284,5 @@ db.transaction(() => {
 ```
 
 **D1 schema drift causes team sync failures.** Always sync D1 schema changes using the procedures in step 6. Missing this step creates runtime drift between the daemon schema and the worker database.
+
+**A new column on a synced table with no worker mirror stalls sync for the whole table.** The worker builds its INSERT column list from the row payload, so an unmirrored column makes D1 throw `no such column` for every unsynced row — silently, with no local error. Apply the 3-part worker pattern (DDL + idempotent ALTER + `verifyColumnsAddressable`) from step 6a-parity and run `tests/db/synced-table-parity.test.ts`, which fails and names any local column missing from the D1 mirror. A column that is deliberately local-only belongs in `LOCAL_ONLY_SYNC_COLUMNS` instead.


### PR DESCRIPTION
Docs-only PR (three Myco skills, no code changes). Codifies the capture patterns that shipped with structural envelope classification and Codex sub-agent thread capture, so the working skills reflect the current model.

## What each skill gained

**`debug-capture`** (SKILL.md + `references/symbiont-capture-contract.md`)
- The three-lane action model: `drop` (proven-valueless only), `classify` + `set_origin` (preserve-and-hide), `rewrite_prompt` / `strip_envelope` (unwrap human wrappers).
- The two structural predicates: `prompt_envelope_tag_in` (attribute-robust tag-name match) and `prompt_is_enclosing_envelope` (whole-message fail-safe → `system`, must be last, only for agents without wrapped human input).
- A new step to diagnose a misclassified prompt: check `prompt_batches.origin`, then grep the daemon log for the rule's `reason`.
- The sub-agent thread model: turns mined onto the PARENT session as `agent_dispatch` batches with `thread_id`/`thread_label`; a "missing" sub-agent transcript now means checking the `resolveSubagentThread` paths (`subagentParentPath`/`subagentThreadIdPath`/`subagentLabelPath`) and the two distinct WARN logs.

**`add-symbiont`**
- A capture-rules step documenting the manifest `when` predicates (incl. the two structural ones), the three action lanes, session-level `classify`, the fail-safe ordering invariant, and **when NOT to add the fail-safe** — agents whose human input arrives wrapped (Cursor `<user_query>`, Cline `<user_input>`) strip first and carry no fail-safe.
- The three sub-agent dot-paths, declared only for agents that isolate sub-agent work into separate transcripts, with label derivation noted as living in code.

**`vault-schema-migration`**
- The synced-column parity rule: any column added to a synced table must land in the D1 worker mirror via the 3-part idempotent pattern (`CREATE TABLE` DDL + idempotent ALTER + `verifyColumnsAddressable`), enforced by `tests/db/synced-table-parity.test.ts`.
- The verified older-binary-on-newer-schema safety fact for additive-nullable columns (migration loop no-ops when `user_version` is ahead; queries are name-keyed).
- The offline-migration-with-backup procedure (stop daemon → back up db + wal → open with new binary → `integrity_check` → restart).

## Validation
- `npm run lint:skills:strict` — 56 files, 0 hard, 0 warnings.
- `npm test -- tests/ui/settings-manifest-sync.test.ts` — 2 pass (worktree sanity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)