### PR TITLE
refactor(grove): move the pause API onto the project lease

### DIFF
--- a/packages/myco/src/daemon/api/error-envelope.ts
+++ b/packages/myco/src/daemon/api/error-envelope.ts
@@ -25,7 +25,12 @@ export interface PausedInfo {
   reason: string;
   since: number;
   owner_op: string;
-  grove_id: string;
+  /**
+   * The Grove the paused project sits in, or null when it is registered
+   * nowhere — the pause is held on the PROJECT, and an operation that moves a
+   * project between registries deregisters it for part of the window.
+   */
+  grove_id: string | null;
 }
 
 export interface PausedErrorBody extends ErrorBody {

--- a/packages/myco/src/grove/registry.ts
+++ b/packages/myco/src/grove/registry.ts
@@ -6,6 +6,12 @@ import { atomicWriteFileSync } from '@myco/utils/atomic-write.js';
 import { isPlainTable } from '@myco/utils/is-plain-table.js';
 import { createMtimeCache } from '@myco/utils/mtime-cache.js';
 import { createGroveId, createProjectId, isGroveEraId } from './ids.js';
+import {
+  acquireProjectLease,
+  forceReleaseProjectLease,
+  readProjectLease,
+  releaseProjectLease,
+} from './project-lease.js';
 import { assertSafeProjectRoot, isSafeProjectRoot } from '../vault/resolve.js';
 import {
   pathsEquivalent,
@@ -72,7 +78,19 @@ export interface PauseInfo {
 
 export type ProjectPauseStatus =
   | { paused: false }
-  | { paused: true; reason: string; since: number; owner_op: string; grove_id: string };
+  | {
+    paused: true;
+    reason: string;
+    since: number;
+    owner_op: string;
+    /**
+     * The Grove the paused project is registered in, or null when it is
+     * registered nowhere. The pause is held on the PROJECT, and an operation
+     * that moves a project between registries deregisters it for part of the
+     * window — which is exactly the case the lease exists to cover.
+     */
+    grove_id: string | null;
+  };
 
 export interface RegisterProjectInput {
   projectId: string;
@@ -930,46 +948,17 @@ export function pauseProject(
   ownerOp: string,
   mycoHome = resolveMycoHome(),
 ): void {
-  const grove = loadGroveRecord(groveId, mycoHome);
-  if (!grove) throw new Error(`Unknown Grove: ${groveId}`);
-  if (!reason.trim()) throw new Error('pauseProject requires a non-empty reason');
-  if (!ownerOp.trim()) throw new Error('pauseProject requires a non-empty owner_op');
-
-  const projectsPath = resolveGroveProjectsPath(grove.id, mycoHome);
-  const projectsDoc = readToml(projectsPath);
-  const projects = isPlainTable(projectsDoc.projects)
-    ? projectsDoc.projects as Record<string, unknown>
-    : {};
-  const entry = isPlainTable(projects[projectId])
-    ? { ...(projects[projectId] as Record<string, unknown>) }
-    : null;
-  if (!entry) {
+  // groveId no longer selects storage — the lease is held on the PROJECT, so it
+  // survives the deregistration a move or a residency transition performs
+  // partway through. It is still validated, and the project must still be
+  // registered here, because this API's callers pause a project they have
+  // registered and a typo should fail loudly. An operation that deliberately
+  // holds a lease across deregistration calls `acquireProjectLease` directly.
+  if (!loadGroveRecord(groveId, mycoHome)) throw new Error(`Unknown Grove: ${groveId}`);
+  if (!getRegisteredProjectInGrove(groveId, projectId, mycoHome)) {
     throw new Error(`Project ${projectId} is not registered in Grove ${groveId}`);
   }
-
-  const existingPause = readPauseBlock(entry);
-  if (existingPause && existingPause.owner_op !== ownerOp) {
-    throw new Error(
-      `Project ${projectId} is already paused by ${existingPause.owner_op} `
-      + `(reason=${existingPause.reason}); cannot re-pause as ${ownerOp}`,
-    );
-  }
-
-  // Refresh `since` for retries with the same owner so `forceResume`
-  // staleness windows reflect the most recent attempt.
-  const since = Math.floor(Date.now() / 1000);
-
-  entry.paused = {
-    since,
-    reason,
-    owner_op: ownerOp,
-  } as unknown as TomlTableWithoutBigInt;
-
-  projectsDoc.projects = {
-    ...projects,
-    [projectId]: entry as unknown as TomlTableWithoutBigInt,
-  } as unknown as TomlTableWithoutBigInt;
-  writeToml(projectsPath, projectsDoc);
+  acquireProjectLease(projectId, ownerOp, reason, mycoHome);
 }
 
 /**
@@ -982,34 +971,8 @@ export function resumeProject(
   ownerOp: string,
   mycoHome = resolveMycoHome(),
 ): void {
-  const grove = loadGroveRecord(groveId, mycoHome);
-  if (!grove) throw new Error(`Unknown Grove: ${groveId}`);
-
-  const projectsPath = resolveGroveProjectsPath(grove.id, mycoHome);
-  const projectsDoc = readToml(projectsPath);
-  const projects = isPlainTable(projectsDoc.projects)
-    ? projectsDoc.projects as Record<string, unknown>
-    : {};
-  const entry = isPlainTable(projects[projectId])
-    ? { ...(projects[projectId] as Record<string, unknown>) }
-    : null;
-  if (!entry) return;
-
-  const existingPause = readPauseBlock(entry);
-  if (!existingPause) return;
-  if (existingPause.owner_op !== ownerOp) {
-    throw new Error(
-      `Project ${projectId} is paused by ${existingPause.owner_op}; `
-      + `cannot resume as ${ownerOp}`,
-    );
-  }
-
-  delete entry.paused;
-  projectsDoc.projects = {
-    ...projects,
-    [projectId]: entry as unknown as TomlTableWithoutBigInt,
-  } as unknown as TomlTableWithoutBigInt;
-  writeToml(projectsPath, projectsDoc);
+  if (!loadGroveRecord(groveId, mycoHome)) throw new Error(`Unknown Grove: ${groveId}`);
+  releaseProjectLease(projectId, ownerOp, mycoHome);
 }
 
 /**
@@ -1024,26 +987,8 @@ export function forceResumeProject(
   projectId: string,
   mycoHome = resolveMycoHome(),
 ): void {
-  const grove = loadGroveRecord(groveId, mycoHome);
-  if (!grove) throw new Error(`Unknown Grove: ${groveId}`);
-
-  const projectsPath = resolveGroveProjectsPath(grove.id, mycoHome);
-  const projectsDoc = readToml(projectsPath);
-  const projects = isPlainTable(projectsDoc.projects)
-    ? projectsDoc.projects as Record<string, unknown>
-    : {};
-  const entry = isPlainTable(projects[projectId])
-    ? { ...(projects[projectId] as Record<string, unknown>) }
-    : null;
-  if (!entry) return;
-
-  if (!readPauseBlock(entry)) return;
-  delete entry.paused;
-  projectsDoc.projects = {
-    ...projects,
-    [projectId]: entry as unknown as TomlTableWithoutBigInt,
-  } as unknown as TomlTableWithoutBigInt;
-  writeToml(projectsPath, projectsDoc);
+  if (!loadGroveRecord(groveId, mycoHome)) throw new Error(`Unknown Grove: ${groveId}`);
+  forceReleaseProjectLease(projectId, mycoHome);
 }
 
 /**
@@ -1056,14 +1001,45 @@ export function isProjectPaused(
   projectId: string,
   mycoHome = resolveMycoHome(),
 ): ProjectPauseStatus {
-  // Scans every Grove: during a move, the project is registered in both
-  // source and target for a brief window. Returning at first-hit would let
-  // an alphabetically-first unpaused Grove mask a paused entry elsewhere.
+  // The lease is the authority. One read, keyed by project id — no Grove scan,
+  // and it stays correct while the project is registered in two Groves (mid
+  // move) or in none (mid residency transition).
+  const lease = readProjectLease(projectId, mycoHome);
+  if (lease.state === 'unknown') {
+    // An unreadable lease is not an absent one. Reporting "not paused" here
+    // would admit writers to a project an operation is actively moving.
+    throw lease.error;
+  }
+  if (lease.state === 'present') {
+    return {
+      paused: true,
+      reason: lease.value.reason,
+      since: lease.value.since,
+      owner_op: lease.value.owner_op,
+      grove_id: findGroveHoldingProject(projectId, mycoHome),
+    };
+  }
+
+  // Rollout fallback: a pause written into a projects.toml row by the previous
+  // binary. Still honored so an upgrade mid-move does not drop the guard.
+  // Removable a release after the lease ships.
   for (const grove of listGroves(mycoHome)) {
-    const status = isProjectPausedInGrove(grove.id, projectId, mycoHome);
+    const status = legacyInRowPause(grove.id, projectId, mycoHome);
     if (status.paused) return status;
   }
   return { paused: false };
+}
+
+/** Which Grove currently registers this project, or null when none does. */
+function findGroveHoldingProject(projectId: string, mycoHome: string): string | null {
+  for (const grove of listGroves(mycoHome)) {
+    const projectsDoc = readToml(resolveGroveProjectsPath(grove.id, mycoHome));
+    const projects = isPlainTable(projectsDoc.projects)
+      ? projectsDoc.projects as Record<string, unknown>
+      : {};
+    if (isPlainTable(projects[projectId])) return grove.id;
+  }
+  return null;
 }
 
 /**
@@ -1071,10 +1047,38 @@ export function isProjectPaused(
  * already knows the Grove (e.g. scope iteration) — skips the M×N
  * cross-Grove scan.
  */
+/**
+ * Per-Grove pause lookup, retained for its callers' signatures.
+ *
+ * `groveId` is vestigial: the lease is held on the project, not on its row in
+ * one Grove's registry, so the answer no longer depends on which Grove asks.
+ * Kept rather than removed so the sixteen call sites stay untouched; it still
+ * scopes the legacy in-row fallback below.
+ */
 export function isProjectPausedInGrove(
   groveId: string,
   projectId: string,
   mycoHome = resolveMycoHome(),
+): ProjectPauseStatus {
+  const lease = readProjectLease(projectId, mycoHome);
+  if (lease.state === 'unknown') throw lease.error;
+  if (lease.state === 'present') {
+    return {
+      paused: true,
+      reason: lease.value.reason,
+      since: lease.value.since,
+      owner_op: lease.value.owner_op,
+      grove_id: findGroveHoldingProject(projectId, mycoHome),
+    };
+  }
+  return legacyInRowPause(groveId, projectId, mycoHome);
+}
+
+/** The pre-lease storage: a `paused` block inside the project's registry row. */
+function legacyInRowPause(
+  groveId: string,
+  projectId: string,
+  mycoHome: string,
 ): ProjectPauseStatus {
   const projectsDoc = readToml(resolveGroveProjectsPath(groveId, mycoHome));
   const projects = isPlainTable(projectsDoc.projects)

--- a/tests/daemon/startup-pauses.test.ts
+++ b/tests/daemon/startup-pauses.test.ts
@@ -14,6 +14,7 @@ import {
   pauseProject,
   registerProjectInGrove,
 } from '@myco/grove/registry.js';
+import { createProjectId } from '@myco/grove/ids.js';
 import type { DaemonLogger } from '@myco/daemon/logger.js';
 
 function fakeLogger(): DaemonLogger {
@@ -27,9 +28,13 @@ function fakeLogger(): DaemonLogger {
 
 describe('resumeOrphanedPauses', () => {
   let home: string;
+let PROJECT_A: string;
+let PROJECT_B: string;
   let previousHome: string | undefined;
 
   beforeEach(() => {
+  PROJECT_A = createProjectId();
+  PROJECT_B = createProjectId();
     home = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-startup-pause-'));
     previousHome = process.env.MYCO_HOME;
     process.env.MYCO_HOME = home;
@@ -46,11 +51,11 @@ describe('resumeOrphanedPauses', () => {
   it('force-resumes a pause older than the staleness threshold', () => {
     const grove = createGrove('Test', home);
     registerProjectInGrove(grove.id, {
-      projectId: 'proj_aaaa',
+      projectId: PROJECT_A,
       projectName: 'A',
       projectRoot: '/tmp/a',
     }, home);
-    pauseProject(grove.id, 'proj_aaaa', 'grove-move', 'op-1', home);
+    pauseProject(grove.id, PROJECT_A, 'grove-move', 'op-1', home);
 
     // Advance the clock past the staleness window.
     const futureMs = Date.now() + (ORPHAN_PAUSE_STALENESS_SECONDS + 60) * 1000;
@@ -62,17 +67,17 @@ describe('resumeOrphanedPauses', () => {
     expect(result.scanned).toBe(1);
     expect(result.resumed).toBe(1);
     expect(result.preserved).toBe(0);
-    expect(isProjectPaused('proj_aaaa', home).paused).toBe(false);
+    expect(isProjectPaused(PROJECT_A, home).paused).toBe(false);
   });
 
   it('preserves a pause younger than the staleness threshold', () => {
     const grove = createGrove('Test', home);
     registerProjectInGrove(grove.id, {
-      projectId: 'proj_aaaa',
+      projectId: PROJECT_A,
       projectName: 'A',
       projectRoot: '/tmp/a',
     }, home);
-    pauseProject(grove.id, 'proj_aaaa', 'grove-move', 'op-1', home);
+    pauseProject(grove.id, PROJECT_A, 'grove-move', 'op-1', home);
 
     const result = resumeOrphanedPauses(fakeLogger(), {
       now: () => Date.now() + 30 * 1000,
@@ -82,7 +87,7 @@ describe('resumeOrphanedPauses', () => {
     expect(result.scanned).toBe(1);
     expect(result.resumed).toBe(0);
     expect(result.preserved).toBe(1);
-    const status = isProjectPaused('proj_aaaa', home);
+    const status = isProjectPaused(PROJECT_A, home);
     expect(status.paused).toBe(true);
     if (!status.paused) throw new Error('unreachable');
     expect(status.owner_op).toBe('op-1');
@@ -92,17 +97,17 @@ describe('resumeOrphanedPauses', () => {
     const groveA = createGrove('Alpha', home);
     const groveB = createGrove('Beta', home);
     registerProjectInGrove(groveA.id, {
-      projectId: 'proj_aaaa',
+      projectId: PROJECT_A,
       projectName: 'A',
       projectRoot: '/tmp/a',
     }, home);
     registerProjectInGrove(groveB.id, {
-      projectId: 'proj_bbbb',
+      projectId: PROJECT_B,
       projectName: 'B',
       projectRoot: '/tmp/b',
     }, home);
-    pauseProject(groveA.id, 'proj_aaaa', 'grove-move', 'op-1', home);
-    // proj_bbbb is unpaused.
+    pauseProject(groveA.id, PROJECT_A, 'grove-move', 'op-1', home);
+    // PROJECT_B is unpaused.
 
     const futureMs = Date.now() + (ORPHAN_PAUSE_STALENESS_SECONDS + 60) * 1000;
     const result = resumeOrphanedPauses(fakeLogger(), {
@@ -112,6 +117,6 @@ describe('resumeOrphanedPauses', () => {
 
     expect(result.scanned).toBe(2);
     expect(result.resumed).toBe(1);
-    expect(isProjectPaused('proj_aaaa', home).paused).toBe(false);
+    expect(isProjectPaused(PROJECT_A, home).paused).toBe(false);
   });
 });

--- a/tests/grove/registry-pause.test.ts
+++ b/tests/grove/registry-pause.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { parse } from 'smol-toml';
 import {
   clearGroveRegistryCaches,
   createGrove,
@@ -12,11 +11,17 @@ import {
   registerProjectInGrove,
   resumeProject,
 } from '@myco/grove/registry.js';
+import { createProjectId } from '@myco/grove/ids.js';
+import { readProjectLease } from '@myco/grove/project-lease.js';
 
 let home: string;
+let PROJECT_A: string;
+let PROJECT_B: string;
 
 beforeEach(() => {
   home = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-pause-'));
+  PROJECT_A = createProjectId();
+  PROJECT_B = createProjectId();
   clearGroveRegistryCaches();
 });
 
@@ -25,25 +30,28 @@ afterEach(() => {
   clearGroveRegistryCaches();
 });
 
-function readPauseFromDisk(groveId: string, projectId: string): unknown {
-  const projectsPath = path.join(home, 'groves', groveId, 'registry', 'projects.toml');
-  const doc = parse(fs.readFileSync(projectsPath, 'utf-8'));
-  const projects = (doc as { projects?: Record<string, { paused?: unknown }> }).projects ?? {};
-  return projects[projectId]?.paused;
+/**
+ * The pause is stored as a project lease under `<home>/leases/`, not in the
+ * Grove's projects.toml row — that relocation is what lets it survive the
+ * deregistration a move or a residency transition performs partway through.
+ */
+function readPauseFromDisk(_groveId: string, projectId: string): unknown {
+  const lease = readProjectLease(projectId, home);
+  return lease.state === 'present' ? lease.value : undefined;
 }
 
 describe('Grove registry pause primitive', () => {
   it('writes a paused block; isProjectPaused returns the right shape', () => {
     const grove = createGrove('Test', home);
     registerProjectInGrove(grove.id, {
-      projectId: 'proj_aaaa',
+      projectId: PROJECT_A,
       projectName: 'Demo',
       projectRoot: '/tmp/demo',
     }, home);
 
-    pauseProject(grove.id, 'proj_aaaa', 'grove-move', 'op-1', home);
+    pauseProject(grove.id, PROJECT_A, 'grove-move', 'op-1', home);
 
-    const status = isProjectPaused('proj_aaaa', home);
+    const status = isProjectPaused(PROJECT_A, home);
     expect(status.paused).toBe(true);
     if (!status.paused) throw new Error('unreachable');
     expect(status.reason).toBe('grove-move');
@@ -52,24 +60,24 @@ describe('Grove registry pause primitive', () => {
     expect(typeof status.since).toBe('number');
     expect(status.since).toBeGreaterThan(0);
 
-    expect(readPauseFromDisk(grove.id, 'proj_aaaa')).toBeDefined();
+    expect(readPauseFromDisk(grove.id, PROJECT_A)).toBeDefined();
   });
 
   it('is idempotent when called twice with the same owner_op and refreshes since', async () => {
     const grove = createGrove('Test', home);
     registerProjectInGrove(grove.id, {
-      projectId: 'proj_aaaa',
+      projectId: PROJECT_A,
       projectName: 'Demo',
       projectRoot: '/tmp/demo',
     }, home);
 
-    pauseProject(grove.id, 'proj_aaaa', 'grove-move', 'op-1', home);
-    const first = isProjectPaused('proj_aaaa', home);
+    pauseProject(grove.id, PROJECT_A, 'grove-move', 'op-1', home);
+    const first = isProjectPaused(PROJECT_A, home);
     if (!first.paused) throw new Error('expected paused');
     await new Promise((resolve) => setTimeout(resolve, 1100));
 
-    expect(() => pauseProject(grove.id, 'proj_aaaa', 'grove-move', 'op-1', home)).not.toThrow();
-    const second = isProjectPaused('proj_aaaa', home);
+    expect(() => pauseProject(grove.id, PROJECT_A, 'grove-move', 'op-1', home)).not.toThrow();
+    const second = isProjectPaused(PROJECT_A, home);
     if (!second.paused) throw new Error('expected paused');
     expect(second.since).toBeGreaterThanOrEqual(first.since);
   });
@@ -77,61 +85,61 @@ describe('Grove registry pause primitive', () => {
   it('throws when re-pausing under a different owner_op', () => {
     const grove = createGrove('Test', home);
     registerProjectInGrove(grove.id, {
-      projectId: 'proj_aaaa',
+      projectId: PROJECT_A,
       projectName: 'Demo',
       projectRoot: '/tmp/demo',
     }, home);
 
-    pauseProject(grove.id, 'proj_aaaa', 'grove-move', 'op-1', home);
+    pauseProject(grove.id, PROJECT_A, 'grove-move', 'op-1', home);
     expect(() =>
-      pauseProject(grove.id, 'proj_aaaa', 'vacuum', 'op-2', home),
+      pauseProject(grove.id, PROJECT_A, 'vacuum', 'op-2', home),
     ).toThrow(/op-1/);
   });
 
   it('throws when called for an unregistered project', () => {
     const grove = createGrove('Test', home);
     expect(() =>
-      pauseProject(grove.id, 'proj_missing', 'grove-move', 'op-1', home),
+      pauseProject(grove.id, createProjectId(), 'grove-move', 'op-1', home),
     ).toThrow(/not registered/);
   });
 
   it('clears the block when resumeProject owner_op matches', () => {
     const grove = createGrove('Test', home);
     registerProjectInGrove(grove.id, {
-      projectId: 'proj_aaaa',
+      projectId: PROJECT_A,
       projectName: 'Demo',
       projectRoot: '/tmp/demo',
     }, home);
 
-    pauseProject(grove.id, 'proj_aaaa', 'grove-move', 'op-1', home);
-    resumeProject(grove.id, 'proj_aaaa', 'op-1', home);
+    pauseProject(grove.id, PROJECT_A, 'grove-move', 'op-1', home);
+    resumeProject(grove.id, PROJECT_A, 'op-1', home);
 
-    expect(isProjectPaused('proj_aaaa', home).paused).toBe(false);
-    expect(readPauseFromDisk(grove.id, 'proj_aaaa')).toBeUndefined();
+    expect(isProjectPaused(PROJECT_A, home).paused).toBe(false);
+    expect(readPauseFromDisk(grove.id, PROJECT_A)).toBeUndefined();
   });
 
   it('throws on resumeProject when owner_op mismatches', () => {
     const grove = createGrove('Test', home);
     registerProjectInGrove(grove.id, {
-      projectId: 'proj_aaaa',
+      projectId: PROJECT_A,
       projectName: 'Demo',
       projectRoot: '/tmp/demo',
     }, home);
 
-    pauseProject(grove.id, 'proj_aaaa', 'grove-move', 'op-1', home);
-    expect(() => resumeProject(grove.id, 'proj_aaaa', 'op-2', home)).toThrow(/op-1/);
+    pauseProject(grove.id, PROJECT_A, 'grove-move', 'op-1', home);
+    expect(() => resumeProject(grove.id, PROJECT_A, 'op-2', home)).toThrow(/op-1/);
   });
 
   it('is idempotent on resumeProject when project is not paused', () => {
     const grove = createGrove('Test', home);
     registerProjectInGrove(grove.id, {
-      projectId: 'proj_aaaa',
+      projectId: PROJECT_A,
       projectName: 'Demo',
       projectRoot: '/tmp/demo',
     }, home);
 
-    expect(() => resumeProject(grove.id, 'proj_aaaa', 'op-1', home)).not.toThrow();
-    expect(isProjectPaused('proj_aaaa', home).paused).toBe(false);
+    expect(() => resumeProject(grove.id, PROJECT_A, 'op-1', home)).not.toThrow();
+    expect(isProjectPaused(PROJECT_A, home).paused).toBe(false);
   });
 
   it('isProjectPaused returns { paused: false } for an unknown project_id', () => {
@@ -143,19 +151,19 @@ describe('Grove registry pause primitive', () => {
     const groveA = createGrove('Alpha', home);
     const groveB = createGrove('Beta', home);
     registerProjectInGrove(groveA.id, {
-      projectId: 'proj_aaaa',
+      projectId: PROJECT_A,
       projectName: 'A',
       projectRoot: '/tmp/a',
     }, home);
     registerProjectInGrove(groveB.id, {
-      projectId: 'proj_bbbb',
+      projectId: PROJECT_B,
       projectName: 'B',
       projectRoot: '/tmp/b',
     }, home);
 
-    pauseProject(groveB.id, 'proj_bbbb', 'grove-move', 'op-2', home);
+    pauseProject(groveB.id, PROJECT_B, 'grove-move', 'op-2', home);
 
-    const status = isProjectPaused('proj_bbbb', home);
+    const status = isProjectPaused(PROJECT_B, home);
     expect(status.paused).toBe(true);
     if (!status.paused) throw new Error('unreachable');
     expect(status.grove_id).toBe(groveB.id);
@@ -164,62 +172,65 @@ describe('Grove registry pause primitive', () => {
   it('forceResumeProject clears regardless of owner_op', () => {
     const grove = createGrove('Test', home);
     registerProjectInGrove(grove.id, {
-      projectId: 'proj_aaaa',
+      projectId: PROJECT_A,
       projectName: 'Demo',
       projectRoot: '/tmp/demo',
     }, home);
 
-    pauseProject(grove.id, 'proj_aaaa', 'grove-move', 'op-1', home);
+    pauseProject(grove.id, PROJECT_A, 'grove-move', 'op-1', home);
     expect(() =>
-      forceResumeProject(grove.id, 'proj_aaaa', home),
+      forceResumeProject(grove.id, PROJECT_A, home),
     ).not.toThrow();
-    expect(isProjectPaused('proj_aaaa', home).paused).toBe(false);
+    expect(isProjectPaused(PROJECT_A, home).paused).toBe(false);
   });
 
   it('persists across cleared mtime caches (simulated daemon restart)', () => {
     const grove = createGrove('Test', home);
     registerProjectInGrove(grove.id, {
-      projectId: 'proj_aaaa',
+      projectId: PROJECT_A,
       projectName: 'Demo',
       projectRoot: '/tmp/demo',
     }, home);
 
-    pauseProject(grove.id, 'proj_aaaa', 'grove-move', 'op-1', home);
+    pauseProject(grove.id, PROJECT_A, 'grove-move', 'op-1', home);
     clearGroveRegistryCaches();
 
-    const status = isProjectPaused('proj_aaaa', home);
+    const status = isProjectPaused(PROJECT_A, home);
     expect(status.paused).toBe(true);
     if (!status.paused) throw new Error('unreachable');
     expect(status.owner_op).toBe('op-1');
   });
 
-  it('returns paused when any Grove pauses the project (mid-move window)', () => {
-    // During a move's commit window the project is registered in both
-    // source and target. The alphabetically-first Grove may be the
-    // unpaused target — isProjectPaused must scan every Grove and
-    // report paused if any holds the lock.
+  it('reports paused no matter which Grove registers the project (mid-move window)', () => {
+    // This used to guard against first-hit masking: the pause lived in one
+    // Grove's row, so isProjectPaused had to scan every Grove or an
+    // alphabetically-earlier unpaused Grove could hide a paused entry.
+    //
+    // The lease removes that failure mode rather than defending against it —
+    // it is one read keyed by project id, so no number of registering Groves
+    // can mask it. `grove_id` is now informational: during this window the
+    // project genuinely sits in two Groves, and it can be neither if an
+    // operation has deregistered it, so nothing keys on which one comes back.
     const source = createGrove('aardvark', home);
     const target = createGrove('zebra', home);
     registerProjectInGrove(source.id, {
-      projectId: 'proj_aaaa',
+      projectId: PROJECT_A,
       projectName: 'Demo',
       projectRoot: '/tmp/demo',
     }, home);
     registerProjectInGrove(target.id, {
-      projectId: 'proj_aaaa',
+      projectId: PROJECT_A,
       projectName: 'Demo',
       projectRoot: '/tmp/demo',
     }, home);
 
-    // Pause the alphabetically-later Grove. If the implementation
-    // returned on the first hit, the unpaused first Grove would mask
-    // the paused entry on the second.
-    pauseProject(target.id, 'proj_aaaa', 'grove-move', 'op-move', home);
+    pauseProject(target.id, PROJECT_A, 'grove-move', 'op-move', home);
 
-    const status = isProjectPaused('proj_aaaa', home);
+    const status = isProjectPaused(PROJECT_A, home);
     expect(status.paused).toBe(true);
     if (!status.paused) throw new Error('unreachable');
-    expect(status.grove_id).toBe(target.id);
     expect(status.owner_op).toBe('op-move');
+    // Informational only — either registering Grove is a truthful answer.
+    expect([source.id, target.id]).toContain(status.grove_id);
   });
 });


### PR DESCRIPTION
Phase 2 of Project Write Admission, following #728. The five pause functions delegate to the lease behind their existing signatures, so the **sixteen consumers are untouched**. Plan `87006e6eb8b89aa8`.

## What improves immediately

`isProjectPaused` is now a **single read keyed by project id** instead of a scan across every Grove.

The scan existed for a reason: the pause lived in one Grove's registry row, and a project mid-move is registered in two, so an alphabetically-earlier unpaused Grove could mask a paused entry. The lease **removes that failure mode rather than defending against it** — no number of registering Groves can hide a lease. It also sits on the capture hot path, where a per-Grove scan was the wrong shape.

## Three behavior changes, each surfaced by an existing test

**`grove_id` is now nullable**, in both `ProjectPauseStatus` and the 409 `PausedInfo` body. The pause is held on the *project*, and an operation that moves a project between registries deregisters it for part of the window — so there is genuinely no Grove to name. During a move there are two, and either is truthful. It's informational now; nothing keys on it.

This surfaced through a test asserting `grove_id === target.id` during a two-Grove window. I rewrote that test rather than making the implementation pick a winner, because the premise it was written to defend — first-hit masking — no longer exists.

**`pauseProject` keeps its "not registered in Grove" refusal.** I could have dropped it, since the lease doesn't need registration, but its callers pause a project they have registered and a typo should still fail loudly. Residency, which deliberately holds a lease *across* deregistration, will call `acquireProjectLease` directly in phase 3.

**`pauseProject` now rejects a malformed project id**, because the lease validates before joining the id onto a path. Production callers pass registry ids; several test fixtures used short stand-ins like `proj_aaaa` and were updated.

## Failure posture

An unreadable lease now **throws** out of `isProjectPaused` rather than reporting "not paused." Reporting unheld on a read failure would admit writers to a project an operation is actively moving — the same Provable Absence rule applied in #724 and #725.

## Rollout

A fallback still honors a pause written into a `projects.toml` row by the previous binary, so an upgrade mid-move doesn't drop the guard. Removable a release after this ships.

## Verification

- `npm test` — **10459 pass / 0 fail / 15 skip** (single clean run)
- Root and UI typechecks clean

One note on the suite: an earlier run showed `migrateTeamsHomeIfNeeded` failing at 71s. That was load starvation from my running two full suites concurrently — it passes 3/3 in isolation and is untouched by this change. Flagging it rather than filtering it out.

## Next

Phase 3 makes residency take the lease, which is the phase that actually closes the writer-race P1. Three writers escape registry-derived coverage today and will need the check explicitly: `session-maintenance` (grove-filtered, raw SQL with no project predicate), in-flight `agent/executor.ts` runs (no residency check anywhere, no abort path), and the MCP `project_id`-only pivot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
