### PR TITLE
chore: post-E-2 follow-ups — doctor remediation, migration-skill drift, install-skill pin refs

### DIFF
--- a/.agents/skills/install-and-initialize-myco/SKILL.md
+++ b/.agents/skills/install-and-initialize-myco/SKILL.md
@@ -207,7 +207,7 @@ node packages/myco-team/dist/main.js status --team-id <team_id>
 
 `.myco/runtime.command` is set to the absolute path of `myco-dev`. The hook guard only uses this file to choose the main Myco binary; it never selects an operator CLI.
 
-`.agents/myco-hook.cjs` reads `~/.myco/runtime.command` at every hook invocation and substitutes that path for the default `myco` command. Because the read happens at hook-fire time (not at shell startup), no shell restart is required.
+The hook guard checks the project-scope `.myco/runtime.command` first (walking up from the invoking directory), falling back to the machine-scope `~/.myco/runtime.command` if no project pin is found, and substitutes whichever path resolves for the default `myco` command. Because the read happens at hook-fire time (not at shell startup), no shell restart is required.
 
 ### Verify Dev Configuration
 
@@ -215,15 +215,15 @@ node packages/myco-team/dist/main.js status --team-id <team_id>
 myco-dev doctor
 ```
 
-The output should report the dev binary path. If it falls back to the global binary path, check that `~/.myco/runtime.command` exists and contains the correct path.
+The output should report the dev binary path. If it falls back to the global binary path, check that the project-scope `.myco/runtime.command` (in the repo, not `~/.myco/`) exists and contains the correct path.
 
-Confirm `~/.myco/runtime.command` is gitignored:
+Confirm the project-scope `.myco/runtime.command` is gitignored (it lives inside the repo, unlike the machine-scope fallback under `~/.myco/`):
 
 ```bash
-grep 'runtime.command' packages/myco/src/cli/shared.ts
+grep 'runtime.command' packages/myco/src/vault/gitignore.ts
 ```
 
-You should see it listed in `VAULT_GITIGNORE`. The file holds your machine's absolute path, so it must never be committed.
+You should see it listed in the `VAULT_GITIGNORE` body there — the canonical `.myco/.gitignore` content. `ProjectVault.ensureGitignore()` (`packages/myco/src/vault/project-vault.ts`) writes it, and every ProjectVault write of a per-machine file (`runtime.command`, `project.local.toml`) refreshes it automatically. The pin file holds your machine's absolute path, so it must never be committed.
 
 ### Build After Code Changes
 
@@ -241,7 +241,7 @@ Because the symlinks point to your repo's built files, the rebuilt artifact is i
 make dev-unlink
 ```
 
-This removes `~/.myco/runtime.command` and deletes the `~/.local/bin/myco-*` symlinks. Hooks fall back to the globally-installed `myco` automatically because `.agents/myco-hook.cjs` treats a missing `~/.myco/runtime.command` as "use the default."
+This removes the project-scope `.myco/runtime.command` and `.myco/runtime.home` pins, deletes the `~/.local/bin/myco-dev` wrapper and `myco-run` symlink plus the standalone `~/.myco-dev/bin/myco` copy, and also sweeps any legacy machine-scope `~/.myco/runtime.command` an older dev-link may have written. Hooks fall back to the globally-installed `myco` automatically because the hook guard (`.agents/myco-run.cjs`) treats a missing pin at both scopes as "use the default."
 
 ### Why This Approach Works
 
@@ -348,7 +348,7 @@ This is the canonical way to invoke Cortex or any Myco MCP tool from a script or
 
 **Use `make dev-link`, not `npm link`.** `npm link` rewires global resolution and will interfere with production-install testing in the same shell session.
 
-**`~/.myco/runtime.command` is machine-specific.** If you copy your repo to another machine, re-run `make dev-link` there — the path baked into the file will be wrong otherwise.
+**The project-scope `.myco/runtime.command` holds a machine-specific absolute path.** If you copy your repo to another machine, re-run `make dev-link` there — the path baked into the file will be wrong otherwise.
 
 **Rebuild before testing.** `myco-dev doctor` (or any hook) reads the binary on disk. Stale `packages/myco/bin/myco.cjs` means stale behavior, even if your source edits look right.
 

--- a/.agents/skills/vault-schema-extension/SKILL.md
+++ b/.agents/skills/vault-schema-extension/SKILL.md
@@ -26,32 +26,40 @@ Follow these steps in order. Skipping the query functions or constants update le
 
 ### 1. Add migration to the MIGRATIONS registry
 
