### PR TITLE
fix(team-host): stop the detach clearing staging it never read

### DIFF
--- a/packages/myco/src/host/residency-drain.ts
+++ b/packages/myco/src/host/residency-drain.ts
@@ -49,6 +49,7 @@ import { createFsPlanDrainStore } from '../capture/plan-drain.js';
 import { createFsReplayStore } from '../capture/event-replay-drain.js';
 import type { DrainHealthCounters } from '../capture/drain-health.js';
 import { defaultDial, parseOverlayAddress } from '../daemon/host-proxy.js';
+import { readDirPresence } from '@myco/utils/presence.js';
 import { shouldLogOncePerInterval } from '../daemon/log-throttle.js';
 import { REQUEST_CONTEXT_HEADERS } from '../grove/request-context.js';
 import type { GroveProjectId } from '../grove/ids.js';
@@ -408,6 +409,9 @@ async function runDetachTransition(
         return;
       }
       let cursor: string | null = typeof journal.cursors.pull === 'string' && journal.cursors.pull ? journal.cursors.pull : null;
+      // Resumes from the durable count so a re-entered pull keeps accumulating
+      // rather than restarting the tally at zero.
+      let stagedRows = journal.staged_rows ?? 0;
       for (;;) {
         let page: ResidencyPullResponse;
         try { page = await pullTransport(target, { cursor }, deps.machineId); }
@@ -424,13 +428,17 @@ async function runDetachTransition(
         if (!stillPulling || stillPulling.phase !== 'pulling') return;
         // Append THEN advance the cursor — at-least-once; a resumed re-pull of the
         // same page re-appends, which the idempotent apply engine flattens.
-        appendResidencyStagingRows(journal.project_id, page.rows, teamsHome);
+        const appended = appendResidencyStagingRows(journal.project_id, page.rows, teamsHome);
+        // Count only what actually landed. The increment follows the append, so a
+        // crash mid-write leaves a torn line the file carries and this does not —
+        // which is why the apply's check is "at least", not equality.
+        stagedRows += appended;
         if (page.done) {
-          advanceResidencyPhase(journal.project_id, 'pulling', { cursors: { pull: CURSOR_DONE } }, teamsHome);
+          advanceResidencyPhase(journal.project_id, 'pulling', { cursors: { pull: CURSOR_DONE }, staged_rows: stagedRows }, teamsHome);
           break;
         }
         cursor = page.next_cursor;
-        advanceResidencyPhase(journal.project_id, 'pulling', { cursors: { pull: cursor ?? '' } }, teamsHome);
+        advanceResidencyPhase(journal.project_id, 'pulling', { cursors: { pull: cursor ?? '' }, staged_rows: stagedRows }, teamsHome);
         await yieldToLoop();
       }
     }
