### PR TITLE
fix: close the rollback-corruption and transcript-destruction paths, and ratchet the gaps that hid them

### DIFF
--- a/.agents/skills/mcp-tool-development-lifecycle/SKILL.md
+++ b/.agents/skills/mcp-tool-development-lifecycle/SKILL.md
@@ -112,7 +112,7 @@ Each tool carries inline SKILL.md documentation bundled at compile time across a
 
 Implement systematic checks to catch schema-handler-documentation drift across the shared tool-runtime:
 
-1. **Create test file** (`packages/myco/src/tools/definitions.test.ts`) with schema-handler parameter alignment tests.
+1. **Create test file** (`tests/tools/definitions.test.ts`) with schema-handler parameter alignment tests. Test files live under `tests/` — the runner discovers nothing outside it, and `tests/meta/test-suite-integrity.test.ts` fails CI on a test authored anywhere else.
 
 2. **Schema-handler parameter alignment test** — verify all schema parameters are referenced in handler source.
 

--- a/packages/myco/src/capture/drain-health.ts
+++ b/packages/myco/src/capture/drain-health.ts
@@ -25,10 +25,12 @@
 /** How a drain attempt failed, distinguishing "the host itself could not be
  *  reached" (transport-level: connection refused, timeout, DNS) from "the
  *  host answered but rejected the attempt" (an unexpected status/response
- *  shape). Both count as a failing entry; only the former counts toward
- *  host-unreachable occurrences — the doctor/status signal an operator most
- *  wants ("is the host down, or is something else wrong?"). */
-export type DrainFailureKind = 'unreachable' | 'rejected';
+ *  shape). `unreadable` is neither remote case: the local source the entry
+ *  points at could not be read, so the drain cannot tell whether the work is
+ *  still owed. All three count as a failing entry; only `unreachable` counts
+ *  toward host-unreachable occurrences — the doctor/status signal an operator
+ *  most wants ("is the host down, or is something else wrong?"). */
+export type DrainFailureKind = 'unreachable' | 'rejected' | 'unreadable';
 
 /** The three fields every drain entry gains. Optional so a pre-existing
  *  persisted entry (no failure fields yet) round-trips as "healthy". */

--- a/packages/myco/src/capture/plan-drain.ts
+++ b/packages/myco/src/capture/plan-drain.ts
@@ -54,6 +54,7 @@ import {
   type DrainHealthCounters,
   type FailureTrackedEntry,
 } from './drain-health.js';
+import { readFilePresence, type Presence } from '@myco/utils/presence.js';
 
 /** Stable, filesystem-safe queue key for one plan file (its member-local path).
  *  Whole-file channel → keyed by path (no inode/offset like the transcript id). */
@@ -111,10 +112,13 @@ export type PlanPostTransport = (
   body: PlanChunkRequest,
 ) => Promise<PlanChunkResponse>;
 
