### PR TITLE
feat(grove): add the project write lease, keyed by project rather than registry row

### DIFF
--- a/packages/myco/src/grove/project-lease.ts
+++ b/packages/myco/src/grove/project-lease.ts
@@ -1,0 +1,273 @@
+/**
+ * Project write lease — the machine-global record that a long-running operation
+ * holds exclusive write rights over one project.
+ *
+ * This is the storage half of the pause mechanism that `grove/registry.ts`
+ * already exposes as `pauseProject`/`isProjectPaused`, lifted out of the
+ * per-Grove `projects.toml` row and into a file keyed only by project id.
+ *
+ * WHY IT MOVED. The lease used to live *inside* the registry row it protects.
+ * That works for `grove move`, which keeps the row registered throughout, and
+ * fails for residency migration, which deregisters the row as its first step —
+ * so the lease could not survive the operation it exists to protect, and
+ * residency grew its own quiescence mechanism instead of reusing this one.
+ * Keyed by project id in a registry-independent location, one lease now covers
+ * both, and any future operation that moves a project between registries.
+ *
+ * Two properties the in-row version could not offer:
+ *
+ *   - **A single read.** `isProjectPaused` had to scan every Grove, because a
+ *     moving project is briefly registered in two. A lease keyed by project id
+ *     is one file read regardless of how many Groves exist — and it is on the
+ *     capture hot path, so that matters.
+ *
+ *   - **A monotonic generation.** Each acquisition bumps a counter that is never
+ *     reused. A writer that resolved its tenancy before the current lease was
+ *     taken holds an older generation and can be fenced on that basis, which a
+ *     bare boolean cannot express. Nothing consumes the generation for fencing
+ *     yet; it is recorded now so the write-admission chokepoint can.
+ *
+ * Deliberately DB-free and daemon-free — plain `fs` with atomic temp+rename
+ * writes, matching `host/registry.ts`. Acquisition runs under a per-user file
+ * lock so two processes cannot both observe "unheld" and both take it.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { isGroveEraId } from './ids.js';
+import { resolveMycoHome } from './paths.js';
+import { atomicWriteFileSync } from '@myco/utils/atomic-write.js';
+import { withFileLockSync } from '@myco/utils/lifecycle-lock.js';
+import {
+  nativePerUserLockNamespace,
+  type PerUserLockNamespace,
+} from '@myco/utils/per-user-lock-namespace.js';
+import { ABSENT, readFilePresence, type Presence } from '@myco/utils/presence.js';
+
+/** Directory under the Myco home holding one lease file per project. */
+export const LEASES_DIRNAME = 'leases';
+
+export interface ProjectLease {
+  project_id: string;
+  /** The operation holding the lease (`grove-move`, `residency-attach`, …). */
+  owner_op: string;
+  /** Operator-facing explanation, surfaced by refusals and by doctor. */
+  reason: string;
+  /** Epoch seconds of the most recent acquisition, for staleness sweeps. */
+  since: number;
+  /**
+   * Monotonically increasing per project, never reused — including across a
+   * release and re-acquire, which is why a released lease keeps its record
+   * rather than deleting it. A writer that resolved its tenancy under an older
+   * generation is by definition stale; if the counter could restart, a stale
+   * writer's generation could compare as NEWER than the live one and fencing
+   * would invert.
+   */
+  generation: number;
+  /** Epoch seconds when the holder released, or null while held. */
+  released_at: number | null;
+}
+
+export class ProjectLeaseHeldError extends Error {
+  readonly code = 'project_lease_held';
+
+  constructor(readonly projectId: string, readonly holder: ProjectLease) {
+    super(
+      `project_lease_held: ${projectId} is held by ${holder.owner_op} `
+      + `(reason=${holder.reason}, generation=${holder.generation})`,
+    );
+    this.name = 'ProjectLeaseHeldError';
+  }
+}
+
+export function resolveLeasesDir(mycoHome = resolveMycoHome()): string {
+  return path.join(mycoHome, LEASES_DIRNAME);
+}
+
+function leasePath(projectId: string, mycoHome: string): string {
+  return path.join(resolveLeasesDir(mycoHome), `${projectId}.json`);
+}
+
+function assertProjectId(projectId: string): void {
+  if (!isGroveEraId(projectId, 'project')) {
+    throw new Error(
+      `project lease requires a grove project id (proj_<32 hex>), got ${JSON.stringify(projectId)}.`,
+    );
+  }
+}
+
+/**
+ * Cheap short-circuit for the common no-lease case: no leases dir means no
+ * lease for any project, one stat instead of a per-project read. The capture
+ * hot path hits this on every request.
+ */
+export function leasesDirExists(mycoHome = resolveMycoHome()): boolean {
+  return fs.existsSync(resolveLeasesDir(mycoHome));
+}
+
+function parseLease(raw: string): ProjectLease | null {
+  try {
+    const doc = JSON.parse(raw) as Partial<ProjectLease>;
+    if (typeof doc.project_id !== 'string'
+      || typeof doc.owner_op !== 'string'
+      || typeof doc.reason !== 'string'
+      || typeof doc.since !== 'number'
+      || typeof doc.generation !== 'number'
+      || !(doc.released_at === null || typeof doc.released_at === 'number')) return null;
+    return doc as ProjectLease;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The raw on-disk record, held or released. Released records are retained to
+ * carry the generation forward, so acquisition reads this rather than
+ * {@link readProjectLease}, which reports a released record as absent.
+ */
+function readLeaseRecord(projectId: string, mycoHome: string): Presence<ProjectLease> {
+  if (!isGroveEraId(projectId, 'project')) return ABSENT;
+  if (!leasesDirExists(mycoHome)) return ABSENT;
+  const read = readFilePresence(leasePath(projectId, mycoHome));
+  if (read.state !== 'present') return read as Presence<ProjectLease>;
+  const parsed = parseLease(read.value);
+  return parsed
+    ? { state: 'present', value: parsed }
+    : { state: 'unknown', error: new Error(`project lease at ${leasePath(projectId, mycoHome)} is unreadable`) };
+}
+
+/**
+ * Read a project's lease.
+ *
+ * Three-state: an absent file genuinely means no lease, but an unreadable one
+ * must not read as unheld — that would let a writer proceed against a project
+ * an operation is actively moving. Callers gate on `present`, and treat
+ * `unknown` as held.
+ */
+export function readProjectLease(
+  projectId: string,
+  mycoHome = resolveMycoHome(),
+): Presence<ProjectLease> {
+  const record = readLeaseRecord(projectId, mycoHome);
+  if (record.state !== 'present') return record;
+  // A released record is retained only to carry the generation forward; it is
+  // not a held lease. An unreadable one stays `unknown` so writers stay out.
+  return record.value.released_at === null ? record : ABSENT;
+}
+
+/**
+ * Take (or refresh) the lease for `projectId`.
+ *
+ * Idempotent for the same `ownerOp` — a retry refreshes `since` and takes a new
+ * generation. A different owner is refused rather than overwritten.
+ *
+ * Read and write happen under one lock, so this is not the check-then-act the
+ * in-row version was: two processes cannot both see "unheld" and both take it.
+ */
+export function acquireProjectLease(
+  projectId: string,
+  ownerOp: string,
+  reason: string,
+  mycoHome = resolveMycoHome(),
+  lockNamespace: PerUserLockNamespace = nativePerUserLockNamespace,
+): ProjectLease {
+  assertProjectId(projectId);
+  if (!ownerOp.trim()) throw new Error('acquireProjectLease requires a non-empty owner_op');
+  if (!reason.trim()) throw new Error('acquireProjectLease requires a non-empty reason');
+
+  const dir = resolveLeasesDir(mycoHome);
+  fs.mkdirSync(dir, { recursive: true });
+  const lockPath = path.join(lockNamespace.resolve('project-lease'), `lease-${projectId}.lock`);
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+
+  return withFileLockSync(lockPath, () => {
+    // The raw record, held or released — the released one still carries the
+    // generation this acquisition must advance past.
+    const record = readLeaseRecord(projectId, mycoHome);
+    if (record.state === 'unknown') throw record.error;
+    const prior = record.state === 'present' ? record.value : null;
+    if (prior && prior.released_at === null && prior.owner_op !== ownerOp) {
+      throw new ProjectLeaseHeldError(projectId, prior);
+    }
+    const next: ProjectLease = {
+      project_id: projectId,
+      owner_op: ownerOp,
+      reason,
+      since: Math.floor(Date.now() / 1000),
+      generation: (prior?.generation ?? 0) + 1,
+      released_at: null,
+    };
+    atomicWriteFileSync(leasePath(projectId, mycoHome), `${JSON.stringify(next, null, 2)}\n`);
+    return next;
+  });
+}
+
+/**
+ * Release the lease iff `ownerOp` holds it. A mismatched owner is refused, so a
+ * late-arriving operation cannot clear the lease of the one that superseded it.
+ */
+export function releaseProjectLease(
+  projectId: string,
+  ownerOp: string,
+  mycoHome = resolveMycoHome(),
+  lockNamespace: PerUserLockNamespace = nativePerUserLockNamespace,
+): void {
+  assertProjectId(projectId);
+  const lockPath = path.join(lockNamespace.resolve('project-lease'), `lease-${projectId}.lock`);
+  if (!fs.existsSync(path.dirname(lockPath))) return;
+
+  withFileLockSync(lockPath, () => {
+    const record = readLeaseRecord(projectId, mycoHome);
+    if (record.state === 'absent') return;
+    if (record.state === 'unknown') throw record.error;
+    if (record.value.released_at !== null) return; // already released
+    if (record.value.owner_op !== ownerOp) {
+      throw new ProjectLeaseHeldError(projectId, record.value);
+    }
+    // Marked, not deleted: the record is what carries the generation forward.
+    const released: ProjectLease = { ...record.value, released_at: Math.floor(Date.now() / 1000) };
+    atomicWriteFileSync(leasePath(projectId, mycoHome), `${JSON.stringify(released, null, 2)}\n`);
+  });
+}
+
+/**
+ * Drop a lease regardless of holder — the operator escape hatch, and what the
+ * startup sweeper uses on a lease left behind by a crashed process. The
+ * generation is NOT reset: a forced release still has to fence any writer that
+ * was admitted under the released lease.
+ */
+export function forceReleaseProjectLease(
+  projectId: string,
+  mycoHome = resolveMycoHome(),
+  lockNamespace: PerUserLockNamespace = nativePerUserLockNamespace,
+): boolean {
+  assertProjectId(projectId);
+  const lockPath = path.join(lockNamespace.resolve('project-lease'), `lease-${projectId}.lock`);
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  return withFileLockSync(lockPath, () => {
+    const record = readLeaseRecord(projectId, mycoHome);
+    if (record.state !== 'present' || record.value.released_at !== null) return false;
+    const released: ProjectLease = { ...record.value, released_at: Math.floor(Date.now() / 1000) };
+    atomicWriteFileSync(leasePath(projectId, mycoHome), `${JSON.stringify(released, null, 2)}\n`);
+    return true;
+  });
+}
+
+/** Every project currently holding a lease. Absent dir → none. */
+export function listProjectLeases(mycoHome = resolveMycoHome()): ProjectLease[] {
+  const dir = resolveLeasesDir(mycoHome);
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: ProjectLease[] = [];
+  for (const name of entries) {
+    if (!name.endsWith('.json')) continue;
+    const projectId = name.slice(0, -'.json'.length);
+    const lease = readProjectLease(projectId, mycoHome);
+    if (lease.state === 'present') out.push(lease.value);
+  }
+  return out;
+}

--- a/packages/myco/src/utils/per-user-lock-namespace.ts
+++ b/packages/myco/src/utils/per-user-lock-namespace.ts
@@ -22,7 +22,8 @@ export type PerUserLockNamespaceName =
   | 'host-membership'
   | 'host-operations'
   | 'legacy-team-home'
-  | 'external-mcp-activation';
+  | 'external-mcp-activation'
+  | 'project-lease';
 
 const perUserLockNamespaceBrand: unique symbol = Symbol('PerUserLockNamespace');
 

--- a/tests/grove/project-lease.test.ts
+++ b/tests/grove/project-lease.test.ts
@@ -1,0 +1,140 @@
+/**
+ * The project write lease: exclusivity, a generation that never restarts, and
+ * three-state reads that keep writers out when the lease can't be read.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { createProjectId } from '@myco/grove/ids.js';
+import {
+  acquireProjectLease,
+  forceReleaseProjectLease,
+  listProjectLeases,
+  ProjectLeaseHeldError,
+  readProjectLease,
+  releaseProjectLease,
+  resolveLeasesDir,
+} from '@myco/grove/project-lease.js';
+import { testPerUserLockNamespace } from '../helpers/per-user-lock-namespace.js';
+
+let home: string;
+let projectId: string;
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-lease-'));
+  projectId = createProjectId();
+});
+
+afterEach(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+const acquire = (owner: string, reason = 'moving') =>
+  acquireProjectLease(projectId, owner, reason, home, testPerUserLockNamespace);
+
+describe('project write lease', () => {
+  test('an unleased project reads as absent', () => {
+    expect(readProjectLease(projectId, home).state).toBe('absent');
+  });
+
+  test('acquiring makes the lease readable with its owner and reason', () => {
+    acquire('grove-move', 'moving between Groves');
+    const read = readProjectLease(projectId, home);
+    expect(read.state).toBe('present');
+    if (read.state !== 'present') return;
+    expect(read.value.owner_op).toBe('grove-move');
+    expect(read.value.reason).toBe('moving between Groves');
+    expect(read.value.released_at).toBeNull();
+  });
+
+  test('a different owner is refused, not allowed to steal the lease', () => {
+    acquire('grove-move');
+    expect(() => acquire('residency-attach')).toThrow(ProjectLeaseHeldError);
+
+    // The original holder is untouched.
+    const read = readProjectLease(projectId, home);
+    expect(read.state === 'present' && read.value.owner_op).toBe('grove-move');
+  });
+
+  test('re-acquiring as the same owner is idempotent (crash-resume)', () => {
+    const first = acquire('grove-move');
+    const second = acquire('grove-move');
+    expect(second.owner_op).toBe('grove-move');
+    expect(second.generation).toBeGreaterThan(first.generation);
+  });
+
+  test('release frees the project for a different owner', () => {
+    acquire('grove-move');
+    releaseProjectLease(projectId, 'grove-move', home, testPerUserLockNamespace);
+
+    expect(readProjectLease(projectId, home).state).toBe('absent');
+    expect(() => acquire('residency-attach')).not.toThrow();
+  });
+
+  test('a non-holder cannot release someone else\'s lease', () => {
+    acquire('grove-move');
+    expect(() => releaseProjectLease(projectId, 'residency-attach', home, testPerUserLockNamespace))
+      .toThrow(ProjectLeaseHeldError);
+    expect(readProjectLease(projectId, home).state).toBe('present');
+  });
+
+  test('the generation never restarts across release and re-acquire', () => {
+    // This is the property fencing depends on. If the counter restarted, a
+    // stale writer admitted under an older, higher generation would compare as
+    // NEWER than the live lease and the fence would invert.
+    const first = acquire('grove-move');
+    releaseProjectLease(projectId, 'grove-move', home, testPerUserLockNamespace);
+    const second = acquire('residency-attach');
+    releaseProjectLease(projectId, 'residency-attach', home, testPerUserLockNamespace);
+    const third = acquire('grove-move');
+
+    expect(second.generation).toBeGreaterThan(first.generation);
+    expect(third.generation).toBeGreaterThan(second.generation);
+  });
+
+  test('force-release drops any holder but preserves the generation', () => {
+    const held = acquire('grove-move');
+    expect(forceReleaseProjectLease(projectId, home, testPerUserLockNamespace)).toBe(true);
+    expect(readProjectLease(projectId, home).state).toBe('absent');
+
+    const next = acquire('residency-attach');
+    expect(next.generation).toBeGreaterThan(held.generation);
+  });
+
+  test('force-release on an unheld project reports that it did nothing', () => {
+    expect(forceReleaseProjectLease(projectId, home, testPerUserLockNamespace)).toBe(false);
+  });
+
+  test('an unreadable lease reads as unknown, never as unheld', () => {
+    acquire('grove-move');
+    // Corrupt the record. A writer must not be admitted because the gate that
+    // would have stopped it could not be parsed.
+    fs.writeFileSync(path.join(resolveLeasesDir(home), `${projectId}.json`), '{ not json', 'utf-8');
+
+    const read = readProjectLease(projectId, home);
+    expect(read.state).toBe('unknown');
+  });
+
+  test('acquiring refuses outright when the existing lease is unreadable', () => {
+    acquire('grove-move');
+    fs.writeFileSync(path.join(resolveLeasesDir(home), `${projectId}.json`), 'torn', 'utf-8');
+    expect(() => acquire('grove-move')).toThrow(/unreadable/);
+  });
+
+  test('listProjectLeases reports held leases and omits released ones', () => {
+    const other = createProjectId();
+    acquire('grove-move');
+    acquireProjectLease(other, 'residency-attach', 'detaching', home, testPerUserLockNamespace);
+    releaseProjectLease(other, 'residency-attach', home, testPerUserLockNamespace);
+
+    const held = listProjectLeases(home);
+    expect(held.map((l) => l.project_id)).toEqual([projectId]);
+  });
+
+  test('rejects a non-grove-era project id rather than writing a stray path', () => {
+    expect(() => acquireProjectLease('../escape', 'grove-move', 'x', home, testPerUserLockNamespace))
+      .toThrow(/grove project id/);
+  });
+});


### PR DESCRIPTION
Phase 1 of Project Write Admission. **Storage only — no caller is migrated, so this changes no behavior.** Plan `87006e6eb8b89aa8` carries the phase breakdown.

## Why this exists

The pause mechanism this will replace is already good and already wired: **sixteen consumers** gate on it, covering every HTTP write method and all six background fan-outs, with an owner identity, a staleness clock, an orphan sweeper, and an operator escape hatch.

It has **exactly one producer** — `grove/move.ts:215` — and residency migration doesn't use it at all.

That isn't an oversight, it's structural: the pause block lives *inside* the `projects.toml` row it protects, and residency parking deregisters that row as its first step. The lease could not survive the operation it exists to protect, so residency grew a second quiescence mechanism instead. That second mechanism is where the writer race and the FK-orphan wedge come from.

Keyed by project id under `<mycoHome>/leases/`, the lease outlives deregistration, so one mechanism covers both operations and any future one that moves a project between registries.

## What the relocation buys

**A single read.** `isProjectPaused` had to scan every Grove, because a moving project is briefly registered in two. This is one file read regardless of Grove count — and it sits on the capture hot path.

**A monotonic generation.** Each acquisition takes a number that is never reused, so a writer that resolved its tenancy under an older generation is provably stale. Nothing fences on it yet; it's recorded now so the admission chokepoint in a later phase can.

## A design bug I introduced and had to fix

My first version **deleted** the record on release, which restarted the generation at 1. A stale writer holding generation 3 would then have compared as *newer* than the live lease — the fence inverted, silently.

Release now marks the record instead, because the record is what carries the counter forward. `the generation never restarts across release and re-acquire` is the test that pins it, and it's the one worth keeping if any of this is ever refactored.

## Other properties

Acquisition reads and writes under one per-user file lock, so unlike the check-then-act it replaces, two processes cannot both observe "unheld" and both take it. Reads are three-state: a corrupt record is `unknown`, never unheld, so a torn write keeps writers *out* rather than opening the gate.

## Verification

13 tests; suite **10459 pass / 0 fail**; typechecks clean.

## What this does NOT do

No caller uses it yet — deliberately. Phase 2 migrates the five pause functions onto it behind their current signatures (with a dual-read window for pauses written by a pre-upgrade binary), leaving the sixteen consumers untouched. Phase 3 makes residency take it, which is the phase that actually closes the writer-race P1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
