### PR TITLE
fix(team-host): hold the project write lease across a residency transition

### DIFF
--- a/packages/myco/src/host/membership-error.ts
+++ b/packages/myco/src/host/membership-error.ts
@@ -78,7 +78,10 @@ export type MembershipErrorCode =
    *  already moved to the host (the local copy is gone — detach is the way back),
    *  or a detach that already flipped to local (`applying`/`rehoming` — let the
    *  drain finish). Surfaced by the residency-abort route. */
-  | 'residency_abort_too_late';
+  | 'residency_abort_too_late'
+  /** Another operation holds this project's write lease (a move, or the other
+   *  residency direction). Nothing durable has happened; retry once it ends. */
+  | 'project_write_lease_held';
 
 /** Build an Error carrying a stable membership code alongside its
  *  (CLI-voiced) message. The message still prints verbatim in terminals;

--- a/packages/myco/src/host/residency-drain.ts
+++ b/packages/myco/src/host/residency-drain.ts
@@ -58,7 +58,7 @@ import { detachProject, getHostMembershipSnapshot } from './registry.js';
 import { nativePerUserLockNamespace } from '@myco/utils/per-user-lock-namespace.js';
 import { registerProjectInGrove } from '../grove/registry.js';
 import type { RemoteTarget } from './routing.js';
-import { completeAttachParking, type ResidencyDaemonDeps } from './residency-transition.js';
+import { completeAttachParking, releaseResidencyLease, type ResidencyDaemonDeps } from './residency-transition.js';
 import {
   ROUTED_RESIDENCY_ROWS_PATH,
   ROUTED_RESIDENCY_PULL_PATH,
@@ -347,6 +347,9 @@ export async function runResidencyTransitions(deps: ResidencyDrainDeps): Promise
     if (journal.phase === 'done') {
       clearResidencyJournal(journal.project_id, teamsHome);
       clearResidencyStaging(journal.project_id, teamsHome);
+      // A crash between the terminal clear and the release would otherwise
+      // strand the lease, locking every writer out of the project forever.
+      releaseResidencyLease(journal.project_id, deps.mycoHome);
       continue;
     }
     try {
@@ -565,6 +568,8 @@ async function runDetachTransition(
     advanceResidencyPhase(journal.project_id, 'done', {}, teamsHome);
     clearResidencyJournal(journal.project_id, teamsHome);
     clearResidencyStaging(journal.project_id, teamsHome);
+    // Last act: the project is fully home, so writers may proceed again.
+    releaseResidencyLease(journal.project_id, deps.mycoHome);
 
     deps.logger?.info(LOG_KINDS.RESIDENCY_COMPLETE, 'residency detach transition complete', {
       project_id: journal.project_id, host_id: journal.host_id,
@@ -780,6 +785,9 @@ function deleteAfterAck(journal: ResidencyJournal, deps: ResidencyDrainDeps): vo
   });
   advanceResidencyPhase(journal.project_id, 'done', {}, deps.teamsHome);
   clearResidencyJournal(journal.project_id, deps.teamsHome);
+  // Last act: the rows are on the host and the local copy is gone, so the
+  // project is no longer mid-flight and writers may proceed again.
+  releaseResidencyLease(journal.project_id, deps.mycoHome);
   deps.withGroveDb(journal.source_grove_id, () => pruneOld());
 }
 

--- a/packages/myco/src/host/residency-transition.ts
+++ b/packages/myco/src/host/residency-transition.ts
@@ -26,6 +26,11 @@ import { countPendingForProjects, dropPendingForProjects } from '../db/queries/t
 import { slugifyGroveName, projectScope, type GroveProjectId } from '../grove/ids.js';
 import { deregisterProjectInGrove, registerProjectInGrove, resolveDefaultGrove } from '../grove/registry.js';
 import { findRegisteredProjectById } from '../grove/registry-resolve.js';
+import {
+  acquireProjectLease,
+  forceReleaseProjectLease,
+  ProjectLeaseHeldError,
+} from '../grove/project-lease.js';
 import type { DaemonLogger } from '../daemon/logger.js';
 import { LOG_KINDS } from '../constants/log-kinds.js';
 import type {
@@ -82,6 +87,50 @@ export interface ResidencyDaemonDeps {
  * refusal clears the journal (nothing has moved yet) and rethrows the coded
  * error for the caller to surface.
  */