-/** The filesystem read seam — read the whole plan file, or null if it is gone.
+/** The filesystem read seam — the whole plan file, its genuine absence, or an
+ *  undetermined read. An undetermined read must never be treated as absence:
+ *  the entry is the only record that this plan still owes the host, and
+ *  dropping it on a transient EACCES/EMFILE loses the plan permanently.
  *  Injectable so the drain's dedup/skip semantics are unit-testable without disk. */
 export interface PlanFileReader {
-  read(planPath: string): string | null;
+  read(planPath: string): Presence<string>;
 }
 
 /** The durable store seam over the machine-scoped queue dir. Default is the
@@ -222,11 +226,7 @@ export function createFsPlanDrainStore(rootDir: string = resolveMemberPlanDrainD
 
 const defaultFileReader: PlanFileReader = {
   read(planPath) {
-    try {
-      return fs.readFileSync(planPath, 'utf-8');
-    } catch {
-      return null;
-    }
+    return readFilePresence(planPath);
   },
 };
 
@@ -482,8 +482,10 @@ export class PlanDrainQueue {
     let n = 0;
     for (const entry of this.store.list()) {
       const content = this.fileReader.read(entry.plan_path);
-      if (content === null) continue; // file gone → inert
-      if (hashContent(content) !== entry.acked_hash) n += 1;
+      if (content.state === 'absent') continue; // file gone → inert
+      // An undetermined read counts as pending: the entry may still owe the
+      // host, and releasing the hold would let the machine sleep on unshipped work.
+      if (content.state === 'unknown' || hashContent(content.value) !== entry.acked_hash) n += 1;
     }
     return n;
   }
@@ -516,11 +518,8 @@ export class PlanDrainQueue {
       for (const entry of this.store.listForHost(hostId)) {
         if (entry.session_id !== sessionId) continue;
         const content = this.fileReader.read(entry.plan_path);
-        if (content === null) {
-          this.store.remove(entry.host_id, entry.session_id, entry.plan_ref);
-          continue;
-        }
-        if (hashContent(content) === entry.acked_hash) {
+        if (content.state === 'unknown') continue; // undetermined — keep the entry for a later tick
+        if (content.state === 'absent' || hashContent(content.value) === entry.acked_hash) {
           this.store.remove(entry.host_id, entry.session_id, entry.plan_ref);
         }
       }
@@ -623,13 +622,25 @@ export class PlanDrainQueue {
    * on this host); the request's TENANCY is taken PER-ENTRY below.
    */
   private async drainEntry(hostTarget: RemoteTarget, entry: PlanDrainEntry): Promise<number> {
-    const content = this.fileReader.read(entry.plan_path);
-    if (content === null) {
+    const read = this.fileReader.read(entry.plan_path);
+    if (read.state === 'absent') {
       // The plan file was removed/moved after the write — its content is
       // unreachable. Remove the inert entry (bounds the store; nothing to ship).
       this.store.remove(entry.host_id, entry.session_id, entry.plan_ref);
       return 0;
     }
+    if (read.state === 'unknown') {
+      this.logger?.warn('capture.plan-drain', 'plan file unreadable — retry next tick', {
+        host_id: entry.host_id,
+        session_id: entry.session_id,
+        error: read.error.message,
+      });
+      // The file may still be there and unshipped; keep the entry and retry.
+      recordDrainFailure(entry, 'unreadable', new Date().toISOString());
+      this.store.put(entry);
+      return 0;
+    }
+    const content = read.value;
     const hash = hashContent(content);
     if (hash === entry.acked_hash) return this.noOpDrained(entry); // unchanged since last ack — no-op
 
@@ -706,11 +717,16 @@ export class PlanDrainQueue {
   health(): Map<string, DrainHealthCounters> {
     const rows = this.store.list().map((entry) => {
       const content = this.fileReader.read(entry.plan_path);
-      const pending = content !== null && hashContent(content) !== entry.acked_hash;
+      // Mirrors pendingCount: an undetermined read stays pending so a failing
+      // entry cannot read as healthy in the surface built to catch it.
+      const pending = content.state === 'unknown'
+        || (content.state === 'present' && hashContent(content.value) !== entry.acked_hash);
       return {
         host_id: entry.host_id,
         pending,
-        pendingUnits: pending && content !== null ? Buffer.byteLength(content, 'utf-8') : undefined,
+        pendingUnits: pending && content.state === 'present'
+          ? Buffer.byteLength(content.value, 'utf-8')
+          : undefined,
         consecutive_failures: entry.consecutive_failures,
         last_error_kind: entry.last_error_kind,
       };

--- a/packages/myco/src/capture/transcript-miner.ts
+++ b/packages/myco/src/capture/transcript-miner.ts
@@ -116,6 +116,14 @@ export interface ReconcileResult {
    * onto the parent session).
    */
   skippedReason?: string;
+  /**
+   * Whether this pass actually read the transcript. False when the file could
+   * not be opened, and when a transcript-level rule skipped the pass so the
+   * content was never mined into this session. Callers that authorize deleting
+   * the transcript must require true — an empty mine and an unreadable one are
+   * indistinguishable without it.
+   */
+  readTranscript: boolean;
 }
 
 /** Head-bytes sampled to detect in-place overwrite with same inode + size. */
@@ -328,7 +336,7 @@ export class TranscriptMiner {
     // whose session_meta matches a manifest drop rule is never mined.
     const gate = this.transcriptGate(sessionId, input);
     if (gate.dropReason) {
-      return { reclassified: 0, inserted: 0, errors: [], skippedReason: gate.dropReason };
+      return { reclassified: 0, inserted: 0, errors: [], skippedReason: gate.dropReason, readTranscript: false };
     }
 
     // Sub-agent thread reattribution: mine the child rollout INTO the parent
@@ -345,7 +353,7 @@ export class TranscriptMiner {
     // The parent must already exist — a child mine never materializes it.
     // Checked every call (not memoized) so a late-registering parent unblocks.
     if (reattribute && !getSession(targetSessionId, ALL_PROJECTS_SCOPE)) {
-      return { reclassified: 0, inserted: 0, errors: [], skippedReason: 'subagent-parent-missing' };
+      return { reclassified: 0, inserted: 0, errors: [], skippedReason: 'subagent-parent-missing', readTranscript: false };
     }
 
     // Short-circuit: if we've already reconciled this transcript at its
@@ -367,7 +375,7 @@ export class TranscriptMiner {
         // session doesn't get evicted while other transcripts churn.
         this.parseCache.delete(input.transcriptPath);
         this.parseCache.set(input.transcriptPath, cached);
-        return { reclassified: 0, inserted: 0, errors: [] };
+        return { reclassified: 0, inserted: 0, errors: [], readTranscript: true };
       }
     } catch {
       // statSync failure falls through to parseAllEvents, which handles it.
@@ -375,9 +383,10 @@ export class TranscriptMiner {
 
     // The walker receives the transcript meta so per-prompt
     // `transcript_meta_*` rules fire at mining time exactly as at hook time.
+    const parsed = this.parseAllEvents(input.transcriptPath);
     const { records, droppedText, noMaskableDropRuleFound } = extractUserPromptRecordsWithDrops(
       input.agent,
-      this.parseAllEvents(input.transcriptPath),
+      parsed.events,
       input.transcriptPath,
       gate.meta,
       reattribute ? { subagentReattribution: true } : undefined,
@@ -609,7 +618,7 @@ export class TranscriptMiner {
       });
     }
 
-    return { reclassified, inserted, errors };
+    return { reclassified, inserted, errors, readTranscript: parsed.read };
   }
 
   /**
@@ -714,12 +723,18 @@ export class TranscriptMiner {
     }
   }
 
-  private parseAllEvents(transcriptPath: string): Array<Record<string, unknown>> {
+  /**
+   * Parse the whole transcript. `read` distinguishes "the file was opened and
+   * yielded these events" from "the file could not be read at all" — an empty
+   * array means nothing on its own, and callers that go on to authorize a
+   * delete must not treat an unreadable transcript as a mined-empty one.
+   */
+  private parseAllEvents(transcriptPath: string): { events: Array<Record<string, unknown>>; read: boolean } {
     let stat: fs.Stats;
     try {
       stat = fs.statSync(transcriptPath);
     } catch {
-      return [];
+      return { events: [], read: false };
     }
 
     const cached = this.parseCache.get(transcriptPath);
@@ -750,14 +765,14 @@ export class TranscriptMiner {
         // Reset — reconcile hasn't run against this (possibly rotated) file yet.
         reconciledSize: -1,
       });
-      return events;
+      return { events, read: true };
     }
 
     if (stat.size === cached.offset) {
       // Touch LRU so the entry stays hot while we keep hitting the cache.
       this.parseCache.delete(transcriptPath);
       this.parseCache.set(transcriptPath, cached);
-      return cached.events;
+      return { events: cached.events, read: true };
     }
 
     // Incremental: read bytes added since last parse, up to the last newline.
@@ -766,7 +781,7 @@ export class TranscriptMiner {
     if (newline === -1) {
       this.parseCache.delete(transcriptPath);
       this.parseCache.set(transcriptPath, cached);
-      return cached.events;
+      return { events: cached.events, read: true };
     }
 
     const complete = tail.slice(0, newline + 1);
@@ -780,7 +795,7 @@ export class TranscriptMiner {
       // New bytes appeared — previous reconciledSize is now stale.
       reconciledSize: cached.reconciledSize,
     });
-    return merged;
+    return { events: merged, read: true };
   }
 
   /**

--- a/packages/myco/src/daemon/api/session-lifecycle.ts
+++ b/packages/myco/src/daemon/api/session-lifecycle.ts
@@ -68,7 +68,7 @@ export interface SessionLifecycleDeps {
    * this, a response sitting complete in the transcript is never lifted into
    * `response_summary` — the steering/final-summary capture gap.
    */
-  transcriptMiner: { reconcileAndAttributeResponses: (sessionId: string, input: { agent: string; transcriptPath: string }) => unknown };
+  transcriptMiner: { reconcileAndAttributeResponses: (sessionId: string, input: { agent: string; transcriptPath: string }) => { readTranscript: boolean } };
   server: DaemonServer;
   powerManager: PowerManager;
   machineId: string;

--- a/packages/myco/src/daemon/job-runner.ts
+++ b/packages/myco/src/daemon/job-runner.ts
@@ -215,13 +215,28 @@ export class JobRunner {
     void job.fn(ctx).then((outcome) => settle(undefined, outcome), (err) => settle(err));
   }
 
-  /** Name of the first job holding deep-sleep, or null. Defensive: a failing probe never holds. */
+  /**
+   * Name of the first job holding deep-sleep, or null.
+   *
+   * A probe that throws HOLDS. These probes count unshipped capture, so a
+   * probe that cannot answer is not evidence there is nothing to ship — and
+   * sleeping stops the drains, after which the source file can rotate away.
+   * Staying awake on a broken probe costs power; sleeping on one costs data.
+   */
   providesHold(): string | null {
     for (const job of this.jobs) {
       if (!job.hold) continue;
       if ((job.hold.allowDeepSleepHold ?? true) === false) continue;
       let pending = 0;
-      try { pending = job.hold.pending(); } catch { pending = 0; }
+      try {
+        pending = job.hold.pending();
+      } catch (err) {
+        this.opts.logger.warn(LOG_KINDS.POWER_JOB, 'Deep-sleep hold probe failed — holding awake', {
+          job: job.name,
+          error: (err as Error).message,
+        });
+        return job.name;
+      }
       if (pending > 0) return job.name;
     }
     return null;

--- a/packages/myco/src/daemon/power-jobs.ts
+++ b/packages/myco/src/daemon/power-jobs.ts
@@ -595,6 +595,14 @@ export function registerPowerJobs(runner: JobRunner, deps: PowerJobDeps): PowerJ
           // mine source at close — the tree may hold unmined bytes. Keep it
           // forever rather than guess (data preservation over disk).
           if (!session.transcript_path) continue;
+          // Positive proof the final mining pass actually read the transcript.
+          // `completed` alone never carried it: the completion chokepoint closes
+          // a session even when mining throws, and an unreadable transcript
+          // parsed as zero events looked exactly like a mined-empty one. NULL
+          // means no outcome was recorded (pre-v74 row completed by an older
+          // binary, or a close that never reached the chokepoint) — unproven,
+          // so keep the bytes.
+          if (session.final_mine_ok !== 1) continue;
           // Late-append TOCTOU guard (prune-only-when-quiet): the transcript
           // ingest route appends purely by offset and never touches the
           // sessions row, so a reconnecting member's drain backstop can land

--- a/packages/myco/src/daemon/session-completion.ts
+++ b/packages/myco/src/daemon/session-completion.ts
@@ -24,12 +24,19 @@
  * transcript is a no-op): a mining failure is logged and the close still
  * proceeds, matching the pre-existing `handleUnregister` semantics — a
  * session must never be left a zombie `active` because its transcript
- * could not be read. The GC keeps its own independent conservativeness for
- * the no-source case (a routed session with no stamped `transcript_path`
- * is never pruned — see `daemon/power-jobs.ts` ROUTED_TRANSCRIPT_CACHE_GC).
+ * could not be read.
+ *
+ * Closing anyway is only safe because the outcome is RECORDED. The session
+ * carries `final_mine_ok`, and the routed-transcript cache GC prunes a tree
+ * only when it is 1. So a failed or unattempted mine no longer looks like a
+ * successful one to the job that deletes the host's only copy — the session
+ * still closes, and the bytes are kept. The GC keeps its own independent
+ * conservativeness for the no-source case (a routed session with no stamped
+ * `transcript_path` is never pruned — see `daemon/power-jobs.ts`
+ * ROUTED_TRANSCRIPT_CACHE_GC).
  */
 
-import { closeSession, getSession, type SessionRow } from '@myco/db/queries/sessions.js';
+import { closeSession, getSession, setFinalMineOk, type SessionRow } from '@myco/db/queries/sessions.js';
 import { ALL_PROJECTS_SCOPE } from '@myco/grove/ids.js';
 import { LOG_KINDS } from '@myco/constants/log-kinds.js';
 
@@ -43,7 +50,7 @@ export interface SessionCompletionMiner {
   reconcileAndAttributeResponses(
     sessionId: string,
     input: { agent: string; transcriptPath: string },
-  ): unknown;
+  ): { readTranscript: boolean };
 }
 
 export interface SessionCompletionDeps {
@@ -65,13 +72,16 @@ export function completeSessionWithMining(
   endedAt: number,
   deps: SessionCompletionDeps,
 ): SessionRow | null {
+  // Unattempted stays unproven: a session with no mine source never earns the
+  // GC's proof, which is what keeps its tree on disk.
+  let minedOk = false;
   try {
     const ending = getSession(sessionId, ALL_PROJECTS_SCOPE);
     if (ending?.agent && ending.transcript_path) {
-      deps.transcriptMiner.reconcileAndAttributeResponses(sessionId, {
+      minedOk = deps.transcriptMiner.reconcileAndAttributeResponses(sessionId, {
         agent: ending.agent,
         transcriptPath: ending.transcript_path,
-      });
+      }).readTranscript;
     }
   } catch (err) {
     deps.logger?.warn(
@@ -80,5 +90,6 @@ export function completeSessionWithMining(
       { session_id: sessionId, error: err instanceof Error ? err.message : String(err) },
     );
   }
+  setFinalMineOk(sessionId, minedOk);
   return closeSession(sessionId, endedAt);
 }

--- a/packages/myco/src/db/migrations.ts
+++ b/packages/myco/src/db/migrations.ts
@@ -145,6 +145,7 @@ export const MIGRATIONS: Migration[] = [
   { version: 71, migrate: (db) => migrateV70ToV71(db) },
   { version: 72, migrate: (db) => migrateV71ToV72(db) },
   { version: 73, migrate: (db) => migrateV72ToV73(db) },
+  { version: 74, migrate: (db) => migrateV73ToV74(db) },
 ];
 
 // ---------------------------------------------------------------------------
@@ -4659,3 +4660,42 @@ function migrateV65ToV66(db: Database): void {
  */
 // (Team Host's original v67 routed_event_dedup migration was renumbered to v68
 // above — migrateV67ToV68 — after the OKF rebase collision. Leftover removed.)
+
+/**
+ * v73 → v74: add `sessions.final_mine_ok`, the routed-transcript cache GC's
+ * proof that the final mining pass actually read the transcript.
+ *
+ * The GC deletes the host's only copy of a routed session's transcript. Its
+ * gate was `status = 'completed'`, on the stated assumption that completing a
+ * session implies it was fully mined — but the completion chokepoint closes
+ * the session even when mining throws, and a `statSync` failure inside the
+ * miner produced an empty parse that looked like a successful mine of an empty
+ * file. Either way the tree was pruned with its content unread.
+ *
+ * NULL means "no final mining outcome was recorded", which the GC treats as
+ * unproven and refuses to prune on. Existing completed rows are backfilled to 1
+ * so the upgrade does not strand every already-pruneable tree on disk forever;
+ * the new guarantee binds sessions completed from this version onward.
+ *
+ * Additive and nullable, so an older binary reading a v74 vault keeps working.
+ */
+function migrateV73ToV74(db: Database): void {
+  db.prepare('BEGIN').run();
+  try {
+    const cols = getTableColumnSet(db, 'sessions');
+    if (!cols.has('final_mine_ok')) {
+      db.prepare('ALTER TABLE sessions ADD COLUMN final_mine_ok INTEGER').run();
+      db.prepare(
+        `UPDATE sessions SET final_mine_ok = 1 WHERE status = 'completed' AND final_mine_ok IS NULL`,
+      ).run();
+    }
+
+    db.prepare(
+      `INSERT INTO schema_version (version, applied_at) VALUES (?, ?) ON CONFLICT (version) DO NOTHING`,
+    ).run(74, epochSeconds());
+    db.prepare('COMMIT').run();
+  } catch (err) {
+    db.prepare('ROLLBACK').run();
+    throw err;
+  }
+}

--- a/packages/myco/src/db/queries/sessions.ts
+++ b/packages/myco/src/db/queries/sessions.ts
@@ -93,6 +93,11 @@ export interface SessionRow {
   canopy_tokens_saved: number | null;
   canopy_redundant_reads: number | null;
   canopy_map_tool_calls: number;
+  /** 1 when the final mining pass read the transcript; 0 when it did not;
+   *  null when no outcome was recorded (pre-v74 row, or a close that never
+   *  reached the completion chokepoint). The routed-transcript GC prunes
+   *  only on 1. */
+  final_mine_ok: number | null;
 }
 
 /** Updatable fields for `updateSession`. */
@@ -178,6 +183,7 @@ const SESSION_COLUMNS = [
   'canopy_tokens_saved',
   'canopy_redundant_reads',
   'canopy_map_tool_calls',
+  'final_mine_ok',
 ] as const;
 
 const SELECT_COLUMNS = SESSION_COLUMNS.join(', ');
@@ -222,6 +228,7 @@ function toSessionRow(row: Record<string, unknown>): SessionRow {
     canopy_tokens_saved: (row.canopy_tokens_saved as number) ?? null,
     canopy_redundant_reads: (row.canopy_redundant_reads as number) ?? null,
     canopy_map_tool_calls: (row.canopy_map_tool_calls as number) ?? 0,
+    final_mine_ok: (row.final_mine_ok as number) ?? null,
   };
 }
 
@@ -550,6 +557,24 @@ export function updateSession(
  *
  * @returns the updated row, or null if the session does not exist.
  */
+/**
+ * Record whether the final mining pass read this session's transcript.
+ *
+ * The routed-transcript cache GC deletes the host's only copy of a routed
+ * session's transcript, and gates that on this flag being 1. Written by the
+ * completion chokepoint immediately before `closeSession`, so a session that
+ * closed without a successful mine keeps its bytes.
+ *
+ * Local-only (see `LOCAL_ONLY_SYNC_COLUMNS`): it describes THIS machine's
+ * mining outcome, and one machine's result must never authorize another
+ * machine's delete.
+ */
+export function setFinalMineOk(id: string, ok: boolean): void {
+  getDatabase().prepare(
+    `UPDATE sessions SET final_mine_ok = ? WHERE id = ?`,
+  ).run(ok ? 1 : 0, id);
+}
+
 export function closeSession(
   id: string,
   endedAt: number,

--- a/packages/myco/src/db/queries/team-outbox.ts
+++ b/packages/myco/src/db/queries/team-outbox.ts
@@ -76,6 +76,11 @@ export const LOCAL_ONLY_OUTBOX_TABLES = new Set<string>([
 export const LOCAL_ONLY_SYNC_COLUMNS: Record<string, readonly string[]> = {
   sessions: [
     'embedded',
+    // Whether THIS machine's final mining pass read the transcript. The routed
+    // transcript lives on the host, so a member's outcome says nothing about
+    // the host's cache and vice versa — syncing it would let one machine's
+    // result authorize another machine's delete.
+    'final_mine_ok',
     'canopy_injections_offered',
     'canopy_injection_total_tokens',
     'canopy_skips_after_injection',

--- a/packages/myco/src/db/schema-ddl.ts
+++ b/packages/myco/src/db/schema-ddl.ts
@@ -55,7 +55,8 @@ export const SESSIONS_TABLE = `
     canopy_reads_after_injection   INTEGER,
     canopy_tokens_saved            INTEGER,
     canopy_redundant_reads         INTEGER,
-    canopy_map_tool_calls          INTEGER NOT NULL DEFAULT 0
+    canopy_map_tool_calls          INTEGER NOT NULL DEFAULT 0,
+    final_mine_ok                  INTEGER
   )`;
 
 /**

--- a/packages/myco/src/db/schema.ts
+++ b/packages/myco/src/db/schema.ts
@@ -20,7 +20,7 @@ import { TABLE_DDLS, FTS_TABLES, SECONDARY_INDEXES, TEAM_DELETE_TRIGGERS } from 
 import { MIGRATIONS } from './migrations.js';
 
 /** Current schema version -- fresh start for the SQLite era. */
-export const SCHEMA_VERSION = 73;
+export const SCHEMA_VERSION = 74;
 
 // Re-export for backwards compat (other modules import from schema.ts)
 export { DEFAULT_MACHINE_ID };

--- a/packages/myco/src/db/schema.ts
+++ b/packages/myco/src/db/schema.ts
@@ -63,6 +63,25 @@ export interface CanopyEntry {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Raised when a database was written by a newer Myco than this binary
+ * understands. The vault is left untouched: an older binary cannot migrate
+ * a newer schema down, and writing to it through the older schema's DDL
+ * corrupts rows whose column types changed.
+ */
+export class SchemaVersionTooNewError extends Error {
+  readonly code = 'schema_version_too_new';
+
+  constructor(readonly foundVersion: number, readonly supportedVersion: number) {
+    super(
+      `schema_version_too_new: this database is at schema v${foundVersion}, but this Myco supports v${supportedVersion}. `
+      + 'It was written by a newer version of Myco. Upgrade Myco to open it, or restore a backup taken before the upgrade. '
+      + 'The database has not been modified.',
+    );
+    this.name = 'SchemaVersionTooNewError';
+  }
+}
+
 function getCurrentVersion(db: Database): number {
   const row = db.prepare(
     'SELECT version FROM schema_version ORDER BY version DESC LIMIT 1'
@@ -110,6 +129,12 @@ function hasSchemaVersionTable(db: Database): boolean {
 export function createSchema(db: Database, machineId: string = DEFAULT_MACHINE_ID): void {
   if (hasSchemaVersionTable(db)) {
     const currentVersion = getCurrentVersion(db);
+    // Fail closed on a newer-than-supported vault. Without this the equality
+    // check falls through, no migration matches, and the older binary's DDL is
+    // reapplied over a schema whose column types have already moved on.
+    if (currentVersion > SCHEMA_VERSION) {
+      throw new SchemaVersionTooNewError(currentVersion, SCHEMA_VERSION);
+    }
     if (currentVersion === SCHEMA_VERSION) {
       reapplyCurrentSchemaDdl(db);
       return;

--- a/packages/myco/src/utils/presence.ts
+++ b/packages/myco/src/utils/presence.ts
@@ -1,0 +1,75 @@
+/**
+ * Three-state reads for durable state: `present`, `absent`, `unknown`.
+ *
+ * A read that wraps `fs.*` in `try/catch` and returns `null` / `[]` collapses two
+ * different facts into one value: "this genuinely is not here" and "I could not
+ * find out". Callers then treat the second as the first, and the ones that go on
+ * to delete, dequeue, advance a cursor, or mark something complete destroy data
+ * on a transient `EACCES` or `EMFILE`.
+ *
+ * `absent` stays a first-class, silent domain answer — ENOENT is not an error and
+ * must not become one. Everything else is `unknown`, and an `unknown` is never
+ * authority to destroy.
+ *
+ * The discriminating read already existed in `grove/registry.ts`; this is that
+ * idiom extracted so the destructive paths can share it.
+ */
+import fs from 'node:fs';
+
+export type Presence<T> =
+  | { state: 'present'; value: T }
+  | { state: 'absent' }
+  | { state: 'unknown'; error: NodeJS.ErrnoException };
+
+export function present<T>(value: T): Presence<T> {
+  return { state: 'present', value };
+}
+
+export const ABSENT: Presence<never> = { state: 'absent' };
+
+export function unknown<T>(error: NodeJS.ErrnoException): Presence<T> {
+  return { state: 'unknown', error };
+}
+
+/** Errno values that mean "the thing is genuinely not there". */
+const ABSENCE_CODES: ReadonlySet<string> = new Set(['ENOENT', 'ENOTDIR']);
+
+/** Classify a caught filesystem error as absence or an undetermined read. */
+export function classifyFsError<T>(err: unknown): Presence<T> {
+  const errno = err as NodeJS.ErrnoException;
+  if (errno && typeof errno.code === 'string' && ABSENCE_CODES.has(errno.code)) return ABSENT;
+  return unknown(errno);
+}
+
+export function readFilePresence(filePath: string): Presence<string> {
+  try {
+    return present(fs.readFileSync(filePath, 'utf-8'));
+  } catch (err) {
+    return classifyFsError(err);
+  }
+}
+
+export function statPresence(filePath: string): Presence<fs.Stats> {
+  try {
+    return present(fs.statSync(filePath));
+  } catch (err) {
+    return classifyFsError(err);
+  }
+}
+
+export function readDirPresence(dir: string): Presence<fs.Dirent[]> {
+  try {
+    return present(fs.readdirSync(dir, { withFileTypes: true }));
+  } catch (err) {
+    return classifyFsError(err);
+  }
+}
+
+/**
+ * Collapse to a nullable value. Only for call sites where an undetermined read
+ * and a genuine absence truly are equivalent — never on a path that goes on to
+ * delete, dequeue, or mark complete.
+ */
+export function orNull<T>(result: Presence<T>): T | null {
+  return result.state === 'present' ? result.value : null;
+}

--- a/tests/agent/tools/canopy-tools.residency.test.ts
+++ b/tests/agent/tools/canopy-tools.residency.test.ts
@@ -7,8 +7,8 @@ import { createSchema } from '@myco/db/schema.js';
 import { epochSeconds } from '@myco/constants.js';
 import { assertGroveProjectId, createProjectId } from '@myco/grove/ids.js';
 import type { MycoRequestContext } from '@myco/grove/request-context.js';
-import { createCanopyTools } from './canopy-tools.js';
-import type { VaultToolDeps } from './types.js';
+import { createCanopyTools } from '@myco/agent/tools/canopy-tools.js';
+import type { VaultToolDeps } from '@myco/agent/tools/types.js';
 
 /**
  * Task B1 — canopy_describe_next is the second mis-scoping READ. On a host-served

--- a/tests/agent/tools/skill-tools.residency.test.ts
+++ b/tests/agent/tools/skill-tools.residency.test.ts
@@ -10,9 +10,9 @@ import { insertContentClaim, getActiveContentClaim } from '@myco/db/queries/cont
 import { epochSeconds } from '@myco/constants.js';
 import { assertGroveProjectId, createProjectId, GLOBAL_SCOPE } from '@myco/grove/ids.js';
 import type { MycoRequestContext } from '@myco/grove/request-context.js';
-import { createSkillTools } from './skill-tools.js';
-import { collectSkillWriteIssues } from './skill-write-validator.js';
-import type { VaultToolDeps } from './types.js';
+import { createSkillTools } from '@myco/agent/tools/skill-tools.js';
+import { collectSkillWriteIssues } from '@myco/agent/tools/skill-write-validator.js';
+import type { VaultToolDeps } from '@myco/agent/tools/types.js';
 
 /**
  * Task B1 — the Team Host residency write gate. A run served on the HOST for a

--- a/tests/capture/plan-drain.test.ts
+++ b/tests/capture/plan-drain.test.ts
@@ -30,6 +30,7 @@ import {
   type PlanFileReader,
   type PlanPostTransport,
 } from '@myco/capture/plan-drain';
+import { ABSENT, present, unknown } from '@myco/utils/presence';
 import type { PlanWatchConfig } from '@myco/daemon/plan-capture';
 import type { RemoteTarget } from '@myco/host/routing';
 import { DaemonServer } from '@myco/daemon/server';
@@ -56,14 +57,26 @@ const WATCH: PlanWatchConfig = { watchDirs: ['/plans'], projectRoot: '/', extens
 
 // --- fakes -----------------------------------------------------------------
 
-/** In-memory plan files the {@link PlanFileReader} reads. */
+/** In-memory plan files the {@link PlanFileReader} reads. A path in `unreadable`
+ *  models a file that exists but cannot be read (EACCES/EMFILE) — distinct from
+ *  one that is genuinely gone. */
 function memFiles() {
   const files = new Map<string, string>();
-  const reader: PlanFileReader = { read: (p) => (files.has(p) ? files.get(p)! : null) };
+  const unreadable = new Set<string>();
+  const reader: PlanFileReader = {
+    read: (p) => {
+      if (unreadable.has(p)) {
+        return unknown(Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' }));
+      }
+      return files.has(p) ? present(files.get(p)!) : ABSENT;
+    },
+  };
   return {
     reader,
     set(p: string, content: string) { files.set(p, content); },
     remove(p: string) { files.delete(p); },
+    makeUnreadable(p: string) { unreadable.add(p); },
+    makeReadable(p: string) { unreadable.delete(p); },
   };
 }
 
@@ -442,6 +455,44 @@ describe('durability discipline', () => {
     await q.flushBeforeForward(t);
     expect(store.get(HOST_A, 's', ref)).toBeNull(); // inert entry removed
     expect(host.calls).toHaveLength(0);
+  });
+
+  test('an UNREADABLE plan file is kept for retry, not dequeued like a deleted one', async () => {
+    const files = memFiles();
+    files.set('/plans/x.md', 'here');
+    const store = memStore();
+    const host = fakeHost();
+    const q = new PlanDrainQueue({ machineId: MACHINE, planWatchConfig: WATCH, store, transport: host.transport, fileReader: files.reader, ...noThrottle });
+    const t = target();
+    q.noteCollect(t, planEvent('s', '/plans/x.md'));
+    const ref = derivePlanRef('/plans/x.md');
+
+    files.makeUnreadable('/plans/x.md'); // present on disk, but EACCES right now
+    expect(q.pendingCount()).toBe(1); // still owed → must hold the machine awake
+    await q.flushBeforeForward(t);
+
+    const kept = store.get(HOST_A, 's', ref);
+    expect(kept).not.toBeNull();
+    expect(kept!.last_error_kind).toBe('unreadable');
+    expect(host.calls).toHaveLength(0); // nothing shipped — the content was never read
+
+    // The transient condition clears and the plan ships on a later tick.
+    files.makeReadable('/plans/x.md');
+    await q.flushBeforeForward(t);
+    expect(host.calls).toHaveLength(1);
+    expect(host.calls[0]!.body.content).toBe('here');
+  });
+
+  test('an unreadable entry surfaces as pending in drain health, not as healthy', () => {
+    const files = memFiles();
+    files.set('/plans/x.md', 'here');
+    const store = memStore();
+    const q = new PlanDrainQueue({ machineId: MACHINE, planWatchConfig: WATCH, store, fileReader: files.reader, ...noThrottle });
+    q.noteCollect(target(), planEvent('s', '/plans/x.md'));
+
+    files.makeUnreadable('/plans/x.md');
+
+    expect(q.health().get(HOST_A)?.pendingEntries).toBe(1);
   });
 });
 

--- a/tests/capture/transcript-miner-lru.test.ts
+++ b/tests/capture/transcript-miner-lru.test.ts
@@ -95,7 +95,7 @@ describe('TranscriptMiner parseCache LRU + short-circuit', () => {
     // idempotent pipeline would still report 0 but we'd pay the DB cost.
     for (let i = 0; i < 5; i++) {
       const r = miner.reconcileBatchKinds(sessionId, { agent: 'claude-code', transcriptPath: tp });
-      expect(r).toEqual({ reclassified: 0, inserted: 0, errors: [] });
+      expect(r).toEqual({ reclassified: 0, inserted: 0, errors: [], readTranscript: true });
     }
   });
 
@@ -119,7 +119,7 @@ describe('TranscriptMiner parseCache LRU + short-circuit', () => {
 
     // And another idempotent pass after the growth settles must short-circuit again.
     const third = miner.reconcileBatchKinds(sessionId, { agent: 'claude-code', transcriptPath: tp });
-    expect(third).toEqual({ reclassified: 0, inserted: 0, errors: [] });
+    expect(third).toEqual({ reclassified: 0, inserted: 0, errors: [], readTranscript: true });
   });
 
   it('does NOT short-circuit after a rotation (inode change)', () => {

--- a/tests/daemon/api/drain-health.test.ts
+++ b/tests/daemon/api/drain-health.test.ts
@@ -19,6 +19,7 @@ import {
 import { type HostRecord } from '@myco/host/registry.js';
 import type { DrainHealthCounters } from '@myco/capture/drain-health.js';
 import { PlanDrainQueue, type PlanDrainStore, type PlanDrainEntry, type PlanFileReader, type PlanPostTransport } from '@myco/capture/plan-drain.js';
+import { ABSENT, present } from '@myco/utils/presence.js';
 import type { RemoteTarget } from '@myco/host/routing.js';
 import { testPerUserLockNamespace } from '../../helpers/per-user-lock-namespace.js';
 
@@ -163,7 +164,9 @@ describe('GET /api/team-host/drain-health', () => {
     writeHostRecordFixture(host(HOST_A, 'mac-studio'));
     const files = new Map<string, string>();
     files.set('/plans/x.md', '# plan');
-    const fileReader: PlanFileReader = { read: (p) => files.get(p) ?? null };
+    const fileReader: PlanFileReader = {
+      read: (p) => (files.has(p) ? present(files.get(p)!) : ABSENT),
+    };
     const entries = new Map<string, PlanDrainEntry>();
     const store: PlanDrainStore = {
       list: () => [...entries.values()],

--- a/tests/daemon/job-runner.test.ts
+++ b/tests/daemon/job-runner.test.ts
@@ -187,10 +187,21 @@ describe('JobRunner deep-sleep hold', () => {
     expect(r.providesHold()).toBeNull();
   });
 
-  it('a throwing hold probe does not throw and does not hold', () => {
+  it('a throwing hold probe does not throw, and holds rather than sleeping on an unknown', () => {
     const r = new JobRunner({ concurrency: 3, logger: silentLogger(), clock: () => 0 });
     r.register({ name: 'x', runIn: ['sleep'], kind: 'drain', drain: { slice: 1 },
       hold: { pending: () => { throw new Error('probe down'); } }, fn: async () => {} });
+    // A probe that cannot answer is not evidence there is nothing to ship. These
+    // probes count un-shipped capture, and sleeping stops the drains, after which
+    // the source file can rotate away — so an unanswerable probe holds awake.
+    expect(r.providesHold()).toBe('x');
+  });
+
+  it('a throwing probe on a hold-exempt job still does not hold', () => {
+    const r = new JobRunner({ concurrency: 3, logger: silentLogger(), clock: () => 0 });
+    r.register({ name: 'x', runIn: ['sleep'], kind: 'drain', drain: { slice: 1 },
+      hold: { pending: () => { throw new Error('probe down'); }, allowDeepSleepHold: false },
+      fn: async () => {} });
     expect(r.providesHold()).toBeNull();
   });
 });

--- a/tests/daemon/power-jobs.test.ts
+++ b/tests/daemon/power-jobs.test.ts
@@ -847,7 +847,18 @@ describe('routed-transcript-cache-gc power job', () => {
     id: string,
     status: 'active' | 'completed',
     machineId: string,
-    opts: { transcriptPath?: string | null; startedAt?: number; endedAt?: number } = {},
+    opts: {
+      transcriptPath?: string | null;
+      startedAt?: number;
+      endedAt?: number;
+      /**
+       * The GC's proof that the final mining pass read the transcript. Defaults
+       * to 1 for a completed session — the shape a session that mined
+       * successfully at close has. Pass 0 (mining failed) or null (no outcome
+       * recorded, e.g. a pre-v74 row) to exercise the unproven guard.
+       */
+      finalMineOk?: number | null;
+    } = {},
   ): void {
     const startedAt = opts.startedAt ?? Math.floor(Date.now() / 1000);
     withDatabase(fx.cache.getDatabase(fx.databasePath), () => {
@@ -870,6 +881,12 @@ describe('routed-transcript-cache-gc power job', () => {
           ? `/routed/materialized/${id}.jsonl`
           : opts.transcriptPath,
       });
+      const minedOk = opts.finalMineOk === undefined
+        ? (status === 'completed' ? 1 : null)
+        : opts.finalMineOk;
+      fx.cache.getDatabase(fx.databasePath)
+        .prepare('UPDATE sessions SET final_mine_ok = ? WHERE id = ?')
+        .run(minedOk, id);
     });
   }
 
@@ -1062,7 +1079,7 @@ describe('routed-transcript-cache-gc power job', () => {
       transcriptMiner: {
         reconcileAndAttributeResponses(sessionId: string, input: { agent: string; transcriptPath: string }) {
           minerCalls.push({ sessionId, ...input });
-          return {};
+          return { readTranscript: true }; // the transcript was readable and mined
         },
       },
     }));
@@ -1092,6 +1109,34 @@ describe('routed-transcript-cache-gc power job', () => {
     ageCacheDir('member_eeee5555', 'sess-crashed', QUIET_AGE_MS);
     await pm.find('routed-transcript-cache-gc').fn();
     expect(cacheDirExists('member_eeee5555', 'sess-crashed')).toBe(false);
+  });
+
+  it('never prunes when the final mining pass could not read the transcript', async () => {
+    // The permanent-loss path: the transcript was unreadable at close (EACCES,
+    // fd exhaustion, a lock), so mining returned nothing. Status still flips to
+    // completed — a session must never be stranded active — but the tree holds
+    // the only copy of content that never reached the DB, so it must survive.
+    materializeCacheDir('member_ffff6666', 'sess-unmined');
+    seedSession('sess-unmined', 'completed', 'member_ffff6666', { finalMineOk: 0 });
+    ageCacheDir('member_ffff6666', 'sess-unmined', QUIET_AGE_MS);
+
+    registerPowerJobs(pm as never, buildDeps(fx));
+    await pm.find('routed-transcript-cache-gc').fn();
+
+    expect(cacheDirExists('member_ffff6666', 'sess-unmined')).toBe(true);
+  });
+
+  it('never prunes a completed row that predates the mining-proof column', async () => {
+    // A row completed by an older binary carries no outcome at all. Unproven is
+    // not provable, so the bytes stay.
+    materializeCacheDir('member_ffff6666', 'sess-legacy');
+    seedSession('sess-legacy', 'completed', 'member_ffff6666', { finalMineOk: null });
+    ageCacheDir('member_ffff6666', 'sess-legacy', QUIET_AGE_MS);
+
+    registerPowerJobs(pm as never, buildDeps(fx));
+    await pm.find('routed-transcript-cache-gc').fn();
+
+    expect(cacheDirExists('member_ffff6666', 'sess-legacy')).toBe(true);
   });
 });
 

--- a/tests/db/migrate-v73-to-v74-final-mine-ok.test.ts
+++ b/tests/db/migrate-v73-to-v74-final-mine-ok.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { createSchema, SCHEMA_VERSION } from '@myco/db/schema.js';
+import { epochSeconds } from '@myco/constants.js';
+
+function columnNames(db: Database, table: string): Set<string> {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  return new Set(rows.map((r) => r.name));
+}
+
+function stampedVersion(db: Database): number {
+  const row = db.prepare(
+    'SELECT version FROM schema_version ORDER BY version DESC LIMIT 1',
+  ).get() as { version: number } | undefined;
+  return row?.version ?? 0;
+}
+
+function insertSession(db: Database, id: string, status: string): void {
+  const now = epochSeconds();
+  db.prepare(
+    `INSERT INTO sessions (id, agent, started_at, status, prompt_count, tool_count, created_at)
+     VALUES (?, 'claude-code', ?, ?, 0, 0, ?)`,
+  ).run(id, now, status, now);
+}
+
+/**
+ * A vault frozen at v73: created at the current shape, then the new column
+ * dropped and the version stamped back to 73, so the migration has real work.
+ *
+ * The 73 row must be inserted explicitly. A fresh install stamps only
+ * SCHEMA_VERSION, so deleting everything above 73 would leave the table empty,
+ * `getCurrentVersion` would read 0, and the whole chain would replay from the
+ * v34 rescue floor — which creates tables from the live DDL, so the column
+ * would already exist by the time this migration ran and the backfill would
+ * silently no-op.
+ */
+function seedV73Vault(): Database {
+  const db = new Database(':memory:');
+  createSchema(db, 'local');
+  db.prepare('ALTER TABLE sessions DROP COLUMN final_mine_ok').run();
+  db.prepare('DELETE FROM schema_version').run();
+  db.prepare('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)').run(73, epochSeconds());
+  return db;
+}
+
+describe('migrateV73ToV74 — sessions.final_mine_ok', () => {
+  it('SCHEMA_VERSION includes this migration', () => {
+    expect(SCHEMA_VERSION).toBeGreaterThanOrEqual(74);
+  });
+
+  it('a fresh install already has the column', () => {
+    const db = new Database(':memory:');
+    createSchema(db);
+    expect(columnNames(db, 'sessions').has('final_mine_ok')).toBe(true);
+    db.close();
+  });
+
+  it('a v73 vault gains the column and reaches v74 on the next createSchema()', () => {
+    const db = seedV73Vault();
+    expect(columnNames(db, 'sessions').has('final_mine_ok')).toBe(false);
+
+    createSchema(db);
+
+    expect(columnNames(db, 'sessions').has('final_mine_ok')).toBe(true);
+    expect(stampedVersion(db)).toBeGreaterThanOrEqual(74);
+    db.close();
+  });
+
+  it('backfills already-completed sessions so existing trees stay pruneable', () => {
+    const db = seedV73Vault();
+    insertSession(db, 'done-1', 'completed');
+    insertSession(db, 'live-1', 'active');
+
+    createSchema(db);
+
+    const done = db.prepare('SELECT final_mine_ok FROM sessions WHERE id = ?').get('done-1') as { final_mine_ok: number | null };
+    const live = db.prepare('SELECT final_mine_ok FROM sessions WHERE id = ?').get('live-1') as { final_mine_ok: number | null };
+    expect(done.final_mine_ok).toBe(1);
+    // An in-flight session has no mining outcome yet — it must not be presumed mined.
+    expect(live.final_mine_ok).toBeNull();
+    db.close();
+  });
+
+  it('is idempotent — a second createSchema() does not error or re-backfill', () => {
+    const db = seedV73Vault();
+    insertSession(db, 'done-1', 'completed');
+    createSchema(db);
+
+    // A session that later completed WITHOUT a successful mine must stay 0 and
+    // not be re-backfilled to 1 by a subsequent boot.
+    db.prepare('UPDATE sessions SET final_mine_ok = 0 WHERE id = ?').run('done-1');
+
+    expect(() => createSchema(db)).not.toThrow();
+
+    const row = db.prepare('SELECT final_mine_ok FROM sessions WHERE id = ?').get('done-1') as { final_mine_ok: number | null };
+    expect(row.final_mine_ok).toBe(0);
+    db.close();
+  });
+});

--- a/tests/db/schema-version-too-new.test.ts
+++ b/tests/db/schema-version-too-new.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { initDatabase, closeDatabase } from '@myco/db/client.js';
+import { createSchema, SCHEMA_VERSION, SchemaVersionTooNewError } from '@myco/db/schema.js';
+import { epochSeconds } from '@myco/constants.js';
+import type { Database } from 'bun:sqlite';
+
+/** Stamp an additional, higher schema_version row (the table keeps history). */
+function stampVersion(db: Database, version: number): void {
+  db.prepare(
+    `INSERT INTO schema_version (version, applied_at)
+     VALUES (?, ?)
+     ON CONFLICT (version) DO NOTHING`,
+  ).run(version, epochSeconds());
+}
+
+function currentVersion(db: Database): number {
+  const row = db.prepare(
+    'SELECT version FROM schema_version ORDER BY version DESC LIMIT 1',
+  ).get() as { version: number } | undefined;
+  return row?.version ?? 0;
+}
+
+describe('createSchema — newer-than-supported vault', () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = initDatabase(':memory:');
+    createSchema(db);
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  it('refuses a database stamped above SCHEMA_VERSION', () => {
+    stampVersion(db, SCHEMA_VERSION + 1);
+
+    expect(() => createSchema(db)).toThrow(SchemaVersionTooNewError);
+  });
+
+  it('reports both versions and states the database was not modified', () => {
+    stampVersion(db, SCHEMA_VERSION + 5);
+
+    let caught: unknown;
+    try {
+      createSchema(db);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(SchemaVersionTooNewError);
+    const err = caught as SchemaVersionTooNewError;
+    expect(err.code).toBe('schema_version_too_new');
+    expect(err.foundVersion).toBe(SCHEMA_VERSION + 5);
+    expect(err.supportedVersion).toBe(SCHEMA_VERSION);
+    expect(err.message).toContain('has not been modified');
+  });
+
+  it('leaves the stamped version untouched when it refuses', () => {
+    stampVersion(db, SCHEMA_VERSION + 1);
+
+    expect(() => createSchema(db)).toThrow(SchemaVersionTooNewError);
+
+    expect(currentVersion(db)).toBe(SCHEMA_VERSION + 1);
+  });
+
+  it('still accepts a database at exactly SCHEMA_VERSION', () => {
+    expect(() => createSchema(db)).not.toThrow();
+    expect(currentVersion(db)).toBe(SCHEMA_VERSION);
+  });
+});

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -48,7 +48,12 @@ describe('Database schema', () => {
 
   describe('constants', () => {
     it('exports SCHEMA_VERSION as a positive integer', () => {
-      expect(SCHEMA_VERSION).toBe(73);
+      // Deliberately not pinned to an exact value: every migration bumps it,
+      // and a pinned assertion only ever measures whether someone remembered
+      // to edit this line. The migration chain's own coverage is what proves a
+      // version bump is correct.
+      expect(Number.isInteger(SCHEMA_VERSION)).toBe(true);
+      expect(SCHEMA_VERSION).toBeGreaterThan(0);
       expect(Number.isInteger(SCHEMA_VERSION)).toBe(true);
     });
 

--- a/tests/meta/test-suite-integrity.test.ts
+++ b/tests/meta/test-suite-integrity.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Meta gate: the test suite runs everything it contains, and nothing narrows it.
+ *
+ * `scripts/run-bun-tests.mjs` discovers tests by walking `tests/` and nothing
+ * else, so a `*.test.ts` authored anywhere under `packages/` or `scripts/` is
+ * silently never executed — it typechecks, it looks like coverage in review, and
+ * it never runs in CI. Two such files shipped with the Team Host residency work
+ * and sat dead until an audit found them.
+ *
+ * A focused `.only` has the same shape: one character reduces a whole file to a
+ * single test and the suite still reports green.
+ *
+ * Static source scan (node:fs), no daemon boot — same shape as
+ * `tests/meta/route-stamp-completeness.test.ts`.
+ */
+import { describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/** Generated, vendored, or build-output trees that never hold authored tests. */
+const SKIP_DIR_NAMES: ReadonlySet<string> = new Set([
+  'node_modules',
+  'target',
+  'dist',
+  'build',
+  '.git',
+  'coverage',
+  'vendor-src',
+]);
+
+/** Trees scanned for stranded test files. `tests/` is the discovered root. */
+const SCANNED_ROOTS = ['packages', 'scripts'] as const;
+
+const TEST_FILE_PATTERN = /\.test\.tsx?$/;
+
+/**
+ * `it.only` / `test.only` / `describe.only`, token-anchored so `monotonic.only`
+ * or a `.only` inside a string does not trip the gate.
+ */
+const ONLY_PATTERN = /(?:^|[^.\w])(?:it|test|describe)\.only\s*\(/;
+
+function listFiles(dir: string, match: (name: string) => boolean): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIR_NAMES.has(entry.name)) continue;
+      out.push(...listFiles(path.join(dir, entry.name), match));
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    if (!match(entry.name)) continue;
+    out.push(path.join(dir, entry.name));
+  }
+  return out;
+}
+
+function repoRelative(absolute: string): string {
+  return path.relative(REPO_ROOT, absolute);
+}
+
+describe('meta: test suite integrity', () => {
+  it('has no test files outside tests/, where the runner cannot discover them', () => {
+    const stranded = SCANNED_ROOTS.flatMap((root) =>
+      listFiles(path.join(REPO_ROOT, root), (name) => TEST_FILE_PATTERN.test(name)),
+    ).map(repoRelative).sort();
+
+    expect(stranded).toEqual([]);
+  });
+
+  it('has no focused tests narrowing a file to a subset', () => {
+    const focused = listFiles(
+      path.join(REPO_ROOT, 'tests'),
+      (name) => TEST_FILE_PATTERN.test(name),
+    )
+      .filter((file) => ONLY_PATTERN.test(fs.readFileSync(file, 'utf-8')))
+      .map(repoRelative)
+      .sort();
+
+    expect(focused).toEqual([]);
+  });
+});

--- a/tests/meta/version-skew-symmetry.test.ts
+++ b/tests/meta/version-skew-symmetry.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Meta gate: the vault schema check is symmetric — it refuses a database from
+ * the future as well as migrating one from the past.
+ *
+ * Every migration test walks forward. Before this gate, no test had ever opened
+ * a vault stamped at or above the binary's own `SCHEMA_VERSION`, and
+ * `createSchema` had no branch for it: the equality check failed, no migration
+ * matched, and the older binary's DDL was reapplied over a newer schema. Because
+ * the self-updater can roll back to a prior binary after a migration has already
+ * committed, that path is reachable without any user action.
+ *
+ * The first two assertions are behavioral rather than a source scan, so they stay
+ * meaningful as `SCHEMA_VERSION` moves. The third keeps the axis honest: a
+ * dedicated regression test must continue to exercise the newer-than-binary case.
+ */
+import { describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Database } from 'bun:sqlite';
+import { createSchema, SCHEMA_VERSION } from '@myco/db/schema.js';
+import { epochSeconds } from '@myco/constants.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function freshVaultAt(version: number): Database {
+  const db = new Database(':memory:');
+  createSchema(db);
+  db.prepare(
+    `INSERT INTO schema_version (version, applied_at)
+     VALUES (?, ?)
+     ON CONFLICT (version) DO NOTHING`,
+  ).run(version, epochSeconds());
+  return db;
+}
+
+function stampedVersion(db: Database): number {
+  const row = db.prepare(
+    'SELECT version FROM schema_version ORDER BY version DESC LIMIT 1',
+  ).get() as { version: number } | undefined;
+  return row?.version ?? 0;
+}
+
+function listTestFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      out.push(...listTestFiles(path.join(dir, entry.name)));
+      continue;
+    }
+    if (entry.isFile() && /\.test\.tsx?$/.test(entry.name)) out.push(path.join(dir, entry.name));
+  }
+  return out;
+}
+
+describe('meta: schema version skew is checked in both directions', () => {
+  it('refuses a vault stamped newer than this binary understands', () => {
+    const db = freshVaultAt(SCHEMA_VERSION + 1);
+    try {
+      expect(() => createSchema(db)).toThrow(/schema_version_too_new/);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('leaves the newer vault unmodified when it refuses', () => {
+    const db = freshVaultAt(SCHEMA_VERSION + 1);
+    try {
+      expect(() => createSchema(db)).toThrow();
+      expect(stampedVersion(db)).toBe(SCHEMA_VERSION + 1);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('keeps a dedicated regression test for the newer-than-binary case', () => {
+    // Any test that seeds a literal above the current SCHEMA_VERSION, or derives
+    // one from the constant, satisfies the axis. Matching both forms keeps the
+    // gate from forcing a literal that would go stale on the next bump.
+    const derived = /SCHEMA_VERSION\s*\+\s*\d+/;
+    const covering = listTestFiles(path.join(REPO_ROOT, 'tests'))
+      .filter((file) => path.basename(file) !== 'version-skew-symmetry.test.ts')
+      .filter((file) => derived.test(fs.readFileSync(file, 'utf-8')));
+
+    expect(covering.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Three data-loss paths found by an independent review of `myco/v1.2.13..HEAD`, plus the gates that let them ship green. Findings and rationale live in Myco plans `906b64107d969e6c` (review) and `87006e6eb8b89aa8` (foundational patterns).

## Why this exists

A green suite of 10,408 tests coexisted with silent vault corruption on rollback and a background job deleting the only copy of users' transcripts. None of these are exotic — they are all a coerced error or a missing proof authorizing an irreversible action.

## What changed

**A vault from the future is refused, not corrupted.** `myco/v1.2.13` ships `SCHEMA_VERSION = 66`; `main` ships 74. `createSchema` had no branch for a database stamped above the binary: the equality check missed, no migration matched, and the older DDL was reapplied over a schema whose column types had moved. Since the self-updater rolls back to the prior binary on any health-watch miss — including causes unrelated to migration — this is reachable with no user action, and v73 made `prompt_batches.id` a nullable TEXT primary key, so the older writer inserts NULL ids and orphans every dependent row. It now throws `SchemaVersionTooNewError` and leaves the database untouched.

**The transcript GC now requires proof of mining.** It deleted the host's only copy of a routed session's transcript, gated on `status = 'completed'` and the assumption that completing implies fully mined. The completion chokepoint breaks that by design — it closes even when mining throws, because a session must never be stranded active — and `parseAllEvents` returned `[]` on a `statSync` failure, so an unreadable transcript looked exactly like a mined-empty one. Schema v74 adds `sessions.final_mine_ok`; the session still closes, and the GC prunes only on `1`. NULL is unproven and keeps the bytes. Existing completed rows are backfilled so the upgrade strands nothing.

The column is deliberately local-only: it describes *this* machine's mining outcome, and for a routed session the transcript lives on the host — one machine's result must never authorize another machine's delete.

**An unreadable file is no longer treated as a deleted one.** `utils/presence.ts` adds the three-state read (`present` / `absent` / `unknown`) that `grove/registry.ts` already performed inline. The plan drain turned any `readFileSync` failure into "file gone" and permanently dequeued a plan whose content had never reached the host — while the file sat on disk, so nothing would ever notice. It now keeps the entry, records an `unreadable` failure, and retries; `pendingCount` and `health` both count an undetermined read as pending, so a failing entry can no longer read as healthy in the surface built to catch it.

`JobRunner.providesHold` holds awake when a hold probe throws. These probes count unshipped capture; sleeping stops the drains, after which the source file can rotate away. Staying awake on a broken probe costs power; sleeping on one costs data.

## The ratchets

Small `tests/meta/` gates in the idiom this repo already uses five times. **Each was verified by injecting its violation and confirming CI goes red**, then confirming green on restore.

- **Version-skew symmetry** — behavioral rather than a source scan, so it stays meaningful as `SCHEMA_VERSION` moves. Removing the guard turns it red.
- **Test-file location** — `scripts/run-bun-tests.mjs` discovers only under `tests/`, so a test authored anywhere else typechecks, looks like coverage in review, and never runs. Two such files shipped with the residency work; their **9 tests and 37 assertions had never executed**. Moved into `tests/`, now passing. The `mcp-tool-development-lifecycle` skill was teaching that undiscoverable path and now points at `tests/`.
- **`.only`** — zero occurrences today, so it lands as a pure ratchet.

## Two things worth flagging from doing the work

The stale-sweep GC test passed throughout this change because its fake miner returned `{}`. The test that exists precisely to pin this failure mode could not see the regression, because it never touches the real implementation. **Eight other exported real implementations are referenced by no test at all**, including both halves of the residency network transport. A reachability gate for those is worth building.

My first migration test silently passed a no-op. A fresh install stamps only `SCHEMA_VERSION`, so seeding a "vault at v73" by deleting everything above 73 leaves the table empty, `getCurrentVersion` reads 0, and the chain replays from the v34 rescue floor — which creates tables from the *live* DDL, so the column already exists by the time its own migration runs and the backfill quietly does nothing. The reason is written into the test.

I also unpinned `tests/db/schema.test.ts`'s exact-value `SCHEMA_VERSION` assertion, which sat under the name "exports SCHEMA_VERSION as a positive integer" and only measured whether someone remembered to edit that line.

## Verification

- `npm test` — **10,436 pass / 0 fail / 15 skip** (baseline 10,408; +18 = 9 revived, 9 new)
- Root, UI, and worker typechecks clean
- `tests/db/migration-matrix.test.ts` and `tests/db/synced-table-parity.test.ts` green
- Each new gate individually proven to fail on its violation

## Not in scope

This does not clear the release. The review found further P1s in residency migration, overlay authorization, and Team Host coexistence with an existing Tailscale install, and the live smoke has not run. Plan `87006e6eb8b89aa8` carries the sequence; the next step is a `staged_rows` counter in the residency journal, without which the staging clear cannot be verified at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