@@ -470,17 +478,54 @@ async function runDetachTransition(
     // NOT the arbitrary readdirSync order the staging enumerator returns — a child
     // before its parent throws in the immediate-FK transaction and would wedge the
     // retry.
-    const staged = new Set(listResidencyStagingTables(journal.project_id, teamsHome));
+    const listed = listResidencyStagingTables(journal.project_id, teamsHome);
+    if (listed.state === 'unknown') {
+      // The staging directory could not be enumerated. Applying what that
+      // returns and then deleting the tree would destroy the entire pulled
+      // dataset un-applied, so stop and retry on a later tick.
+      recordJournalFailure(journal, listed.error, deps, teamsHome);
+      return;
+    }
+    const staged = new Set(listed.state === 'present' ? listed.value : []);
     const ordered = RESIDENCY_TABLE_ORDER.filter((table) => staged.has(table));
     // An unexpected staged table (outside the allow-listed residency set) applies
     // last; the engine rejects an unknown table, surfacing the drift loudly rather
     // than dropping data silently.
     const extras = [...staged].filter((table) => !RESIDENCY_TABLE_ORDER.includes(table));
+
+    // Read every table BEFORE opening the write transaction: a read that fails
+    // partway through would otherwise apply a prefix of the tables and advance,
+    // and the unread remainder would be deleted with the tree.
+    const pages: Array<{ table: string; rows: Record<string, unknown>[] }> = [];
+    let stagedLinesSeen = 0;
+    for (const table of [...ordered, ...extras]) {
+      const page = readResidencyStagingRows(journal.project_id, table, teamsHome);
+      if (page.state === 'unknown') {
+        recordJournalFailure(journal, page.error, deps, teamsHome);
+        return;
+      }
+      if (page.state === 'absent') continue;
+      stagedLinesSeen += page.value.lines;
+      pages.push({ table, rows: page.value.rows });
+    }
+
+    // The staging files must still hold at least every line the pull recorded
+    // writing. Fewer means the tree was truncated or partly unreadable, and the
+    // apply would silently drop the difference before the tree is deleted.
+    const expected = journal.staged_rows ?? 0;
+    if (stagedLinesSeen < expected) {
+      recordJournalFailure(
+        journal,
+        new Error(`residency staging holds ${stagedLinesSeen} line(s) but the pull recorded ${expected}`),
+        deps,
+        teamsHome,
+      );
+      return;
+    }
+
     deps.withGroveDb(targetGroveId, (db) => {
       db.transaction(() => {
-        for (const table of [...ordered, ...extras]) {
-          applyRows(db, table, readResidencyStagingRows(journal.project_id, table, teamsHome));
-        }
+        for (const page of pages) applyRows(db, page.table, page.rows);
       })();
     });
     // Advance to the terminal sweep. The journal PERSISTS through `rehoming` so a
@@ -499,10 +544,18 @@ async function runDetachTransition(
     // complete — that is what makes the sweep itself crash-resumable (clearing it
     // earlier would orphan any residual buffered events with no journal to drive
     // the resume).
-    rehomeBufferedEvents(
+    const rehomed = rehomeBufferedEvents(
       resolveProjectBufferDir(journal.divert_grove_id, journal.project_id, deps.mycoHome),
       resolveProjectBufferDir(targetGroveId, journal.project_id, deps.mycoHome),
     );
+    if (!rehomed.complete) {
+      // Clearing now would strand these events in a host-Grove buffer directory
+      // that no enumerator visits once the attach ref is gone — silent capture
+      // loss under a "transition complete" log. The journal IS the retry path,
+      // so it has to outlive the failure.
+      recordJournalFailure(journal, rehomed.error, deps, teamsHome);
+      return;
+    }
     try {
       createFsDrainStore().purgeProject(journal.host_id, journal.project_id);
       createFsPlanDrainStore().purgeProject(journal.host_id, journal.project_id);
@@ -523,10 +576,12 @@ async function runDetachTransition(
  *  Grove during the window into the local Grove's buffer dir — a byte-level move
  *  (no re-parse), merging by append on a same-session collision so the local
  *  reconciler dedups by event id. */
-function rehomeBufferedEvents(fromDir: string, toDir: string): void {
-  let files: string[];
-  try { files = fs.readdirSync(fromDir); } catch { return; } // nothing buffered
-  for (const file of files) {
+function rehomeBufferedEvents(fromDir: string, toDir: string): { complete: true } | { complete: false; error: Error } {
+  const listed = readDirPresence(fromDir);
+  if (listed.state === 'absent') return { complete: true }; // nothing buffered
+  if (listed.state === 'unknown') return { complete: false, error: listed.error };
+  for (const entry of listed.value) {
+    const file = entry.name;
     if (!file.endsWith('.jsonl')) continue; // durable capture only; skip .lock / quarantine
     const src = path.join(fromDir, file);
     const dest = path.join(toDir, file);
@@ -538,8 +593,15 @@ function rehomeBufferedEvents(fromDir: string, toDir: string): void {
       } else {
         fs.renameSync(src, dest);
       }
-    } catch { /* skip a file that vanished mid-move; a retry re-home catches the rest */ }
+    } catch (err) {
+      // A file that vanished mid-move is genuinely done; anything else means
+      // these bytes are still in a directory nothing will enumerate again once
+      // the journal is cleared, so the sweep is not complete.
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      return { complete: false, error: err as Error };
+    }
   }
+  return { complete: true };
 }
 
 /** Ship a `pushing` journal's outbox rows and sidecars; on full ack, purge and

--- a/packages/myco/src/host/residency-journal.ts
+++ b/packages/myco/src/host/residency-journal.ts
@@ -18,6 +18,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { isGroveEraId } from '../grove/ids.js';
+import { ABSENT, present, readDirPresence, readFilePresence, type Presence } from '@myco/utils/presence.js';
 import { resolveTeamsHome } from '../grove/paths.js';
 
 /** Directory under the machine-global team home that holds residency journals. */
@@ -109,6 +110,19 @@ export interface ResidencyJournal {
    *  when the transition makes forward progress again. */
   last_error?: string;
   last_error_at?: string;
+  /**
+   * Lines written to the staging files so far, counted after each successful
+   * append. The apply reads the staging back and refuses to proceed unless it
+   * sees at least this many lines — without it, a staging directory that could
+   * not be read enumerates as empty, applies zero rows, and is then deleted,
+   * destroying the whole pulled dataset with no error anywhere.
+   *
+   * At-least-once re-appends inflate this and the files together, so the two
+   * stay comparable. A torn trailing line from a crash mid-append is counted in
+   * the file but not here (the increment follows the append), which is why the
+   * check is "at least", not equality.
+   */
+  staged_rows?: number;
 }
 
 /** Fields a caller supplies to open a journal; timestamps are stamped here. */
@@ -259,8 +273,8 @@ export function appendResidencyStagingRows(
   projectId: string,
   rows: ReadonlyArray<{ table: string; row: Record<string, unknown> }>,
   teamsHome: string = resolveTeamsHome(),
-): void {
-  if (!isGroveEraId(projectId, 'project') || rows.length === 0) return;
+): number {
+  if (!isGroveEraId(projectId, 'project') || rows.length === 0) return 0;
   const dir = residencyStagingDir(projectId, teamsHome);
   fs.mkdirSync(dir, { recursive: true });
   const byTable = new Map<string, string[]>();
@@ -270,42 +284,64 @@ export function appendResidencyStagingRows(
     lines.push(JSON.stringify(row));
     byTable.set(table, lines);
   }
+  let written = 0;
   for (const [table, lines] of byTable) {
     fs.appendFileSync(path.join(dir, `${table}.ndjson`), `${lines.join('\n')}\n`, 'utf-8');
+    written += lines.length;
   }
+  return written;
 }
 
-/** Every table with a staged page file (apply order is the caller's concern). */
-export function listResidencyStagingTables(projectId: string, teamsHome: string = resolveTeamsHome()): string[] {
-  try {
-    return fs.readdirSync(residencyStagingDir(projectId, teamsHome))
-      .filter((f) => f.endsWith('.ndjson'))
-      .map((f) => f.slice(0, -'.ndjson'.length));
-  } catch {
-    return [];
-  }
+/**
+ * Every table with a staged page file (apply order is the caller's concern).
+ *
+ * Three-state: an absent directory genuinely means nothing was staged, but an
+ * unreadable one must never enumerate as empty — the caller applies what this
+ * returns and then deletes the directory.
+ */
+export function listResidencyStagingTables(
+  projectId: string,
+  teamsHome: string = resolveTeamsHome(),
+): Presence<string[]> {
+  const dir = readDirPresence(residencyStagingDir(projectId, teamsHome));
+  if (dir.state !== 'present') return dir as Presence<string[]>;
+  return present(
+    dir.value
+      .filter((e) => e.isFile() && e.name.endsWith('.ndjson'))
+      .map((e) => e.name.slice(0, -'.ndjson'.length)),
+  );
 }
 
-/** Read one table's staged rows (skips a torn trailing line rather than throw). */
+/**
+ * Read one table's staged rows.
+ *
+ * `lines` counts every non-empty line the file held, parseable or not, so the
+ * caller can compare against the journal's `staged_rows` and detect a file that
+ * was silently truncated. A torn trailing line from a crash mid-append is
+ * skipped for the rows but still counted here.
+ *
+ * Three-state for the same reason as the enumerator: the rows this returns are
+ * applied and the file is then deleted, so an unreadable file must not read as
+ * an empty one.
+ */
 export function readResidencyStagingRows(
   projectId: string,
   table: string,
   teamsHome: string = resolveTeamsHome(),
-): Record<string, unknown>[] {
-  if (!SAFE_STAGING_TABLE.test(table)) return [];
-  let content: string;
-  try {
-    content = fs.readFileSync(path.join(residencyStagingDir(projectId, teamsHome), `${table}.ndjson`), 'utf-8');
-  } catch {
-    return [];
-  }
+): Presence<{ rows: Record<string, unknown>[]; lines: number }> {
+  if (!SAFE_STAGING_TABLE.test(table)) return ABSENT;
+  const read = readFilePresence(path.join(residencyStagingDir(projectId, teamsHome), `${table}.ndjson`));
+  if (read.state !== 'present') return read as Presence<{ rows: Record<string, unknown>[]; lines: number }>;
+  const content = read.value;
+  let lines = 0;
   const out: Record<string, unknown>[] = [];
   for (const line of content.split('\n')) {
     const trimmed = line.trim();
     if (!trimmed) continue;
+    lines += 1;
     try { out.push(JSON.parse(trimmed) as Record<string, unknown>); } catch { /* skip a torn line */ }
   }
-  return out;
+  return present({ rows: out, lines });
 }
 
 /** Remove a project's staging tree (final detach cleanup). Idempotent. */

--- a/tests/host/residency-detach.test.ts
+++ b/tests/host/residency-detach.test.ts
@@ -271,8 +271,100 @@ describe('detach drain — round trip', () => {
 
     // Journal + staging cleared.
     expect(readResidencyJournal(projectId)).toBeNull();
-    expect(listResidencyStagingTables(projectId)).toEqual([]);
+    expect(listResidencyStagingTables(projectId).state).toBe('absent');
     expect(countResidencyInFlight()).toBe(0);
+  });
+
+  test('an unreadable staging tree stops the apply — nothing is applied, nothing is cleared', async () => {
+    // The destruction path: on a read failure the staging dir enumerates as
+    // empty, the apply consumes zero rows, and the tree is deleted — taking the
+    // entire pulled dataset with it, under a "transition complete" log.
+    const local = createGrove('Local', home);
+    const host = makeHost(3);
+    writeHostRecordFixture(host);
+    const projectId = createProjectId();
+    const root = makeCheckout(projectId);
+    attachRef(host, projectId, root, local.id);
+
+    detachCommand({ projectPath: root, beginDetachResidency: injectedBeginDetach });
+
+    // Stage one page, then stall so the journal stays pre-apply.
+    let call = 0;
+    const stallingPull = async () => {
+      call += 1;
+      if (call === 1) {
+        return { status: 200, rows: [{ table: 'spores', row: { id: 'sp_a', project_id: projectId } }], next_cursor: 'c1', done: false };
+      }
+      return { status: 503, rows: [], next_cursor: null, done: false };
+    };
+    await runResidencyTransitions({ ...baseDeps(), pullTransport: stallingPull as never, resolveHostTarget: targetResolver(), applyStagedRows: () => {} });
+
+    const stagingDir = path.join(teamHome, 'residency', `${projectId}-staging`);
+    expect(fs.existsSync(stagingDir)).toBe(true);
+    fs.chmodSync(stagingDir, 0o000); // deny enumeration
+
+    try {
+      const finishingPull = async () => ({ status: 200, rows: [], next_cursor: null, done: true });
+      const applied: string[] = [];
+      await runResidencyTransitions({
+        ...baseDeps(),
+        pullTransport: finishingPull as never,
+        resolveHostTarget: targetResolver(),
+        applyStagedRows: (_db, table) => { applied.push(table); },
+      });
+
+      expect(applied).toEqual([]); // nothing applied off an unreadable tree
+      expect(readResidencyJournal(projectId)).not.toBeNull(); // the retry path survives
+      expect(fs.existsSync(stagingDir)).toBe(true); // and so does the data
+    } finally {
+      fs.chmodSync(stagingDir, 0o700); // restore so the fixture can clean up
+    }
+  });
+
+  test('a staging tree holding fewer lines than the pull recorded refuses to apply', async () => {
+    const local = createGrove('Local', home);
+    const host = makeHost(3);
+    writeHostRecordFixture(host);
+    const projectId = createProjectId();
+    const root = makeCheckout(projectId);
+    attachRef(host, projectId, root, local.id);
+
+    detachCommand({ projectPath: root, beginDetachResidency: injectedBeginDetach });
+
+    // Pull one page, then stop before the apply by refusing the second page.
+    let call = 0;
+    const stallingPull = async () => {
+      call += 1;
+      if (call === 1) {
+        return { status: 200, rows: [{ table: 'spores', row: { id: 'sp_a', project_id: projectId } }], next_cursor: 'c1', done: false };
+      }
+      return { status: 503, rows: [], next_cursor: null, done: false };
+    };
+    await runResidencyTransitions({ ...baseDeps(), pullTransport: stallingPull as never, resolveHostTarget: targetResolver(), applyStagedRows: () => {} });
+
+    const journal = readResidencyJournal(projectId);
+    expect(journal?.phase).toBe('pulling');
+    expect(journal?.staged_rows).toBe(1); // the durable count the apply will check
+
+    // Truncate the staged file behind the drain's back, then let the pull finish.
+    const stagingDir = path.join(teamHome, 'residency', `${projectId}-staging`);
+    fs.writeFileSync(path.join(stagingDir, 'spores.ndjson'), '', 'utf-8');
+
+    const finishingPull = async () => ({ status: 200, rows: [], next_cursor: null, done: true });
+    const applied: string[] = [];
+    await runResidencyTransitions({
+      ...baseDeps(),
+      pullTransport: finishingPull as never,
+      resolveHostTarget: targetResolver(),
+      applyStagedRows: (_db, table) => { applied.push(table); },
+    });
+
+    // Nothing applied, nothing cleared — the journal survives as the retry path.
+    expect(applied).toEqual([]);
+    const after = readResidencyJournal(projectId);
+    expect(after).not.toBeNull();
+    expect(after?.last_error).toContain('staging holds');
+    expect(resolveAttach(projectId)).toBeNull(); // the flip had already run
   });
 
   test('an abort mid-pull stops before the flip: the project stays attached, no local row, staging cleared', async () => {
@@ -297,7 +389,7 @@ describe('detach drain — round trip', () => {
     expect(resolveAttach(projectId)).not.toBeNull(); // still attached — the flip bailed
     expect(findRegisteredProjectById(projectId, home)).toBeNull(); // no local Grove row re-materialized
     expect(readResidencyJournal(projectId)).toBeNull(); // aborted
-    expect(listResidencyStagingTables(projectId)).toEqual([]); // guard stopped re-staging after abort cleared it
+    expect(listResidencyStagingTables(projectId).state).toBe('absent'); // guard stopped re-staging after abort cleared it
   });
 
   test('a failed pull does not advance: the journal stays pulling and the ref survives', async () => {

--- a/tests/host/residency-status-abort.test.ts
+++ b/tests/host/residency-status-abort.test.ts
@@ -169,7 +169,7 @@ describe('abortResidency — the abort matrix', () => {
     expect(abortResidency(projectId, baseDeps())).toEqual({ ok: true });
 
     expect(readResidencyJournal(projectId)).toBeNull();
-    expect(listResidencyStagingTables(projectId)).toEqual([]);
+    expect(listResidencyStagingTables(projectId).state).toBe('absent');
     expect(resolveAttach(projectId)).not.toBeNull(); // still attached — nothing flipped
   });
 


### PR DESCRIPTION
Continues the foundational-pattern work from #724. Findings and sequence live in Myco plans `906b64107d969e6c` and `87006e6eb8b89aa8`.

## The bug

The detach apply enumerated the staging tree with a `readdir` that returned `[]` on any failure, applied whatever that produced, then deleted the tree. An unreadable staging directory therefore applied **zero rows and destroyed the entire pulled dataset** — every session, spore, and plan the pull had fetched — with no error, under a `residency detach transition complete` log.

The re-home sweep had the same shape: filesystem errors were swallowed with a comment promising *"a retry re-home catches the rest"*, and the journal that **is** the retry path was cleared four lines later.

## The fix

Both staging readers are now three-state (`utils/presence.ts`, introduced in #724). An absent tree still means nothing was staged; an unreadable one aborts the pass and leaves the journal for a later tick.

Absence of a read failure isn't sufficient on its own, because a truncated file reads cleanly. The journal now carries `staged_rows`, counted after each successful append, and the apply refuses unless the files still hold at least that many lines. At-least-once re-appends inflate the counter and the files together so they stay comparable; a torn trailing line from a crash mid-append is in the file but not the counter, which is why the check is *at least* rather than equality.

`rehomeBufferedEvents` reports completion instead of returning `void`. `ENOENT` on a file that vanished mid-move is still fine; anything else means those bytes sit in a host-Grove directory nothing enumerates once the journal is gone, so the sweep is incomplete and the journal survives.

The apply also reads every table **before** opening the write transaction. Reading inside it would apply a prefix and advance if a later read failed, and the unread remainder would be deleted with the tree.

## Verification

Two regression tests, each **verified to fail with the gates neutralised** and pass with them:
- a `chmod 000` staging tree — nothing applied, journal and data both survive
- a file truncated behind the drain's back — nothing applied, `last_error` records the shortfall

Suite **10438 pass / 0 fail**; root, UI, and worker typechecks clean.

## Scope

This does not clear the release. Residency still has no writer quiescence, the journal phase can still regress after the irreversible flip, `leave` is still ungated on in-flight transitions, and the overlay Grove enumeration and Tailscale coexistence hazards are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