-Locate the migration runner (`packages/myco/src/db/migrations.ts`). Add a new `Migration` entry to the `MIGRATIONS` array:
+Locate the migration runner (`packages/myco/src/db/migrations.ts`). The `Migration` interface is `{ version: number; migrate: (db: Database, machineId: string) => void }` — there is no `name`, `description`, or `up` field. Append a new entry to the end of the `MIGRATIONS` array, pointing at a standalone `migrateVXToVY` function defined later in the same file:
 
 ```typescript
 export const MIGRATIONS: Migration[] = [
   // ... existing migrations
-  {
-    version: 21,
-    name: 'add_my_new_table',
-    description: 'Add my_new_table for <purpose>',
-    up: (db: Database) => {
-      db.exec(`
-        CREATE TABLE IF NOT EXISTS my_new_table (
-          id          TEXT PRIMARY KEY,
-          session_id  TEXT,
-          content     TEXT NOT NULL,
-          created_at  INTEGER NOT NULL DEFAULT (unixepoch()),
-          FOREIGN KEY (session_id) REFERENCES sessions(id)
-        );
-        CREATE INDEX IF NOT EXISTS idx_my_new_table_session
-          ON my_new_table(session_id);
-        CREATE INDEX IF NOT EXISTS idx_my_new_table_created_at
-          ON my_new_table(created_at DESC);
-      `);
-    }
-  }
+  { version: 21, migrate: (db) => migrateV20ToV21(db) },
 ];
+
+function migrateV20ToV21(db: Database): void {
+  db.prepare('BEGIN').run();
+  try {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS my_new_table (
+        id          TEXT PRIMARY KEY,
+        session_id  TEXT,
+        content     TEXT NOT NULL,
+        created_at  INTEGER NOT NULL DEFAULT (unixepoch()),
+        FOREIGN KEY (session_id) REFERENCES sessions(id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_my_new_table_session
+        ON my_new_table(session_id);
+      CREATE INDEX IF NOT EXISTS idx_my_new_table_created_at
+        ON my_new_table(created_at DESC);
+    `);
+
+    db.prepare(
+      `INSERT INTO schema_version (version, applied_at) VALUES (?, ?) ON CONFLICT (version) DO NOTHING`,
+    ).run(21, epochSeconds());
+    db.prepare('COMMIT').run();
+  } catch (err) {
+    db.prepare('ROLLBACK').run();
+    throw err;
+  }
+}
 ```
 
 Key rules:
@@ -59,7 +67,8 @@ Key rules:
 - **Add all indexes inline** with the table creation. Putting them in a later migration risks a partial-schema state if the process dies between versions.
 - Use `INTEGER NOT NULL DEFAULT (unixepoch())` for timestamps — store Unix epoch seconds, not ISO strings.
 - Use `TEXT PRIMARY KEY` with a UUID for entity tables; use `INTEGER PRIMARY KEY AUTOINCREMENT` only for pure log/event tables where an ordered surrogate is the point.
-- **Each migration is atomic** — the migration runner applies all migrations up to the highest version or rolls back entirely on failure.
+- **Each migration function is atomic on its own** — it wraps itself in an explicit `BEGIN`/`COMMIT`, rolling back and rethrowing on failure. There is no single all-or-nothing transaction around the whole chain: `createSchema()`'s driver loop calls each due migration in order, so if migration N+2 throws, migrations N and N+1 stay committed rather than rolling back too (see `myco:vault-schema-migration` for the driver loop and the frozen-DDL / no-live-query-helper rules migrations must follow).
+- All migration SQL is a literal string frozen at authoring time — never `db.exec()` a live constant like `TABLE_DDLS` from inside a migration, and never call a `db/queries/*` helper from one (see `myco:vault-schema-migration` step 4 for both reasons).
 
 ### 2. Create the query functions
 
@@ -80,22 +89,34 @@ Use `ALTER TABLE` for additive changes (new columns). SQLite does not support dr
 ### Adding a column
 
 ```typescript
-{
-  version: 22,
-  name: 'add_supersedes_column',
-  description: 'Add supersedes column to skill_candidates',
-  up: (db: Database) => {
-    db.exec(`ALTER TABLE skill_candidates ADD COLUMN supersedes TEXT;`);
-    // Backfill: give existing rows a safe default before any code relies on the column
-    db.exec(`UPDATE skill_candidates SET supersedes = '[]' WHERE supersedes IS NULL;`);
+// MIGRATIONS entry: { version: 22, migrate: (db) => migrateV21ToV22(db) }
+
+function migrateV21ToV22(db: Database): void {
+  db.prepare('BEGIN').run();
+  try {
+    const cols = getTableColumnSet(db, 'skill_candidates'); // PRAGMA table_info wrapper
+    if (!cols.has('supersedes')) {
+      db.prepare(`ALTER TABLE skill_candidates ADD COLUMN supersedes TEXT;`).run();
+      // Backfill: give existing rows a safe default before any code relies on the column
+      db.prepare(`UPDATE skill_candidates SET supersedes = '[]' WHERE supersedes IS NULL;`).run();
+    }
+
+    db.prepare(
+      `INSERT INTO schema_version (version, applied_at) VALUES (?, ?) ON CONFLICT (version) DO NOTHING`,
+    ).run(22, epochSeconds());
+    db.prepare('COMMIT').run();
+  } catch (err) {
+    db.prepare('ROLLBACK').run();
+    throw err;
   }
 }
 ```
 
 Rules:
 - **Never add `NOT NULL` without a `DEFAULT`** — existing rows fail the constraint on open.
-- **Backfill in the same migration**, before the migration completes. This keeps the migration atomic: either both the schema change and the backfill succeed, or the whole migration retries.
+- **Backfill in the same migration**, before `COMMIT`. This keeps the migration atomic: either both the schema change and the backfill succeed, or both roll back.
 - **One conceptual change per migration** — keep each migration atomic and describable in a single sentence.
+- SQLite's `ALTER TABLE ADD COLUMN` has no `IF NOT EXISTS` form and throws on a column that already exists — idempotency comes from a `PRAGMA table_info` check (`getTableColumnSet` in `migrations.ts`) guarding the `ALTER`, not from a try/catch that swallows the "duplicate column" error.
 - Update the query functions' INSERT and SELECT statements and the TypeScript row interface to include the new column.
 
 ### Column renames (legacy considerations)
@@ -202,14 +223,14 @@ Two tables for release provenance tracking (both include `project_id` and `grove
 
 ## Procedure I: Migration Chain Validation
 
-Test the complete migration path, not just individual migrations. Follow patterns from existing tests (`tests/db/migrate-v40.test.ts`). Assert invariants, not version constants:
+Test the complete migration path, not just individual migrations. Write a per-migration test under `tests/db/` following the current convention — `tests/db/migrate-v71-to-v72-team-sync-quiesce.test.ts` is the most recent, correctly-authored example (see `myco:vault-schema-migration` step 7 for the full shape: build a `:memory:` database, roll `schema_version` back to simulate the prior version, seed legacy-shaped rows, re-run `createSchema()`, and assert the result). Assert invariants, not version constants:
 ```javascript
-expect(SCHEMA_VERSION).toBeGreaterThanOrEqual(42);
+expect(SCHEMA_VERSION).toBeGreaterThanOrEqual(72);
 ```
 
 ## Procedure J: Fresh Install vs Migration Equivalence Testing
 
-Fresh installs follow CREATE TABLE column order; migrated databases append ALTER TABLE columns at the end. Test column addressability by name, not ordinal position. Use `PRAGMA table_info(table_name)` to check column existence.
+Fresh installs follow CREATE TABLE column order; migrated databases append ALTER TABLE columns at the end. Test column addressability by name, not ordinal position. Use `PRAGMA table_info(table_name)` to check column existence. `tests/db/migration-matrix.test.ts` already does this at the whole-chain level — it upgrades authentic historical fresh-vault fixtures through the current chain and asserts convergence with a fresh-created vault; run it (`npm test -- tests/db/migration-matrix.test.ts`) after any migration change rather than only relying on your new migration's own test.
 
 ## Procedure K: Migration Test Hardening
 
@@ -287,12 +308,13 @@ See `packages/myco/src/daemon/embedding/sqlite-vec-store.ts` for the reference i
 
 ## Cross-Cutting Gotchas
 
-- **`IF NOT EXISTS` is mandatory everywhere** — migrations run at every startup; a bare `CREATE TABLE` throws on the second run.
-- **Each migration is atomic** — all migrations up to the highest version succeed or the runner rolls back entirely.
+- **`IF NOT EXISTS` is mandatory everywhere it exists as SQL syntax** — `CREATE TABLE`/`CREATE INDEX`/`CREATE TRIGGER` all support it and migrations run at every startup, so a bare `CREATE` throws on the second run. `ALTER TABLE ADD COLUMN` has no `IF NOT EXISTS` form; guard it with a `PRAGMA table_info` check (`getTableColumnSet` in `migrations.ts`) instead.
+- **Each migration function is atomic on its own, not the whole chain** — every `migrateVXToVY` wraps itself in an explicit `BEGIN`/`COMMIT`/`ROLLBACK`. There is no single all-or-nothing transaction around the full `MIGRATIONS` array: if migration N+2 throws, migrations up through N+1 stay committed and the vault is left stamped at N+1, not rolled back to its pre-chain state.
+- **Migration SQL is a frozen literal, never a live schema constant or a `db/queries/*` helper call** — see `myco:vault-schema-migration` step 4. A later addition to `TABLE_DDLS`/`SECONDARY_INDEXES`/etc. can retroactively change a shipped migration's behavior (this bricked v34–v40 vaults once), and query helpers often bind the `getDatabase()` singleton rather than the migration's own `db` handle.
 - **D1 ALTER TABLE is lazy (historical)** — while the team-sync worker was live, a D1 column didn't exist until the first post-deploy request. No live deployment exists today; this is background for a future revival, not something to guard against now.
 - **FTS triggers must use `IF NOT EXISTS`** — duplicate triggers corrupt the index silently.
 - **Never post-filter in JS what SQL can filter** — use `json_each` for dynamic ID sets, JOIN for related data, keyset cursors for pagination.
-- **All SQL lives in query modules** — no inline SQL in MCP handlers or business logic.
+- **All SQL lives in query modules — except inside a migration.** Application code (MCP handlers, business logic) must call query-module functions rather than inline SQL. Migrations are the deliberate exception: they must inline frozen literal SQL and must never call a query-module helper (previous bullet) — the two rules point in opposite directions for a reason, not a contradiction.
 - **Scan `packages/myco/src/db/schema-ddl.ts` after every new table** — missing `TABLE_DDLS` or `FTS_TABLES` registration silently limits feature surface.
 - **Grove `project_id` is mandatory in v31+** — all new project-scoped tables must include `project_id` and all queries must scope by it.
 - **Column Order Drift** — Fresh installs and migrated databases have different column orders. Test column addressability by name using `PRAGMA table_info`, never by position.

--- a/.agents/skills/vault-schema-migration/SKILL.md
+++ b/.agents/skills/vault-schema-migration/SKILL.md
@@ -13,59 +13,112 @@ The Myco vault is a SQLite database at `.myco/myco.db`. Its schema evolves throu
 
 ## Prerequisites
 
-- Know which schema version is current. Check `SCHEMA_VERSION` in the schema module (`packages/myco/src/db/schema.ts`).
+- Know which schema version is current. Check `SCHEMA_VERSION` in `packages/myco/src/db/schema.ts`.
+- Know the migration chain itself — the `MIGRATIONS` registry array and every `migrateVXToVY` function — lives in a *separate* file, `packages/myco/src/db/migrations.ts` (~4,400 lines). `schema.ts` only owns the version constant, the fresh-install DDL application, and `createSchema()`'s driver loop.
 - Know exactly what you're adding — table name, column names and types, constraints, indexes.
 - Understand whether the change needs a **backfill** (populating existing rows after adding a column) or is append-only.
 
 ## Steps
 
-### 1. Find the schema file and current version
+### 1. Find the schema files and the current version
 
 ```bash
-grep -r "SCHEMA_VERSION" packages/myco/src --include="*.ts" -l
+grep -n "SCHEMA_VERSION = " packages/myco/src/db/schema.ts
 ```
 
-Open that file. You'll see:
-- A `SCHEMA_VERSION` constant (e.g., `8`)
-- A `createSchema` function containing a sequence of `if (currentVersion < N)` blocks
-
-Read the entire function to understand the chain before touching anything.
-
-### 2. Increment the version constant
-
-Change `SCHEMA_VERSION` from `N` to `N+1`. This is the version the vault will be at after your migration runs.
+`createSchema()` (in `schema.ts`) is the driver, not the chain itself:
 
 ```ts
-// Before
-export const SCHEMA_VERSION = 8;
-
-// After
-export const SCHEMA_VERSION = 9;
-```
-
-Do this first so you never forget — the constant and the migration block must always match.
-
-### 3. Add a new migration block at the end of the chain
-
-Inside `createSchema`, add a new block **after all existing blocks**:
-
-```ts
-if (currentVersion < 9) {
-  db.exec(`
-    ALTER TABLE sessions ADD COLUMN parent_session_id TEXT REFERENCES sessions(id);
-  `);
-  currentVersion = 9;
+export function createSchema(db: Database, machineId: string = DEFAULT_MACHINE_ID): void {
+  if (hasSchemaVersionTable(db)) {
+    // existing vault: run any migrations the vault hasn't reached yet
+    for (const migration of MIGRATIONS) {
+      const version = getCurrentVersion(db);       // re-read every iteration
+      if (version < migration.version) {
+        migration.migrate(db, machineId);
+      }
+    }
+    reapplyCurrentSchemaDdl(db);
+    return;
+  }
+  // fresh install: apply every CURRENT table/FTS/index/trigger DDL at once
+  // and stamp schema_version = SCHEMA_VERSION directly — the migration
+  // chain never runs for a brand-new vault.
+  ...
 }
 ```
 
-Key rules for the block:
-- Use `if (currentVersion < N)` — not `===`, not `>=`. This ensures the block runs exactly once for vaults below that version and is skipped for vaults already at or above it.
-- End the block by setting `currentVersion = N`. This advances the in-memory version tracker so subsequent blocks see the right value.
-- Keep each block **idempotent where possible**. SQLite's `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS` are safe. For `ALTER TABLE ADD COLUMN`, SQLite will error if the column already exists — wrap in a try/catch if there's any risk of partial application.
+Two consequences worth internalizing before you touch anything:
+- **A fresh install never runs your migration function.** It only ever runs for a vault that already has a `schema_version` table below the version you're adding. Test both paths (see step 7).
+- **The loop re-reads the current version on every iteration**, not once at the top. If a migration throws, everything already committed (via that migration's own transaction — see step 3) stays committed, and the next `createSchema()` call resumes from there instead of re-running completed steps.
 
-### 4. Write safe migration SQL
+Read `packages/myco/src/db/migrations.ts` in full before touching it — skim the `MIGRATIONS` array at the top, then find `migrateV71ToV72` (or whatever the most recent function is) as your shape reference.
 
-**Adding a table:**
+### 2. Increment the version constant
+
+Change `SCHEMA_VERSION` in `schema.ts` from `N` to `N+1`. This is the version the vault will be at after your migration runs.
+
+```ts
+// Before
+export const SCHEMA_VERSION = 72;
+
+// After
+export const SCHEMA_VERSION = 73;
+```
+
+Do this first so you never forget — the constant and the migration entry must always match.
+
+### 3. Register the migration and write its function
+
+In `migrations.ts`, append one entry to the **end** of the `MIGRATIONS` array:
+
+```ts
+export const MIGRATIONS: Migration[] = [
+  // ... existing entries ...
+  { version: 73, migrate: (db) => migrateV72ToV73(db) },
+];
+```
+
+Then write the function itself, anywhere in the "Individual migration functions" section further down the file (functions are **not** kept in strict version order there — the array above is what determines execution order, not file position):
+
+```ts
+function migrateV72ToV73(db: Database): void {
+  db.prepare('BEGIN').run();
+  try {
+    db.exec(`ALTER TABLE sessions ADD COLUMN parent_session_id TEXT REFERENCES sessions(id);`);
+
+    db.prepare(
+      `INSERT INTO schema_version (version, applied_at) VALUES (?, ?) ON CONFLICT (version) DO NOTHING`,
+    ).run(73, epochSeconds());
+    db.prepare('COMMIT').run();
+  } catch (err) {
+    db.prepare('ROLLBACK').run();
+    throw err;
+  }
+}
+```
+
+Key rules:
+- **The `Migration` interface is exactly `{ version: number; migrate: (db: Database, machineId: string) => void }`.** There is no `name`, `description`, or `up` field — don't invent one.
+- **Wrap the entire body in an explicit `BEGIN` / `COMMIT`, with a `catch` that `ROLLBACK`s and rethrows.** This is not reserved for multi-statement or "complex" migrations — every migration in the chain uses this exact shape, including single-statement ones, so a failure partway through never leaves the vault stamped at a version it didn't fully reach.
+- **The migration advances the version by inserting its own row into `schema_version`** — `INSERT INTO schema_version (version, applied_at) VALUES (?, ?) ON CONFLICT (version) DO NOTHING`, immediately before `COMMIT`. There is no `PRAGMA user_version` write for the vault schema (see step 5 for where that confusion comes from).
+- Only take a `machineId` second parameter if the migration actually needs it for a backfill (e.g. `migrateV19ToV20`, `migrateV51ToV52`); most migrations take just `db`.
+- **Each migration is one conceptual change.** Don't fold unrelated schema changes into one version bump.
+
+### 4. Frozen literal SQL — never reference live schema constants or query helpers
+
+Two hard rules, both enforced structurally by `tests/db/migration-matrix.test.ts`:
+
+**Every migration's SQL must be a literal string frozen at the revision that ships it.** Never write `db.exec(ddl)` against the live `TABLE_DDLS`, `FTS_TABLES`, `SECONDARY_INDEXES`, or `TEAM_DELETE_TRIGGERS` arrays (imported from `schema-ddl.ts`) inside a migration function — a later addition to those constants silently changes what an already-shipped historical migration does, and can brick the chain outright if the addition targets a table that doesn't exist yet at that point in history. This actually happened: v41 shipped applying live `SECONDARY_INDEXES` and broke every vault stamped v34–v40 once `session_myco_tool_calls` indexes were added alongside v45. `reapplyCurrentSchemaDdl()` (in `schema.ts`) is what supplies everything newer, once, after the whole chain completes — that's the only place live constants belong. (`migrateV33ToV34` is the one documented exception, used as a rescue floor for pre-v34 vaults; it creates every table before any index specifically so it can't hit the missing-table failure class. Don't add a second exception without equally strong justification.) A trigger **body** change ships as a new DROP-then-recreate migration (v53 is the precedent) — `CREATE TRIGGER IF NOT EXISTS` alone never refreshes an existing trigger's body.
+
+**Never call a `db/queries/*` helper function from inside a migration — inline the literal SQL instead**, even when a query module already has a function that does exactly what you need. Two reasons, and the second is the sneaky one:
+1. **Frozen history** — a migration step that imports a live helper silently changes what the shipped migration does whenever that helper is later edited, same failure class as the live-DDL rule above.
+2. **Wrong-connection binding** — many query helpers (e.g. `purgePendingOutbox` in `packages/myco/src/db/queries/team-outbox.ts`) bind the `getDatabase()` singleton internally rather than accepting a `db` handle. Calling one from a migration running on a *passed* `db` (as every `createSchema` chain step does, including the `:memory:` databases every migration test uses) executes against a **different database** than the one being migrated — passing on real vaults by coincidence (where the singleton and the real vault happen to be the same file) while silently corrupting a test's isolation.
+
+`migrateV71ToV72` is the precedent for both rules: instead of calling `purgePendingOutbox`, it copies that function's SQL character-for-character (`DELETE FROM team_outbox WHERE sent_at IS NULL`) as a frozen literal.
+
+### 4a. Adding a table
+
 ```sql
 CREATE TABLE IF NOT EXISTS notifications (
   id TEXT PRIMARY KEY,
@@ -76,55 +129,86 @@ CREATE TABLE IF NOT EXISTS notifications (
 CREATE INDEX IF NOT EXISTS idx_notifications_created_at ON notifications(created_at);
 ```
 
-**Adding a column:**
-```sql
-ALTER TABLE sessions ADD COLUMN machine_id TEXT;
-```
-SQLite only allows adding columns, not modifying or dropping them. If you need to change a column type or drop a column, you must recreate the table (see step 4a).
+`IF NOT EXISTS` on both the table and its indexes makes the statements safe to re-run if a partial upgrade retries.
 
-**Recreating a table (rename → create → copy → drop):**
-```sql
-ALTER TABLE spores RENAME TO spores_old;
-CREATE TABLE spores ( /* new schema */ );
-INSERT INTO spores SELECT id, content, /* ... */ FROM spores_old;
-DROP TABLE spores_old;
-```
-Wrap table recreations in a transaction to prevent partial states.
+### 4b. Adding a column — idempotency via `PRAGMA table_info`, not try/catch
 
-### 4a. Backfill step (when needed)
-
-If you added a NOT NULL column or need to populate existing rows, add a backfill *within the same version block*, after the DDL:
+SQLite's `ALTER TABLE ADD COLUMN` has no `IF NOT EXISTS` form and throws if the column already exists. The pattern used throughout `migrations.ts` is `getTableColumnSet()` (a `PRAGMA table_info` wrapper already defined near the top of the "Individual migration functions" section) plus an explicit `.has()` check — **not** a try/catch that swallows the "duplicate column" error:
 
 ```ts
