### PR TITLE
fix(team-host): scope overlay Grove reads to the requesting member, and stop promising Windows membership

### DIFF
--- a/docs/team-host.md
+++ b/docs/team-host.md
@@ -12,6 +12,12 @@ Team Host turns one teammate's Myco install into your team's shared home. Join i
 - A read-only endpoint lets tools that aren't Myco members — hosted agents, automations — query team storage too.
 - Team storage is the sole copy for anything routed through it, so a serve install backs it up automatically.
 
+## Before you start
+
+Team Host runs on **macOS and Linux**, for hosts and members alike. Windows can't take part yet — not as a host and not as a member — because the overlay client Myco provisions has no Windows build. Everything else in Myco works normally on Windows; it's team membership specifically that's unavailable.
+
+On **macOS**, Myco needs [Homebrew](https://brew.sh) to install the overlay client, on hosts and members both. The open-source overlay client ships through Homebrew on macOS and nowhere else, so `myco join` and `myco install --serve` will stop and tell you if it's missing. On Linux there's no such requirement — Myco downloads and verifies the client itself.
+
 ## Join a team
 
 Open the dashboard (`myco open`) and go to the **Team** page. Under **Join a Team Host**, enter the host id, one-time key, server URL, and overlay address a host operator shared with you, then submit. Myco enrolls this machine, and the join form confirms whether the host is reachable yet.
@@ -87,7 +93,7 @@ The simplest path is at install time:
 curl -fsSL https://myco.sh/install.sh | sh -s -- --serve --server-url https://your-host:8080
 ```
 
-`--serve` requires `--server-url` — the address teammates will dial to reach this host. It designates this machine's default project storage as what it serves for the team, and prints a ready-to-paste `myco join …` command for your first teammate. This installer flag is available on macOS and Linux; Windows hosts aren't supported yet.
+`--serve` requires `--server-url` — the address teammates will dial to reach this host. It designates this machine's default project storage as what it serves for the team, and prints a ready-to-paste `myco join …` command for your first teammate. This installer flag is available on macOS and Linux (see [Before you start](#before-you-start)).
 
 Already installed? `myco host enable --server-url <url>` does the same enrollment on an existing install. It provisions and starts the overlay networking services this machine needs to serve a team, and requires root — expect a sudo prompt. From there:
 

--- a/packages/myco/src/daemon/api/groves.ts
+++ b/packages/myco/src/daemon/api/groves.ts
@@ -32,7 +32,7 @@ import {
 } from '@myco/grove/project-lifecycle.js';
 import { projectUrlSlug } from '@myco/grove/ids.js';
 import { ProjectGroveMissingError, resolveProjectTenancy } from '@myco/grove/project-tenancy.js';
-import type { RouteHandler } from '@myco/daemon/router.js';
+import type { RouteHandler, RouteRequest } from '@myco/daemon/router.js';
 import {
   nativePerUserLockNamespace,
   type PerUserLockNamespace,
@@ -151,6 +151,37 @@ export function servedGroveScopeForDaemon(): ServedGroveScope {
   return { groveIds: null };
 }
 
+/**
+ * Narrow a daemon-wide scope to what THIS request is allowed to see.
+ *
+ * The operator at their own dashboard sees every Grove on the machine — that is
+ * the whole point of the local view. A member reaching the same route across the
+ * overlay must see only the Grove its request resolved to, which the served-Grove
+ * refusal has already pinned to the one Grove this host serves.
+ *
+ * The gate above these handlers stamps ROUTES; it cannot constrain what a
+ * handler reads. Without this narrowing, a route that enumerates independently
+ * of `requestContext` hands a remote member every Grove on the machine and every
+ * project's absolute checkout path — including projects never shared with anyone.
+ */
+export function scopeForRequest(daemonScope: ServedGroveScope, req: RouteRequest): ServedGroveScope {
+  if (!req.isOverlay) return daemonScope;
+  const groveId = req.requestContext?.groveId;
+  // An overlay request with no resolved Grove gets nothing rather than everything.
+  return { groveIds: groveId ? [groveId] : [] };
+}
+
+/**
+ * The same narrowing for the cross-Grove fan-outs, as a `forEachGrove`
+ * `shouldVisitGrove` predicate. Returns undefined for a local request so the
+ * operator's own machine-wide views are unchanged.
+ */
+export function overlayGroveFilter(req: RouteRequest): ((grove: { id: string }) => boolean) | undefined {
+  if (!req.isOverlay) return undefined;
+  const groveId = req.requestContext?.groveId;
+  return (grove) => Boolean(groveId) && grove.id === groveId;
+}
+
 /** Structural logger seam — mirrors `session-completion.ts`'s
  *  `SessionCompletionDeps.logger`: a narrow shape so tests can pass a plain
  *  recording fake without constructing a real `DaemonLogger`. */
@@ -163,7 +194,7 @@ export function createListGrovesHandler(
   lockNamespace: PerUserLockNamespace = nativePerUserLockNamespace,
 ): RouteHandler {
   return async (req) => ({
-    body: listGroveSummaries(scope, {
+    body: listGroveSummaries(scopeForRequest(scope, req), {
       includeArchived: req.query.include_archived === 'true',
     }, logger, lockNamespace),
   });
@@ -177,7 +208,7 @@ export function createListGroveProjectsHandler(
 ): RouteHandler {
   return async (req) => {
     const groveId = req.params.id;
-    const summaries = listGroveSummaries(scope, {}, logger, lockNamespace);
+    const summaries = listGroveSummaries(scopeForRequest(scope, req), {}, logger, lockNamespace);
     const grove = summaries.groves.find((row) => row.id === groveId || row.slug === groveId);
     if (!grove) return { status: 404, body: { error: 'grove_not_found' } };
     const includes = parseTenancyInclude(req.query.include);

--- a/packages/myco/src/daemon/api/host-membership.ts
+++ b/packages/myco/src/daemon/api/host-membership.ts
@@ -395,7 +395,13 @@ export function createHostMembershipStatusHandler(deps: HostMembershipRouteDeps 
       }
     }
 
-    return { status: 200, body: { hosts, hint } };
+    // Whether this machine can take part in a team at all. A capability, not a
+    // platform string: the UI needs to know joining will work, and Windows has
+    // no overlay client build, so the Join form must say so up front rather
+    // than fail after the operator has already minted a one-time key.
+    const overlaySupported = process.platform === 'darwin' || process.platform === 'linux';
+
+    return { status: 200, body: { hosts, hint, overlay_supported: overlaySupported } };
   };
 }
 

--- a/packages/myco/src/daemon/api/maintenance.ts
+++ b/packages/myco/src/daemon/api/maintenance.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import type { Database } from 'bun:sqlite';
 import type { RouteRequest, RouteResponse } from '../router.js';
+import { overlayGroveFilter } from './groves.js';
 import type { Logger } from '../logger.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 import { loadMergedConfig } from '@myco/config/loader.js';
@@ -349,7 +350,7 @@ function computeFlags(
 export function createMaintenanceHandlers(deps: MaintenanceHandlersDeps) {
   const mycoHome = deps.mycoHome ?? resolveMycoHome();
 
-  async function handleSummary(_req: RouteRequest): Promise<RouteResponse> {
+  async function handleSummary(req: RouteRequest): Promise<RouteResponse> {
     const groves: GroveMaintenanceSummary[] = [];
     await forEachGrove(
       deps.cache,
@@ -374,6 +375,9 @@ export function createMaintenanceHandlers(deps: MaintenanceHandlersDeps) {
         jobName: 'maintenance-summary',
         parallel: true,
         lockNamespace: deps.lockNamespace,
+        // A member across the overlay sees only the Grove its request resolved
+        // to; the operator on localhost still sees the whole machine.
+        shouldVisitGrove: overlayGroveFilter(req),
       },
     );
 

--- a/packages/myco/src/daemon/api/projects-activity.ts
+++ b/packages/myco/src/daemon/api/projects-activity.ts
@@ -1,4 +1,5 @@
 import type { RouteRequest, RouteResponse } from '../router.js';
+import { overlayGroveFilter } from './groves.js';
 import type { Logger } from '../logger.js';
 import type { MycoConfig } from '@myco/config/schema.js';
 import type { GroveRuntimeCache } from '../grove-runtime-cache.js';
@@ -87,7 +88,7 @@ function buildProjectRow(
 export function createProjectsActivityHandler(deps: ProjectsActivityHandlersDeps) {
   const mycoHome = deps.mycoHome ?? resolveMycoHome();
 
-  return async function handleProjectsActivity(_req: RouteRequest): Promise<RouteResponse> {
+  return async function handleProjectsActivity(req: RouteRequest): Promise<RouteResponse> {
     const config = deps.liveConfig.current;
     const activeWindowDays = config.agent.cold_project_threshold_days ?? 14;
     const activeWindowSeconds = activeWindowDays * SECONDS_PER_DAY;
@@ -152,6 +153,9 @@ export function createProjectsActivityHandler(deps: ProjectsActivityHandlersDeps
         jobName: 'projects-activity',
         parallel: true,
         lockNamespace: deps.lockNamespace,
+        // A member across the overlay sees only the Grove its request resolved
+        // to; the operator on localhost still sees the whole machine.
+        shouldVisitGrove: overlayGroveFilter(req),
       },
     );
 

--- a/packages/myco/src/daemon/router.ts
+++ b/packages/myco/src/daemon/router.ts
@@ -8,6 +8,16 @@ export interface RouteRequest {
   pathname: string;
   headers?: IncomingHttpHeaders;
   requestContext?: MycoRequestContext;
+  /**
+   * True when the request arrived on the overlay listener rather than
+   * localhost — a remote member, not the operator at their own dashboard.
+   *
+   * Route stamps classify what a route IS; they cannot constrain what a handler
+   * READS. A handler that enumerates or selects data independently of
+   * `requestContext` needs this to narrow itself, because the stamp gate above
+   * it has already let the request through.
+   */
+  isOverlay?: boolean;
 }
 
 export interface RouteResponse {

--- a/packages/myco/src/daemon/server.ts
+++ b/packages/myco/src/daemon/server.ts
@@ -880,6 +880,7 @@ export class DaemonServer {
           pathname: match.pathname,
           headers: req.headers,
           requestContext,
+          isOverlay: isOverlayRequest(req),
         });
         const requestDb = this.databaseForRequestContext(requestContext);
         const result = requestDb

--- a/packages/myco/src/host/overlay-binaries.ts
+++ b/packages/myco/src/host/overlay-binaries.ts
@@ -85,8 +85,10 @@ export function resolveOverlayTarget(
 ): OverlayTarget {
   if (platform !== 'darwin' && platform !== 'linux') {
     throw new Error(
-      `Team Host is only supported on macOS and Linux; this machine reports "${platform}". `
-      + 'Windows hosts are not supported in v1.',
+      `Team Host needs macOS or Linux; this machine reports "${platform}". `
+      + 'Windows cannot host a team OR join one as a member yet — the overlay '
+      + 'client Myco provisions has no Windows build. Everything else in Myco '
+      + 'works normally on Windows.',
     );
   }
   const overlayArch: OverlayArch | null =
@@ -188,9 +190,17 @@ async function provisionTailscaleDarwin(
     log('installing tailscale via Homebrew (open-source, headless variant)…');
     const install = await runner.run(brewBin, ['install', '--formula', 'tailscale']);
     if (install.exitCode !== 0) {
+      // Exit 127 is spawn-ENOENT: brew itself is absent, which is a different
+      // problem from a formula that failed to build. Leading with the install
+      // output in that case buries the actual cause.
+      const brewMissing = install.exitCode === 127;
       throw new Error(
-        `brew install --formula tailscale failed (exit ${install.exitCode}): ${install.stdout.trim()}. `
-        + 'Install Homebrew and the tailscale formula, then re-run.',
+        brewMissing
+          ? 'Team Host on macOS needs Homebrew, which was not found. Myco installs the '
+            + 'open-source overlay client through it — that client ships via Homebrew on macOS '
+            + 'and nowhere else. Install Homebrew (https://brew.sh) and re-run.'
+          : `brew install --formula tailscale failed (exit ${install.exitCode}): ${install.stdout.trim()}. `
+            + 'Resolve the Homebrew error above, then re-run.',
       );
     }
   }

--- a/packages/myco/ui/src/hooks/use-host-membership.ts
+++ b/packages/myco/ui/src/hooks/use-host-membership.ts
@@ -56,6 +56,10 @@ export interface HostMembershipHint {
 export interface HostMembershipStatusResponse {
   hosts: HostMembershipHost[];
   hint: HostMembershipHint | null;
+  /** False when this machine has no overlay client build and cannot join a
+   *  team. Optional so an older daemon (which omits it) reads as capable
+   *  rather than silently disabling the form. */
+  overlay_supported?: boolean;
 }
 
 const HOST_MEMBERSHIP_STATUS_KEY = ['host-membership-status'] as const;

--- a/packages/myco/ui/src/pages/Team/HostTab.tsx
+++ b/packages/myco/ui/src/pages/Team/HostTab.tsx
@@ -90,6 +90,10 @@ function AffiliationHintBanner({ hint }: { hint: HostMembershipHint }) {
 
 function JoinHostForm() {
   const join = useJoinHost();
+  const status = useHostMembershipStatus();
+  // Absent on an older daemon — treat as capable so the form is never disabled
+  // by a missing field rather than a real limitation.
+  const overlaySupported = status.data?.overlay_supported !== false;
   const [hostRef, setHostRef] = useState('');
   const [key, setKey] = useState('');
   const [serverUrl, setServerUrl] = useState('');
@@ -97,7 +101,9 @@ function JoinHostForm() {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
-  const canSubmit = Boolean(hostRef.trim() && key.trim() && serverUrl.trim() && overlayAddress.trim()) && !join.isPending;
+  const canSubmit = overlaySupported
+    && Boolean(hostRef.trim() && key.trim() && serverUrl.trim() && overlayAddress.trim())
+    && !join.isPending;
 
   const handleJoin = async () => {
     setError(null);
@@ -123,6 +129,13 @@ function JoinHostForm() {
         Enroll this machine with a Team Host using the one-time key and overlay address a host operator shared
         with you. The host id is used exactly as typed — Myco can't verify it until the join completes.
       </p>
+      {!overlaySupported && (
+        <p className="text-xs text-terracotta-text m-0 mb-3">
+          This machine can't join a team yet — Myco's overlay client has no build for this operating system.
+          Everything else in Myco works normally here. Ask your host operator not to spend a one-time key on
+          this machine.
+        </p>
+      )}
       <div className="flex flex-col gap-2 mb-3">
         <label className={labelClass} htmlFor="host-join-id">Host id</label>
         <input id="host-join-id" className={inputClass} value={hostRef} onChange={(e) => setHostRef(e.target.value)} placeholder="host_…" />

--- a/tests/cli/host-binaries.test.ts
+++ b/tests/cli/host-binaries.test.ts
@@ -39,8 +39,15 @@ describe('resolveOverlayTarget', () => {
   });
 
   it('refuses Windows and unsupported arches with a clear message', () => {
-    expect(() => resolveOverlayTarget('win32', 'x64')).toThrow(/only supported on macOS and Linux/);
+    expect(() => resolveOverlayTarget('win32', 'x64')).toThrow(/needs macOS or Linux/);
     expect(() => resolveOverlayTarget('linux', 'ia32' as NodeJS.Architecture)).toThrow(/Unsupported CPU architecture/);
+  });
+
+  it('tells a Windows user that MEMBERSHIP is unavailable, not just hosting', () => {
+    // The old wording said "Windows hosts are not supported", which reads as a
+    // host-only limitation to someone who is trying to JOIN — the exact user
+    // the same guard also refuses.
+    expect(() => resolveOverlayTarget('win32', 'x64')).toThrow(/join one as a member/);
   });
 
   it('pins the headscale asset names + urls to the four platforms', () => {

--- a/tests/daemon/api/groves-overlay-scope.test.ts
+++ b/tests/daemon/api/groves-overlay-scope.test.ts
@@ -1,0 +1,122 @@
+/**
+ * A member reaching a Grove-listing route across the overlay must see only the
+ * Grove its request resolved to — never the whole machine.
+ *
+ * The route-stamp gate classifies what a route IS. It cannot constrain what a
+ * handler READS, so a handler that enumerates independently of `requestContext`
+ * walks straight past it. `GET /api/groves` did exactly that: wired once at
+ * startup with the daemon-wide scope, it handed any bearer-holding member every
+ * Grove on the host plus every project's absolute checkout path.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { createGrove } from '@myco/grove/registry.js';
+import type { RouteRequest } from '@myco/daemon/router.js';
+import {
+  createListGrovesHandler,
+  overlayGroveFilter,
+  scopeForRequest,
+  servedGroveScopeForDaemon,
+  type GrovesResponse,
+} from '@myco/daemon/api/groves.js';
+
+let home: string;
+let savedHome: string | undefined;
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-overlay-scope-'));
+  savedHome = process.env.MYCO_HOME;
+  process.env.MYCO_HOME = home;
+});
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env.MYCO_HOME;
+  else process.env.MYCO_HOME = savedHome;
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+function request(overrides: Partial<RouteRequest> = {}): RouteRequest {
+  return {
+    body: undefined,
+    query: {},
+    params: {},
+    pathname: '/api/groves',
+    ...overrides,
+  };
+}
+
+async function listGroves(req: RouteRequest): Promise<GrovesResponse> {
+  const handler = createListGrovesHandler(servedGroveScopeForDaemon(), path.join(home, 'state'));
+  const res = await handler(req);
+  return res.body as GrovesResponse;
+}
+
+describe('GET /api/groves — overlay scope narrowing', () => {
+  test('a local request still sees every Grove on the machine', async () => {
+    const served = createGrove('Served', home);
+    const personal = createGrove('Personal', home);
+
+    const body = await listGroves(request());
+
+    const ids = body.groves.map((g) => g.id);
+    expect(ids).toContain(served.id);
+    expect(ids).toContain(personal.id);
+  });
+
+  test('an overlay request sees ONLY the Grove its request resolved to', async () => {
+    const served = createGrove('Served', home);
+    const personal = createGrove('Personal', home);
+
+    const body = await listGroves(request({
+      isOverlay: true,
+      requestContext: { groveId: served.id } as RouteRequest['requestContext'],
+    }));
+
+    const ids = body.groves.map((g) => g.id);
+    expect(ids).toEqual([served.id]);
+    expect(ids).not.toContain(personal.id); // the operator's private Grove
+  });
+
+  test('an overlay request with no resolved Grove sees nothing, not everything', async () => {
+    createGrove('Served', home);
+    createGrove('Personal', home);
+
+    const body = await listGroves(request({ isOverlay: true }));
+
+    expect(body.groves).toEqual([]);
+  });
+});
+
+describe('scope narrowing helpers', () => {
+  test('scopeForRequest passes the daemon scope through for a local request', () => {
+    const daemonScope = servedGroveScopeForDaemon();
+    expect(scopeForRequest(daemonScope, request()).groveIds).toBeNull();
+  });
+
+  test('scopeForRequest pins an overlay request to its own Grove', () => {
+    const scoped = scopeForRequest(servedGroveScopeForDaemon(), request({
+      isOverlay: true,
+      requestContext: { groveId: 'grove_abc' } as RouteRequest['requestContext'],
+    }));
+    expect(scoped.groveIds).toEqual(['grove_abc']);
+  });
+
+  test('overlayGroveFilter is inert locally and exact over the overlay', () => {
+    expect(overlayGroveFilter(request())).toBeUndefined();
+
+    const filter = overlayGroveFilter(request({
+      isOverlay: true,
+      requestContext: { groveId: 'grove_abc' } as RouteRequest['requestContext'],
+    }));
+    expect(filter?.({ id: 'grove_abc' })).toBe(true);
+    expect(filter?.({ id: 'grove_other' })).toBe(false);
+  });
+
+  test('overlayGroveFilter admits nothing when the overlay request has no Grove', () => {
+    const filter = overlayGroveFilter(request({ isOverlay: true }));
+    expect(filter?.({ id: 'grove_abc' })).toBe(false);
+  });
+});

--- a/tests/daemon/api/host-membership.test.ts
+++ b/tests/daemon/api/host-membership.test.ts
@@ -463,7 +463,7 @@ describe('GET /api/host-membership/status', () => {
     const handler = createHostMembershipStatusHandler({ mycoHome: home });
     const res = await handler(req({}, {}));
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ hosts: [], hint: null });
+    expect(res.body).toEqual({ hosts: [], hint: null, overlay_supported: expect.any(Boolean) });
   });
 
   test('every joined host appears with its attach refs, including the resolved local_grove_id (no bearer/secret leaks)', async () => {
@@ -488,6 +488,7 @@ describe('GET /api/host-membership/status', () => {
         }],
       }],
       hint: null,
+      overlay_supported: expect.any(Boolean),
     });
     expect(JSON.stringify(res.body)).not.toContain('bearer');
   });


### PR DESCRIPTION
Two independent release blockers from the review. Both cheap, neither touches residency. Plans `906b64107d969e6c` and `87006e6eb8b89aa8`.

## Overlay Grove enumeration (P1)

`GET /api/groves` is a serve-default route, wired once at startup with the daemon-wide scope, whose handler read only `req.query` and **never** `req.requestContext`. Any member holding the shared host bearer could enumerate **every Grove on the host machine and every project's absolute checkout path** — including projects never shared with anyone. `/api/groves/:id/projects`, `/api/maintenance/summary`, and `/api/projects/activity` had the same shape; the last two are also reachable through the overlay MCP surface.

**The root cause is worth naming, because this is the second occurrence.** The route-stamp gate classifies what a route *is*. It cannot constrain what a handler *reads*, so a handler that selects data independently of the request context walks straight past it. The original overlay defect was also fixed at the request boundary, and was also bypassed underneath. Stamping routes correctly forever is not a stable strategy.

`RouteRequest` now carries `isOverlay`, set at the single construction site from the existing `isOverlayRequest` check, and handlers narrow through `scopeForRequest` / `overlayGroveFilter` — **widening the existing `ServedGroveScope`** rather than adding a parallel concept. The fan-outs narrow through `forEachGrove`'s existing `shouldVisitGrove` hook.

Behaviour:
- **local request** — unchanged; the operator's dashboard still sees the whole machine
- **overlay request** — only the Grove it resolved to
- **overlay request with no resolved Grove** — nothing, rather than everything

Seven regression tests, **verified to fail with the narrowing neutralised**.

I deliberately did *not* re-stamp the two maintenance routes as localhost-only. Narrowing is the smaller behavioural change and matches the pattern; re-stamping alters HTTP status codes for anything already calling them and deserves its own decision.

## Platform honesty (P2)

Windows can neither host a team **nor join one** — `resolveOverlayTarget` throws for both roles — but the error read `Windows hosts are not supported in v1`, which sounds like a host-only limit to the member it is also refusing. `docs/team-host.md` disclaimed only `--serve`, and the Team page's Join button had **no gating at all**, so a Windows user could fill in a one-time key and click Join before discovering it could never work.

The status route now reports `overlay_supported` — a capability, not a platform string, so the UI asks "can I join" rather than reasoning about operating systems. It's optional in the UI type, so an older daemon reads as capable instead of silently disabling the form.

Separately, **macOS requires Homebrew** for the overlay client, on members and hosts both, documented nowhere. It now appears in a "Before you start" section, and the absent-brew case (spawn exit 127) leads with the real cause instead of a confusing `brew install failed (exit 127)`.

## Verification

- `npm test` — **10446 pass / 0 fail / 15 skip**
- Root, UI, and worker typechecks clean; `lint:skills:strict` clean
- The enumeration tests independently confirmed to fail without the fix

## Scope

Does not clear the release. Residency still has no writer quiescence, the journal phase can regress after the irreversible flip, `leave` is ungated on in-flight transitions, and Tailscale coexistence is unfixed — though the spike (`discovery-edd039d9`) has now confirmed it's achievable without re-architecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