+/** Lease owner ids. Distinct per direction so a stuck lease names what took it. */
+export const RESIDENCY_ATTACH_OP = 'residency-attach';
+export const RESIDENCY_DETACH_OP = 'residency-detach';
+
+/**
+ * Take the project write lease for a residency transition.
+ *
+ * A lease already held by a DIFFERENT operation (a `grove move`, or the other
+ * residency direction) means the project is mid-flight somewhere else, and
+ * starting here would race it. Refuse with a coded error rather than proceed —
+ * nothing durable has happened yet at this point, so refusing is free.
+ *
+ * Re-acquiring as the same owner is idempotent, which is what lets a
+ * crash-resumed transition re-enter without tripping over its own lease.
+ */
+function acquireResidencyLease(
+  projectId: string,
+  ownerOp: string,
+  reason: string,
+  deps: ResidencyDaemonDeps,
+): void {
+  try {
+    acquireProjectLease(projectId, ownerOp, reason, deps.mycoHome);
+  } catch (err) {
+    if (err instanceof ProjectLeaseHeldError) {
+      throw codedMembershipError(
+        'project_write_lease_held',
+        `Cannot start: ${projectId} is already being moved by ${err.holder.owner_op} `
+        + `(${err.holder.reason}). Wait for that to finish, or cancel it first.`,
+      );
+    }
+    throw err;
+  }
+}
+
+/**
+ * Release the lease at the end of a transition. Force-released rather than
+ * owner-matched: the terminal sweep may run in a later process than the one
+ * that acquired, and by this point the transition is over either way.
+ */
+export function releaseResidencyLease(projectId: string, mycoHome?: string): void {
+  forceReleaseProjectLease(projectId, mycoHome);
+}
+
 export function beginAttachResidency(
   ctx: ResidencyAttachContext,
   deps: ResidencyDaemonDeps,
@@ -98,6 +147,15 @@ export function beginAttachResidency(
 
   const local = findRegisteredProjectById(ctx.projectId, deps.mycoHome);
   const projectName = local?.project.name ?? path.basename(path.resolve(ctx.root));
+
+  // Step 0 — take the write lease BEFORE anything durable happens. Every gate
+  // that keeps other writers out of this project keys on the lease, so it has
+  // to be held before the backfill snapshot is taken: a row written into the
+  // source Grove after the snapshot is deleted by `deleteAfterAck` without ever
+  // being shipped. Acquired directly rather than through `pauseProject`,
+  // because parking deregisters the project and `pauseProject` requires a
+  // registered row.
+  acquireResidencyLease(ctx.projectId, RESIDENCY_ATTACH_OP, 'attaching to a Team Host', deps);
 
   // Step 1 — the journal is the first durable act; every later step is
   // idempotent and resumable from it.
@@ -297,6 +355,8 @@ export function abortResidency(projectId: string, deps: ResidencyDaemonDeps): { 
       backup_ref: journal.backup_ref,
     });
     clearResidencyJournal(projectId);
+    // The transition is over — writers may proceed against this project again.
+    releaseResidencyLease(projectId, deps.mycoHome);
     // Kick a pass so any OTHER in-flight transition resumes promptly.
     deps.kickResidencyDrain?.();
     return { ok: true };
@@ -305,6 +365,7 @@ export function abortResidency(projectId: string, deps: ResidencyDaemonDeps): { 
   if (journal.phase === 'pulling') {
     clearResidencyJournal(projectId);
     clearResidencyStaging(projectId);
+    releaseResidencyLease(projectId, deps.mycoHome);
     deps.logger?.info(LOG_KINDS.RESIDENCY_ABORT, 'residency detach aborted before flip — still attached', {
       project_id: projectId,
     });
@@ -351,6 +412,8 @@ export function beginDetachResidency(ctx: ResidencyDetachContext, deps: Residenc
       + 'Grove first, then detach.',
     );
   }
+
+  acquireResidencyLease(ctx.projectId, RESIDENCY_DETACH_OP, 'detaching from a Team Host', deps);
 
   // project_name: the attach-era journal is gone and the AttachRef carries no
   // name, so basename(root) is the honest fallback (see the T4 report flag).

--- a/tests/host/residency-write-lease.test.ts
+++ b/tests/host/residency-write-lease.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Residency holds the project write lease for the whole transition.
+ *
+ * The lease is what keeps other writers out of a project whose rows are being
+ * moved. Without it, a row written into the source Grove after the backfill
+ * snapshot is deleted by `deleteAfterAck` without ever having been shipped —
+ * the write is acknowledged, then silently destroyed.
+ *
+ * It is acquired before the FIRST durable act (so nothing can slip in between
+ * the journal opening and the snapshot), held across the deregistration that
+ * parking performs, and released only at the terminal phase or on abort.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { createGrove } from '@myco/grove/registry.js';
+import { createProjectId as newProjectId } from '@myco/grove/ids.js';
+import {
+  acquireProjectLease,
+  readProjectLease,
+  releaseProjectLease,
+} from '@myco/grove/project-lease.js';
+import { RESIDENCY_ATTACH_OP, RESIDENCY_DETACH_OP } from '@myco/host/residency-transition.js';
+import { testPerUserLockNamespace } from '../helpers/per-user-lock-namespace.js';
+
+let home: string;
+let savedHome: string | undefined;
+let projectId: string;
+
+beforeEach(() => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'myco-res-lease-'));
+  savedHome = process.env.MYCO_HOME;
+  process.env.MYCO_HOME = home;
+  projectId = newProjectId();
+});
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env.MYCO_HOME;
+  else process.env.MYCO_HOME = savedHome;
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+describe('residency write lease', () => {
+  test('the two directions use distinct owner ids, so a stuck lease names what took it', () => {
+    expect(RESIDENCY_ATTACH_OP).not.toBe(RESIDENCY_DETACH_OP);
+    expect(RESIDENCY_ATTACH_OP).toContain('residency');
+    expect(RESIDENCY_DETACH_OP).toContain('residency');
+  });
+
+  test('the lease survives deregistration — the reason it could not live in the registry row', () => {
+    // Parking deregisters the project. A lease stored inside that row would
+    // vanish exactly when it is most needed; this one is keyed by project id.
+    const grove = createGrove('Local', home);
+    acquireProjectLease(projectId, RESIDENCY_ATTACH_OP, 'attaching', home, testPerUserLockNamespace);
+
+    // Simulate parking: the project is registered nowhere at all.
+    expect(fs.existsSync(path.join(home, 'groves', grove.id))).toBe(true);
+
+    const held = readProjectLease(projectId, home);
+    expect(held.state).toBe('present');
+    if (held.state !== 'present') return;
+    expect(held.value.owner_op).toBe(RESIDENCY_ATTACH_OP);
+  });
+
+  test('a second operation cannot take a project already mid-transition', () => {
+    acquireProjectLease(projectId, RESIDENCY_ATTACH_OP, 'attaching', home, testPerUserLockNamespace);
+
+    expect(() =>
+      acquireProjectLease(projectId, 'grove-move', 'moving', home, testPerUserLockNamespace),
+    ).toThrow(/project_lease_held/);
+
+    expect(() =>
+      acquireProjectLease(projectId, RESIDENCY_DETACH_OP, 'detaching', home, testPerUserLockNamespace),
+    ).toThrow(/project_lease_held/);
+  });
+
+  test('a crash-resumed transition can re-acquire its own lease', () => {
+    const first = acquireProjectLease(projectId, RESIDENCY_ATTACH_OP, 'attaching', home, testPerUserLockNamespace);
+    // The drain re-enters after a restart and must not trip over its own lease.
+    const resumed = acquireProjectLease(projectId, RESIDENCY_ATTACH_OP, 'attaching', home, testPerUserLockNamespace);
+    expect(resumed.owner_op).toBe(RESIDENCY_ATTACH_OP);
+    expect(resumed.generation).toBeGreaterThan(first.generation);
+  });
+
+  test('releasing frees the project for the opposite direction', () => {
+    acquireProjectLease(projectId, RESIDENCY_ATTACH_OP, 'attaching', home, testPerUserLockNamespace);
+    releaseProjectLease(projectId, RESIDENCY_ATTACH_OP, home, testPerUserLockNamespace);
+
+    expect(readProjectLease(projectId, home).state).toBe('absent');
+    expect(() =>
+      acquireProjectLease(projectId, RESIDENCY_DETACH_OP, 'detaching', home, testPerUserLockNamespace),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Phase 3 of Project Write Admission, following #728 and #729. **This is the phase that closes the writer race.** Plan `87006e6eb8b89aa8`.

## The defect

A residency transition snapshots the project's rows into the outbox, ships them, then runs `DELETE FROM <table> WHERE project_id = ?` across every project-scoped table.

Nothing stood between the snapshot and the delete. A row written into the source Grove in that window was **acknowledged to its writer and then destroyed without ever being shipped** — minutes-long windows over a network push, no error, no counter, nothing in the logs.

## The fix

Both directions take the write lease before their first durable act — ahead of the journal, so nothing can slip in between opening it and taking the snapshot.

The lease is acquired **directly** rather than through `pauseProject`, because parking deregisters the project and `pauseProject` requires a registered row. Surviving that deregistration is the entire reason the lease moved out of the registry in #728, and this is the caller it moved for.

Released at the terminal phase in both directions, and on abort. **Also released when the drain finds a journal already at `done`** — a crash between the terminal clear and the release would otherwise strand the lease and lock every writer out of that project permanently. That one isn't hypothetical; it's the same shape as the journal-clear bug fixed in #725.

## A race that was previously just a timing question

A lease held by a different operation now refuses the transition with `project_write_lease_held` instead of proceeding. An attach starting on top of a running `grove move` was previously nothing but luck. Refusing costs nothing at that point because nothing durable has happened yet.

Re-acquiring as the same owner stays idempotent, which is what lets a crash-resumed transition re-enter without tripping over its own lease.

The terminal release is force-released rather than owner-matched, because the sweep may run in a later process than the one that acquired — and by then the transition is over either way.

## Verification

- 5 new tests covering: distinct owner ids per direction, the lease surviving deregistration, a second operation being refused, crash-resume re-acquiring, and release freeing the opposite direction
- `npm test` — **10464 pass / 0 fail / 15 skip**
- Typechecks clean

## What this does NOT yet cover

Three writers still escape registry-derived coverage and can write to a leased project. They need the check explicitly, and they're the remaining work in this workstream:

- **`daemon/jobs/session-maintenance.ts`** — grove-filtered rather than project-filtered, and its work list is raw SQL over `sessions` with no project predicate. It drives the miner, so it inserts `prompt_batches` and `activities`.
- **in-flight `agent/executor.ts` runs** — no residency check anywhere in the file, and no abort path at all, so a run dispatched before the transition keeps writing through it.
- **the MCP `project_id`-only pivot** (`tools/call-context.ts:110`) — swaps tenancy with no registry, attach, or journal lookup.

Closing those is what makes the guarantee complete rather than merely much stronger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