-if (currentVersion < 7) {
-  db.exec(`ALTER TABLE spores ADD COLUMN machine_id TEXT;`);
+function migrateV66ToV67(db: Database): void {
+  db.prepare('BEGIN').run();
+  try {
+    const cols = getTableColumnSet(db, 'skill_lineage');
+    if (!cols.has('machine_id')) {
+      db.prepare("ALTER TABLE skill_lineage ADD COLUMN machine_id TEXT NOT NULL DEFAULT 'local'").run();
+    }
+    if (!cols.has('synced_at')) {
+      db.prepare('ALTER TABLE skill_lineage ADD COLUMN synced_at INTEGER').run();
+    }
 
-  // Backfill: existing rows get 'local' as a safe default
-  db.exec(`UPDATE spores SET machine_id = 'local' WHERE machine_id IS NULL;`);
-
-  currentVersion = 7;
+    db.prepare(
+      `INSERT INTO schema_version (version, applied_at) VALUES (?, ?) ON CONFLICT (version) DO NOTHING`,
+    ).run(67, epochSeconds());
+    db.prepare('COMMIT').run();
+  } catch (err) {
+    db.prepare('ROLLBACK').run();
+    throw err;
+  }
 }
 ```
 
-Backfills must complete before `currentVersion` advances — never split DDL and backfill across two version blocks for the same change.
+### 4c. Backfill step (when needed)
 
-### 5. Update the schema version stored in the database
-
-The migration runner reads and writes `PRAGMA user_version` (or a `meta` table row) to know which version the vault is at. Confirm the runner pattern:
-
-```bash
-grep -r "user_version\|schemaVersion\|meta.*version" packages/myco/src --include="*.ts"
-```
-
-Most commonly you'll see something like:
+Backfill in the *same* migration, after the `ALTER TABLE`, before `COMMIT`:
 
 ```ts
-const currentVersion = db.prepare('PRAGMA user_version').get().user_version;
-// ... migration chain ...
-db.pragma(`user_version = ${SCHEMA_VERSION}`);
+db.exec(`ALTER TABLE spores ADD COLUMN machine_id TEXT;`);
+db.exec(`UPDATE spores SET machine_id = 'local' WHERE machine_id IS NULL;`);
 ```
 
-Make sure the final `PRAGMA user_version = N` assignment uses the constant, not a hardcoded number.
+Backfills must complete inside the same `BEGIN`/`COMMIT` as the DDL — never split DDL and backfill across two version blocks for the same change; a crash between them would leave the vault at a version whose backfill never ran.
+
+### 4d. Recreating a table (rename → create → copy → drop)
+
+SQLite only allows adding columns; changing a column's type or dropping/renaming a column requires a full table rebuild. Rename the live table out of the way, create the new shape from a **frozen** literal DDL string (never the live `TABLE_DDLS` constant — see step 4), copy forward only the columns that exist on both shapes, then drop the renamed original:
+
+```ts
+function migrateV39ToV40(db: Database): void {
+  db.prepare('BEGIN').run();
+  try {
+    db.prepare('ALTER TABLE agent_state RENAME TO agent_state_v39').run();
+    db.exec(V40_AGENT_STATE_TABLE); // frozen literal DDL, not the live constant
+    db.prepare(
+      `INSERT INTO agent_state (id, project_id, /* ... */)
+       SELECT id, project_id, /* ... */ FROM agent_state_v39`,
+    ).run();
+    db.prepare('DROP TABLE agent_state_v39').run();
+
+    db.prepare(
+      `INSERT INTO schema_version (version, applied_at) VALUES (?, ?) ON CONFLICT (version) DO NOTHING`,
+    ).run(40, epochSeconds());
+    db.prepare('COMMIT').run();
+  } catch (err) {
+    db.prepare('ROLLBACK').run();
+    throw err;
+  }
+}
+```
+
+The whole rename-create-copy-drop sequence stays inside the migration's own `BEGIN`/`COMMIT` — never a separate transaction.
+
+### 5. Version tracking is a `schema_version` table — not `PRAGMA user_version`
+
+The vault's current version is read with:
+
+```ts
+db.prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1').get();
+```
+
+and advanced by the `INSERT INTO schema_version (version, applied_at) VALUES (?, ?) ON CONFLICT (version) DO NOTHING` shown in step 3. There is no `PRAGMA user_version` involved in vault schema versioning.
+
+`PRAGMA user_version` **does** exist elsewhere in this codebase — it tracks `VEC_STORE_SCHEMA_VERSION` for the separate `vectors.db` (the sqlite-vec embedding store, `packages/myco/src/daemon/embedding/sqlite-vec-store.ts`). That's a different SQLite file with its own independent version scheme; don't let a grep hit there convince you the main vault uses the same mechanism.
 
 ### 6. Keep the dormant team-sync worker's D1 mirror in parity
 
@@ -168,34 +252,79 @@ If the new column is intentionally local-only (never synced), add it to `LOCAL_O
 npm test -- tests/db/synced-table-parity.test.ts
 ```
 
-**Older binary on a newer schema is safe for additive-nullable columns.** The local `createSchema` migration loop no-ops when the vault's `user_version` is already ahead of the running binary's `SCHEMA_VERSION` (the `if (currentVersion < N)` blocks are all skipped), and every query names its columns explicitly rather than `SELECT *`. So a machine still on an older binary reading a vault another machine migrated forward keeps working, as long as the new columns are **additive and nullable** (no NOT-NULL-without-default, no dropped/renamed columns an old query still references). This is the guarantee that lets a mixed-version team share one synced schema.
+**Older binary on a newer schema is safe for additive-nullable columns.** The local `createSchema` migration loop no-ops when the vault's version is already ahead of the running binary's `SCHEMA_VERSION` (every entry's `version < migration.version` check fails), and every query names its columns explicitly rather than `SELECT *`. So a machine still on an older binary reading a vault another machine migrated forward keeps working, as long as the new columns are **additive and nullable** (no NOT-NULL-without-default, no dropped/renamed columns an old query still references). This is the guarantee that lets a mixed-version team share one synced schema.
 
 There is no `wrangler d1 execute` deployment step to run — the worker isn't deployed anywhere. Updating the mirror DDL and passing the parity test above is the entire scope of "D1 sync" for this repo today.
 
-### 7. Test the migration locally
+### 7. Test the migration
 
-Run the daemon against a fresh vault to verify the schema creates correctly from zero:
+**Write a per-migration test in `tests/db/`** — this is the primary verification method, not a manual smoke. `tests/db/migrate-v71-to-v72-team-sync-quiesce.test.ts` is the current reference shape:
 
-```bash
-rm -rf .myco/myco.db && pnpm dev
+```ts
+import { createSchema, SCHEMA_VERSION } from '@myco/db/schema.js';
+import { Database } from 'bun:sqlite';
+
+function seedV72LegacyVault(): Database {
+  const db = new Database(':memory:');
+  createSchema(db, 'local');
+  // Roll the stamped version back to simulate a vault frozen at the prior version.
+  db.prepare('DELETE FROM schema_version WHERE version > 72').run();
+  // ...seed any legacy-shaped rows the migration needs to observe...
+  return db;
+}
+
+describe('migrateV72ToV73 — <what it does>', () => {
+  it('SCHEMA_VERSION includes this migration', () => {
+    expect(SCHEMA_VERSION).toBeGreaterThanOrEqual(73); // never pin an exact number
+  });
+
+  it('a fresh install already has the new shape', () => {
+    const db = new Database(':memory:');
+    createSchema(db);
+    // assert the new column/table/data shape directly
+  });
+
+  it('a v72 vault migrates to v73 on the next createSchema() call', () => {
+    const db = seedV72LegacyVault();
+    createSchema(db);
+    // assert the migration's effect
+  });
+
+  it('is idempotent — a second createSchema() call does not error or duplicate effects', () => {
+    const db = seedV72LegacyVault();
+    createSchema(db);
+    createSchema(db); // second boot
+    // assert nothing changed on the second call
+  });
+});
 ```
 
-Then test against an existing vault to verify the migration applies cleanly. The easiest way is to temporarily reduce `user_version` in a test vault:
+Run it directly:
 
 ```bash
-sqlite3 .myco/myco.db "PRAGMA user_version = N-1;"
-pnpm dev
-sqlite3 .myco/myco.db "PRAGMA user_version; .schema your_new_table"
+npm test -- tests/db/migrate-v72-to-v73-<slug>.test.ts
 ```
 
-Confirm the version advanced and the new table/column exists.
+**Then run the whole-chain structural guard**, `tests/db/migration-matrix.test.ts` — it upgrades authentic historical fresh-vault fixtures (one per past `SCHEMA_VERSION`, under `tests/db/fixtures/historical/`) through the entire current chain and asserts the result is structurally identical to a fresh-created vault. This is the test that would have caught v41's premature `SECONDARY_INDEXES` reference (step 4) before it bricked v34–v40 vaults — treat it as mandatory after any migration change, not optional:
+
+```bash
+npm test -- tests/db/migration-matrix.test.ts
+```
+
+If you want to additionally sanity-check against a real on-disk vault, simulate the prior version the same way the tests do — via the `schema_version` table, not `PRAGMA user_version`:
+
+```bash
+sqlite3 .myco/myco.db "DELETE FROM schema_version WHERE version > 72;"
+myco doctor   # or any command that opens the vault — triggers createSchema()
+sqlite3 .myco/myco.db "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1;"
+```
 
 ### 8. Update schema documentation
 
 If the project has a schema changelog or version reference file, add an entry:
 
 ```
-v9 (2026-04-03): Added parent_session_id to sessions table for lineage tracking
+v73 (2026-07-16): Added parent_session_id to sessions table for lineage tracking
 ```
 
 Check:
@@ -210,7 +339,7 @@ When you need to apply a new binary's migration to a live vault that already hol
 
 ```bash
 # 1. Stop the daemon so nothing writes mid-migration.
-myco daemon stop      # or the service stop for your install
+myco service stop      # or the service stop for your install
 
 # 2. Back up the DB and its write-ahead log together — the WAL holds
 #    committed pages not yet checkpointed into the main file; copying the
@@ -221,11 +350,11 @@ cp "$GROVE_DB-wal"  "$GROVE_DB-wal.bak" 2>/dev/null || true
 
 # 3. Open the vault once with the new binary so createSchema runs the
 #    migration chain to the new SCHEMA_VERSION.
-myco daemon start
+myco service start
 #    (or any command that opens the vault, e.g. `myco doctor`)
 
 # 4. Verify: version advanced and the new column/table is present and intact.
-sqlite3 "$GROVE_DB" "PRAGMA user_version;"
+sqlite3 "$GROVE_DB" "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1;"
 sqlite3 "$GROVE_DB" ".schema <changed_table>"
 sqlite3 "$GROVE_DB" "PRAGMA integrity_check;"   # must print 'ok'
 ```
@@ -234,21 +363,33 @@ If `integrity_check` reports anything but `ok`, or the migration errored, restor
 
 ## Common Pitfalls
 
-**Never edit an existing migration block.** Once a version block ships, real vaults have already applied it. Changing it means the migration won't re-run for existing users. If you need to fix a past migration, add a new version that corrects it.
+**Never edit an existing migration function.** Once a version ships, real vaults have already applied it. Changing it means the migration won't re-run for existing users. If you need to fix a past migration, add a new version that corrects it.
 
-**NOT NULL columns without defaults will fail on existing data.** Either provide a DEFAULT in the DDL, or backfill immediately after the ALTER TABLE and before advancing `currentVersion`.
+**Never reference live schema constants or `db/queries/*` helpers from inside a migration.** See step 4 — this is the single highest-value rule in this skill. Both failure modes (a later DDL addition retroactively changing a shipped migration's behavior, and a query helper silently binding the `getDatabase()` singleton instead of the migration's own `db` handle) are invisible locally and only surface on a vault or test that happens to diverge from the coincidental common case. `tests/db/migration-matrix.test.ts` structurally enforces the DDL half; there's no automated enforcement for the query-helper half, so review for it explicitly (spore `gotcha-55c32500`).
 
-**Older SQLite releases may not support DROP COLUMN.** If targeting older SQLite (common in embedded contexts), use the rename→create→copy→drop pattern instead.
+**NOT NULL columns without defaults will fail on existing data.** Either provide a DEFAULT in the DDL, or backfill immediately after the ALTER TABLE and before `COMMIT`.
 
-**Transaction wrapping matters for multi-statement migrations.** If a version block executes multiple statements and one fails mid-way, the vault can be left in a partially migrated state. Wrap complex blocks:
+**Older SQLite releases may not support DROP COLUMN.** If targeting older SQLite (common in embedded contexts), use the rename→create→copy→drop pattern instead (step 4d).
+
+**Every migration wraps itself in its own `BEGIN`/`COMMIT`/`ROLLBACK` — this is mandatory, not just for multi-statement migrations.** If a version's body executes multiple statements and one fails mid-way without this wrapping, the vault can be left in a partially migrated state:
 
 ```ts
-db.transaction(() => {
-  db.exec(`ALTER TABLE foo RENAME TO foo_old;`);
-  db.exec(`CREATE TABLE foo ( /* new */ );`);
-  db.exec(`INSERT INTO foo SELECT * FROM foo_old;`);
-  db.exec(`DROP TABLE foo_old;`);
-})();
+function migrateVNToVN1(db: Database): void {
+  db.prepare('BEGIN').run();
+  try {
+    db.exec(`ALTER TABLE foo RENAME TO foo_old;`);
+    db.exec(`CREATE TABLE foo ( /* new */ );`);
+    db.exec(`INSERT INTO foo SELECT * FROM foo_old;`);
+    db.exec(`DROP TABLE foo_old;`);
+    db.prepare(
+      `INSERT INTO schema_version (version, applied_at) VALUES (?, ?) ON CONFLICT (version) DO NOTHING`,
+    ).run(/* N */, epochSeconds());
+    db.prepare('COMMIT').run();
+  } catch (err) {
+    db.prepare('ROLLBACK').run();
+    throw err;
+  }
+}
 ```
 
 **A missing worker mirror update fails CI, not a live deployment.** Team sync itself is retired and quiescent (no live D1 exists to drift against today), but `tests/db/synced-table-parity.test.ts` still enforces that the dormant worker's DDL matches the local schema for every synced table. Skipping step 6a-parity turns that test red — treat it the same as any other failing test, not as an optional cleanup step.

--- a/packages/myco/src/cli/doctor.ts
+++ b/packages/myco/src/cli/doctor.ts
@@ -282,8 +282,9 @@ export async function checkExternalMcpCoherence(mycoHome?: string): Promise<Doct
     status: 'warn',
     detail:
       `The external read-only MCP listener is enabled (port ${coherence.port}) but no access token exists — `
-      + 'it cannot authenticate any caller in this state. Re-run the Team page enable toggle to mint one, '
-      + 'or disable exposure until it can.',
+      + 'it cannot authenticate any caller in this state. Enabling it is API-driven, not a dashboard toggle — '
+      + 're-run `PUT /api/team/external-mcp/toggle` to mint one (see docs/team-host.md, "External read-only '
+      + 'MCP"), or disable exposure until it can.',
     fixable: false,
   };
 }


### PR DESCRIPTION
Small follow-up batch clearing the three chips left over from the E-2/E-3 retirement (#699):

- **doctor:** the external-MCP pair-coherence check's remediation pointed at a Team page toggle that doesn't exist; it now gives the real API-driven enable path, consistent with `docs/team-host.md`.
- **vault-schema-migration / vault-schema-extension skills:** the described authoring procedure had drifted from the actual `MIGRATIONS` chain (interface shape, version-constant location, per-version test pattern — grounded against `migrateV71ToV72` as the reference step). The frozen-literal-SQL / no-query-helper doctrine (incl. the `getDatabase()` singleton-binding trap) stays explicit.
- **install-and-initialize skill:** three stale machine-scope `runtime.command` references aligned with the project-scope-first pin reality, plus the real `VAULT_GITIGNORE` home and current hook-guard filename (`myco-run.cjs`).

Every corrected claim was independently re-verified against source in review. Gates: tsc clean, skill lint 54 files/0 warnings, doctor + migration test suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)